### PR TITLE
Respect `keyed` parameter in `percentile_ranks` aggr

### DIFF
--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -516,7 +516,6 @@ func (cw *ClickhouseQueryTranslator) tryMetricsAggregation(queryMap QueryMap) (m
 		}
 		var keyed bool
 		if keyedRaw, ok := percentileRanks.(QueryMap)["keyed"]; ok {
-			fmt.Println(keyedRaw)
 			if keyed, ok = keyedRaw.(bool); !ok {
 				logger.WarnWithCtx(cw.Ctx).Msgf("keyed specified for percentiles aggregation is not a boolean. Querymap: %v", queryMap)
 				keyed = keyedDefaultValuePercentileRanks

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -3,8 +3,6 @@ package queryparser
 import (
 	"cmp"
 	"context"
-	"fmt"
-	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
@@ -581,10 +579,10 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 
 			// Let's leave those commented debugs for now, they'll be useful in next PRs
 			for j, aggregation := range aggregations {
-				fmt.Println("--- Aggregation "+strconv.Itoa(j)+":", aggregation)
-				fmt.Println()
-				fmt.Println("--- SQL string ", aggregation.String())
-				fmt.Println()
+				// fmt.Println("--- Aggregation "+strconv.Itoa(j)+":", aggregation)
+				// fmt.Println()
+				// fmt.Println("--- SQL string ", aggregation.String())
+				// fmt.Println()
 				// fmt.Println("--- Group by: ", aggregation.GroupByFields)
 				if test.ExpectedSQLs[j] != "TODO" {
 					util.AssertSqlEqual(t, test.ExpectedSQLs[j], aggregation.String())
@@ -597,7 +595,7 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 			}
 
 			actualAggregationsPart := cw.MakeAggregationPartOfResponse(aggregations, test.ExpectedResults)
-			pp.Println("ACTUAL", actualAggregationsPart)
+			// pp.Println("ACTUAL", actualAggregationsPart)
 
 			fullResponse, err := cw.MakeResponseAggregationMarshalled(aggregations, test.ExpectedResults)
 			assert.NoError(t, err)
@@ -613,8 +611,8 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 
 			// probability and seed are present in random_sampler aggregation. I'd assume they are not needed, thus let's not care about it for now.
 			acceptableDifference := []string{"doc_count_error_upper_bound", "sum_other_doc_count", "probability", "seed", "bg_count", "doc_count"}
-			pp.Println("ACTUAL", actualMinusExpected)
-			pp.Print("EXPECTED", expectedMinusActual)
+			// pp.Println("ACTUAL", actualMinusExpected)
+			// pp.Print("EXPECTED", expectedMinusActual)
 			assert.True(t, util.AlmostEmpty(actualMinusExpected, acceptableDifference))
 			assert.True(t, util.AlmostEmpty(expectedMinusActual, acceptableDifference))
 			assert.Contains(t, string(fullResponse), `"value":`+strconv.FormatUint(test.ExpectedResults[0][0].Cols[0].Value.(uint64), 10)) // checks if hits nr is OK


### PR DESCRIPTION
Before: dashboard is broken. We don't respect `keyed`, and return response in incorrect format. I've already fixed it for 2 other aggregations.

Not sure why, but I didn't add a test for this aggregation, so we had none. Now we have 1 😆 
<img width="478" alt="Screenshot 2024-05-08 at 00 15 39" src="https://github.com/QuesmaOrg/quesma/assets/5407146/5a45a330-cda2-432f-b249-be11a0467665">
<img width="1728" alt="Screenshot 2024-05-08 at 00 15 14" src="https://github.com/QuesmaOrg/quesma/assets/5407146/54a61242-8ef0-4435-9182-f47e9247b900">
After:
<img width="1725" alt="Screenshot 2024-05-08 at 18 52 39" src="https://github.com/QuesmaOrg/quesma/assets/5407146/9bd7eea9-a9cb-406f-a445-71974dbc087b">
