### PR TITLE
Unifying interface of ProcessAutocompleteSuggestionsQuery

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -114,8 +114,13 @@ func executeQuery(ctx context.Context, lm *LogManager, tableName string, queryAs
 	return res, err
 }
 
-func (lm *LogManager) ProcessAutocompleteSuggestionsQuery(ctx context.Context, table string, query *model.Query) ([]model.QueryResultRow, error) {
-	return executeQuery(ctx, lm, table, query.String(), query.Fields, []interface{}{""})
+func (lm *LogManager) ProcessAutocompleteSuggestionsQuery(ctx context.Context, table *Table, query *model.Query) ([]model.QueryResultRow, error) {
+	colNames, err := table.extractColumns(query, false)
+	if err != nil {
+		return nil, err
+	}
+	rowToScan := make([]interface{}, len(colNames)+len(query.NonSchemaFields))
+	return executeQuery(ctx, lm, table.Name, query.String(), query.Fields, rowToScan)
 }
 
 func (lm *LogManager) ProcessGeneralAggregationQuery(ctx context.Context, table *Table, query *model.Query) ([]model.QueryResultRow, error) {

--- a/quesma/quesma/termsenum/terms_enum.go
+++ b/quesma/quesma/termsenum/terms_enum.go
@@ -20,11 +20,11 @@ func HandleTermsEnum(ctx context.Context, index string, reqBody []byte, lm *clic
 		logger.Error().Msg(errorMsg)
 		return nil, fmt.Errorf(errorMsg)
 	} else {
-		return handleTermsEnumRequest(ctx, resolvedTableName, reqBody, &queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: lm.FindTable(resolvedTableName), Ctx: context.Background()}, qmc)
+		return handleTermsEnumRequest(ctx, reqBody, &queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: lm.FindTable(resolvedTableName), Ctx: context.Background()}, qmc)
 	}
 }
 
-func handleTermsEnumRequest(ctx context.Context, table string, reqBody []byte, qt *queryparser.ClickhouseQueryTranslator, qmc *ui.QuesmaManagementConsole) (result []byte, err error) {
+func handleTermsEnumRequest(ctx context.Context, reqBody []byte, qt *queryparser.ClickhouseQueryTranslator, qmc *ui.QuesmaManagementConsole) (result []byte, err error) {
 	request := NewRequest()
 	startTime := time.Now()
 	if err := request.UnmarshalJSON(reqBody); err != nil {
@@ -37,7 +37,7 @@ func handleTermsEnumRequest(ctx context.Context, table string, reqBody []byte, q
 	dbQueryCtx, cancel := context.WithCancel(ctx)
 	// TODO this will be used to cancel goroutine that is executing the query
 	_ = cancel
-	if rows, err2 := qt.ClickhouseLM.ProcessAutocompleteSuggestionsQuery(dbQueryCtx, table, selectQuery); err2 != nil {
+	if rows, err2 := qt.ClickhouseLM.ProcessAutocompleteSuggestionsQuery(dbQueryCtx, qt.Table, selectQuery); err2 != nil {
 		logger.Error().Msgf("terms enum failed - error processing SQL query [%s]", err2)
 		result, err = json.Marshal(emptyTermsEnumResponse())
 	} else {

--- a/quesma/quesma/termsenum/terms_enum_test.go
+++ b/quesma/quesma/termsenum/terms_enum_test.go
@@ -88,7 +88,7 @@ func TestHandleTermsEnumRequest(t *testing.T) {
 	mock.ExpectQuery(fmt.Sprintf("%s|%s", regexp.QuoteMeta(expectedQuery1), regexp.QuoteMeta(expectedQuery2))).
 		WillReturnRows(sqlmock.NewRows([]string{"client_name"}).AddRow("client_a").AddRow("client_b"))
 
-	resp, err := handleTermsEnumRequest(ctx, table.Name, rawRequestBody, qt, managementConsole)
+	resp, err := handleTermsEnumRequest(ctx, rawRequestBody, qt, managementConsole)
 	assert.NoError(t, err)
 
 	var responseModel model.TermsEnumResponse


### PR DESCRIPTION
- unifies interface of `Process...` to be the same as 3 other process methods
- as a consequence removes redundant `table string` parameter from `handleTermsEnumRequest`