### PR TITLE
Small fix `percentiles` aggregation

### DIFF
--- a/quesma/model/metrics_aggregations/quantile.go
+++ b/quesma/model/metrics_aggregations/quantile.go
@@ -2,6 +2,7 @@ package metrics_aggregations
 
 import (
 	"context"
+	"math"
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
 	"strconv"
@@ -47,7 +48,14 @@ func (query Quantile) TranslateSqlResponseToJson(rows []model.QueryResultRow, le
 				percentileName += ".0"
 			}
 
-			valueMap[percentileName] = percentile[0]
+			if len(percentile) == 0 {
+				logger.WarnWithCtx(query.ctx).Msgf("empty percentile values for %s", percentileName)
+			}
+			if len(percentile) == 0 || math.IsNaN(percentile[0]) {
+				valueMap[percentileName] = nil
+			} else {
+				valueMap[percentileName] = percentile[0]
+			}
 		}
 	}
 

--- a/quesma/testdata/opensearch-visualize/aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/aggregation_requests.go
@@ -1,6 +1,7 @@
 package opensearch_visualize
 
 import (
+	"math"
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/testdata"
 )
@@ -570,7 +571,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 						"1000.0-2000.0": {
 							"1": {
 								"values": {
-									"50.0": 45.5
+									"50.0": null
 								}
 							},
 							"doc_count": 2,
@@ -594,7 +595,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 		ExpectedResults: [][]model.QueryResultRow{
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(4))}}},
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("quantile_50", []float64{46.9921875})}}},
-			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("quantile_50", []float64{45.5})}}},
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("quantile_50", []float64{math.NaN()})}}},
 			{{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("doc_count", 1),
 				model.NewQueryResultCol("doc_count", 2),


### PR DESCRIPTION
`Percentiles` aggregation returns value for some percentile (e.g. 50-th percentile = median). But when there are 0 rows, Elastic returns `null` as a result. Now we also do.
Before we had an error and didn't return a response because of that. Call to `quantiles` (Clickhouse function) returns `NaN` as `float64`, when there are no rows. We didn't check for that and tried to pass `NaN` to the JSON response, which caused error in marshalling.

Before:
<img width="1728" alt="Screenshot 2024-05-03 at 08 35 22" src="https://github.com/QuesmaOrg/quesma/assets/5407146/25cefbfa-127e-449a-a811-dbb2b1657a49">
<img width="1728" alt="Screenshot 2024-05-03 at 08 35 12" src="https://github.com/QuesmaOrg/quesma/assets/5407146/6c7918aa-edd6-468a-92fa-d8066a3c969b">
After: no error
<img width="1728" alt="Screenshot 2024-05-03 at 08 41 38" src="https://github.com/QuesmaOrg/quesma/assets/5407146/939114f3-c235-46e1-85b1-a27dc1524445">
