### PR TITLE
Ignore 'format' property when processing date range's bounds

### DIFF
--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -879,6 +879,8 @@ func (cw *ClickhouseQueryTranslator) parseRange(queryMap QueryMap) SimpleQuery {
 				stmts = append(stmts, NewSimpleStatement(fieldToPrint+">"+vToPrint))
 			case "lt":
 				stmts = append(stmts, NewSimpleStatement(fieldToPrint+"<"+vToPrint))
+			case "format":
+				// ignored
 			default:
 				logger.WarnWithCtx(cw.Ctx).Msgf("invalid range operator: %s", op)
 			}


### PR DESCRIPTION
When parsing constraints of `date_range`, it's possible to encounter `format`, which should be explicitly ignored, because:
- it's not a constraint
- it's processed in a different place

> quesma-1  | May  2 15:10:42.854 WRN quesma/queryparser/query_parser.go:883 > invalid range operator: format path=/logs-*,filebeat-*,kibana_sample_data_logs*/_search request_id=56
