### PR TITLE
Use UUIDv4 for request id

### DIFF
--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -41,7 +41,7 @@ func TestNoAsciiTableName(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(`SELECT * FROM "%s" `, tableName), query.String())
 }
 
-var ctx = context.WithValue(context.TODO(), tracing.RequestIdCtxKey, "test")
+var ctx = context.WithValue(context.TODO(), tracing.RequestIdCtxKey, tracing.GetRequestId())
 
 const tableName = `logs-generic-default`
 

--- a/quesma/quesma/ui/html_pages.go
+++ b/quesma/quesma/ui/html_pages.go
@@ -657,9 +657,9 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 
 	buffer := newBufferWithHead()
 	if requestFound {
-		buffer.Write(generateSimpleTop("Report for request Id " + requestId))
+		buffer.Write(generateSimpleTop("Report for request UUID " + requestId))
 	} else {
-		buffer.Write(generateSimpleTop("Report not found for request Id " + requestId))
+		buffer.Write(generateSimpleTop("Report not found for request UUID " + requestId))
 	}
 
 	buffer.Html(`<main id="queries">`)

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -16,7 +16,7 @@ import (
 func TestHtmlPages(t *testing.T) {
 	xss := "<script>alert('xss')</script>"
 	xssBytes := []byte(xss)
-	id := "MagicId_123"
+	id := "b1c4a89e-4905-5e3c-b57f-dc92627d011e"
 	logChan := make(chan tracing.LogWithLevel, 5)
 	qmc := NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent())
 	qmc.PushPrimaryInfo(&QueryDebugPrimarySource{Id: id, QueryResp: xssBytes})

--- a/quesma/quesma/ui/html_panels.go
+++ b/quesma/quesma/ui/html_panels.go
@@ -27,7 +27,7 @@ func generateQueries(debugKeyValueSlice []DebugKeyValue, withLinks bool) []byte 
 		if withLinks {
 			buffer.Html(`<a href="/request-Id/`).Text(v.Key).Html(`">`)
 		}
-		buffer.Html("<p>RequestID:").Text(v.Key).Html(" Path: ").Text(v.Value.Path).Html("</p>\n")
+		buffer.Html("<p>UUID:").Text(v.Key).Html(" Path: ").Text(v.Value.Path).Html("</p>\n")
 		buffer.Html(`<pre Id="query`).Text(v.Key).Html(`">`)
 		buffer.Text(string(v.Value.IncomingQueryBody))
 		buffer.Html("\n</pre>")
@@ -46,7 +46,7 @@ func generateQueries(debugKeyValueSlice []DebugKeyValue, withLinks bool) []byte 
 			buffer.Html(`<a href="/request-Id/`).Text(v.Key).Html(`">`)
 		}
 		tookStr := fmt.Sprintf(" took %d ms", v.Value.PrimaryTook.Milliseconds())
-		buffer.Html("<p>ResponseID:").Text(v.Key).Text(tookStr).Html("</p>\n")
+		buffer.Html("<p>UUID:").Text(v.Key).Text(tookStr).Html("</p>\n")
 		buffer.Html(`<pre Id="response`).Text(v.Key).Html(`">`)
 		if len(v.Value.QueryResp) > 0 {
 			buffer.Text(string(v.Value.QueryResp))
@@ -69,7 +69,7 @@ func generateQueries(debugKeyValueSlice []DebugKeyValue, withLinks bool) []byte 
 			buffer.Html(`<a href="/request-Id/`).Text(v.Key).Html(`">`)
 		}
 		tookStr := fmt.Sprintf(" took %d ms", v.Value.SecondaryTook.Milliseconds())
-		buffer.Html("<p>RequestID:").Text(v.Key).Text(tookStr).Html(errorBanner(v.Value)).Html("</p>\n")
+		buffer.Html("<p>UUID:").Text(v.Key).Text(tookStr).Html(errorBanner(v.Value)).Html("</p>\n")
 		buffer.Html(`<pre Id="second_query`).Text(v.Key).Html(`">`)
 		buffer.Text(sqlfmt.SqlPrettyPrint(v.Value.QueryBodyTranslated))
 		buffer.Html("\n</pre>")
@@ -87,7 +87,7 @@ func generateQueries(debugKeyValueSlice []DebugKeyValue, withLinks bool) []byte 
 		if withLinks {
 			buffer.Html(`<a href="/request-Id/`).Text(v.Key).Html(`">`)
 		}
-		buffer.Html("<p>ResponseID:").Text(v.Key).Html(errorBanner(v.Value)).Html("</p>\n")
+		buffer.Html("<p>UUID:").Text(v.Key).Html(errorBanner(v.Value)).Html("</p>\n")
 		buffer.Html(`<pre Id="second_response`).Text(v.Key).Html(`">`)
 		if len(v.Value.QueryTranslatedResults) > 0 {
 			buffer.Text(string(v.Value.QueryTranslatedResults))

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -36,7 +36,7 @@ const (
 	RequestStatisticIngest2Elasticsearch = "ingest2elasticsearch"
 )
 
-var requestIdRegex, _ = regexp.Compile(`request_id":"(\d+)"`)
+var requestIdRegex, _ = regexp.Compile(logger.RID + `":"([0-9a-fA-F-]+)"`)
 
 type QueryDebugPrimarySource struct {
 	Id          string

--- a/quesma/tracing/context.go
+++ b/quesma/tracing/context.go
@@ -1,8 +1,7 @@
 package tracing
 
 import (
-	"fmt"
-	"sync/atomic"
+	"github.com/google/uuid"
 )
 
 type ContextKey string
@@ -15,8 +14,6 @@ const (
 	TraceEndCtxKey  ContextKey = "TraceEnd"
 )
 
-var lastRequestId atomic.Int64
-
 func GetRequestId() string {
-	return fmt.Sprintf("%d", lastRequestId.Add(1))
+	return uuid.New().String()
 }


### PR DESCRIPTION
As we go with release, IDs are hard to trace:
- They are not unique, restart changes them.
- Collisions kill them
- We should be able to trace down which requests cause problems across all Quesma.

For this purpose industry uses uuid, let's use UUIDv4.