### PR TITLE
Implement Elasticsearch/Clickhouse source resolver

### DIFF
--- a/quesma/elasticsearch/index_management.go
+++ b/quesma/elasticsearch/index_management.go
@@ -5,6 +5,7 @@ import (
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/quesma/config"
 	"mitmproxy/quesma/quesma/recovery"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -61,6 +62,11 @@ func (im *indexManagement) GetSourceNames() map[string]interface{} {
 	}
 	for _, alias := range sources.Aliases {
 		names[alias.Name] = struct{}{}
+	}
+	for key := range names {
+		if strings.TrimSpace(key) == "" {
+			delete(names, key)
+		}
 	}
 	return names
 }

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -101,7 +101,7 @@ func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.Qu
 func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, config config.QuesmaConfiguration, logChan <-chan tracing.LogWithLevel) *Quesma {
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(config, logManager, indexManager, logChan, phoneHomeAgent)
 	queryRunner := NewQueryRunner()
-	router := configureRouter(config, logManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)
+	router := configureRouter(config, logManager, indexManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)
 	return &Quesma{
 		telemetryAgent:          phoneHomeAgent,
 		processor:               newDualWriteProxy(logManager, indexManager, config, router, quesmaManagementConsole, phoneHomeAgent, queryRunner),

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -49,7 +49,7 @@ func TestSearchOpensearch(t *testing.T) {
 			}
 
 			queryRunner := NewQueryRunner()
-			_, err = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole)
+			_, err = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), config.QuesmaConfiguration{}, lm, nil, managementConsole)
 			assert.NoError(t, err)
 
 			if err = mock.ExpectationsWereMet(); err != nil {
@@ -177,7 +177,7 @@ func TestHighlighter(t *testing.T) {
 															AddRow("text", "text", "text"))
 
 	queryRunner := NewQueryRunner()
-	response, err := queryRunner.handleSearch(ctx, tableName, []byte(query), lm, managementConsole)
+	response, err := queryRunner.handleSearch(ctx, tableName, []byte(query), config.QuesmaConfiguration{}, lm, nil, managementConsole)
 	assert.NoError(t, err)
 	if err = mock.ExpectationsWereMet(); err != nil {
 		t.Fatal("there were unfulfilled expections:", err)

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -96,7 +96,7 @@ func TestAsyncSearchHandler(t *testing.T) {
 				mock.ExpectQuery(wantedRegex).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
 			queryRunner := NewQueryRunner()
-			_, err = queryRunner.handleAsyncSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole, defaultAsyncSearchTimeout, true)
+			_, err = queryRunner.handleAsyncSearch(ctx, config.QuesmaConfiguration{}, tableName, []byte(tt.QueryJson), lm, nil, managementConsole, defaultAsyncSearchTimeout, true)
 			assert.NoError(t, err)
 
 			if err := mock.ExpectationsWereMet(); err != nil {
@@ -134,7 +134,7 @@ func TestAsyncSearchHandlerSpecialCharacters(t *testing.T) {
 			}
 
 			queryRunner := NewQueryRunner()
-			_, err = queryRunner.handleAsyncSearch(ctx, tableName, []byte(tt.QueryRequestJson), lm, managementConsole, defaultAsyncSearchTimeout, true)
+			_, err = queryRunner.handleAsyncSearch(ctx, config.QuesmaConfiguration{}, tableName, []byte(tt.QueryRequestJson), lm, nil, managementConsole, defaultAsyncSearchTimeout, true)
 			assert.NoError(t, err)
 
 			if err = mock.ExpectationsWereMet(); err != nil {
@@ -176,7 +176,7 @@ func TestSearchHandler(t *testing.T) {
 					WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
 			queryRunner := NewQueryRunner()
-			_, _ = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole)
+			_, _ = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), config.QuesmaConfiguration{}, lm, nil, managementConsole)
 
 			if err := mock.ExpectationsWereMet(); err != nil {
 				t.Fatal("there were unfulfilled expections:", err)
@@ -202,7 +202,7 @@ func TestSearchHandlerNoAttrsConfig(t *testing.T) {
 				mock.ExpectQuery(testdata.EscapeBrackets(wantedRegex)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
 			queryRunner := NewQueryRunner()
-			_, _ = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole)
+			_, _ = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), config.QuesmaConfiguration{}, lm, nil, managementConsole)
 
 			if err := mock.ExpectationsWereMet(); err != nil {
 				t.Fatal("there were unfulfilled expections:", err)
@@ -227,7 +227,7 @@ func TestAsyncSearchFilter(t *testing.T) {
 				mock.ExpectQuery(testdata.EscapeBrackets(wantedRegex)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
 			queryRunner := NewQueryRunner()
-			_, _ = queryRunner.handleAsyncSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole, defaultAsyncSearchTimeout, true)
+			_, _ = queryRunner.handleAsyncSearch(ctx, config.QuesmaConfiguration{}, tableName, []byte(tt.QueryJson), lm, nil, managementConsole, defaultAsyncSearchTimeout, true)
 			if err := mock.ExpectationsWereMet(); err != nil {
 				t.Fatal("there were unfulfilled expections:", err)
 			}
@@ -300,7 +300,7 @@ func TestHandlingDateTimeFields(t *testing.T) {
 			WillReturnRows(sqlmock.NewRows([]string{"key", "doc_count"}))
 		// .AddRow(1000, uint64(10)).AddRow(1001, uint64(20))) // here rows should be added if uint64 were supported
 		queryRunner := NewQueryRunner()
-		response, err := queryRunner.handleAsyncSearch(ctx, tableName, []byte(query(fieldName)), lm, managementConsole, defaultAsyncSearchTimeout, true)
+		response, err := queryRunner.handleAsyncSearch(ctx, config.QuesmaConfiguration{}, tableName, []byte(query(fieldName)), lm, nil, managementConsole, defaultAsyncSearchTimeout, true)
 		assert.NoError(t, err)
 
 		var responseMap model.JsonMap
@@ -356,9 +356,9 @@ func TestNumericFacetsQueries(t *testing.T) {
 				queryRunner := NewQueryRunner()
 				var response []byte
 				if handlerName == "handleSearch" {
-					response, err = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole)
+					response, err = queryRunner.handleSearch(ctx, tableName, []byte(tt.QueryJson), config.QuesmaConfiguration{}, lm, nil, managementConsole)
 				} else if handlerName == "handleAsyncSearch" {
-					response, err = queryRunner.handleAsyncSearch(ctx, tableName, []byte(tt.QueryJson), lm, managementConsole, defaultAsyncSearchTimeout, true)
+					response, err = queryRunner.handleAsyncSearch(ctx, config.QuesmaConfiguration{}, tableName, []byte(tt.QueryJson), lm, nil, managementConsole, defaultAsyncSearchTimeout, true)
 				}
 				assert.NoError(t, err)
 

--- a/quesma/quesma/source_resolver.go
+++ b/quesma/quesma/source_resolver.go
@@ -1,0 +1,65 @@
+package quesma
+
+import (
+	"context"
+	"mitmproxy/quesma/clickhouse"
+	"mitmproxy/quesma/elasticsearch"
+	"mitmproxy/quesma/logger"
+	"mitmproxy/quesma/quesma/config"
+	"slices"
+	"strings"
+)
+
+const (
+	sourceElasticsearch = "elasticsearch"
+	sourceClickhouse    = "clickhouse"
+	sourceBoth          = "both"
+	sourceNone          = "none"
+)
+
+func ResolveSources(indexPattern string, cfg config.QuesmaConfiguration, im elasticsearch.IndexManagement, lm *clickhouse.LogManager) string {
+	if elasticsearch.IsIndexPattern(indexPattern) {
+		matchesElastic := []string{}
+		matchesClickhouse := []string{}
+
+		for _, pattern := range strings.Split(indexPattern, ",") {
+			for indexName := range im.GetSourceNamesMatching(pattern) {
+				if !strings.HasPrefix(indexName, ".") {
+					matchesElastic = append(matchesElastic, indexName)
+				}
+			}
+
+			matchesClickhouse = append(matchesClickhouse, lm.ResolveIndexes(context.Background(), pattern)...)
+		}
+		slices.Sort(matchesElastic)
+		slices.Sort(matchesClickhouse)
+		matchesElastic = slices.Compact(matchesElastic)
+		matchesClickhouse = slices.Compact(matchesClickhouse)
+		matchesElastic = slices.DeleteFunc(matchesElastic, func(s string) bool {
+			return slices.Contains(matchesClickhouse, s)
+		})
+
+		logger.Debug().Msgf("Resolved sources for index pattern %s: (Elasticsearch: %s), (Clickhouse: %s)", indexPattern, strings.Join(matchesElastic, ", "), strings.Join(matchesClickhouse, ", "))
+
+		switch {
+		case len(matchesElastic) > 0 && len(matchesClickhouse) > 0:
+			return sourceBoth
+		case len(matchesElastic) > 0:
+			return sourceElasticsearch
+		case len(matchesClickhouse) > 0:
+			return sourceClickhouse
+		default:
+			return sourceNone
+		}
+	} else {
+		if c, exists := cfg.IndexConfig[indexPattern]; exists {
+			if c.Enabled {
+				return sourceClickhouse
+			} else {
+				return sourceElasticsearch
+			}
+		} else {
+			return sourceElasticsearch
+		}
+	}
+}


### PR DESCRIPTION
Implemented a component responsible for identifying which index names behind an index pattern exist and from which source should be queried.

I will integrate it into multi-index search in the next change.