### PR TITLE
Fix test flakiness - bump timeouts

### DIFF
--- a/quesma/quesma/field_caps_test.go
+++ b/quesma/quesma/field_caps_test.go
@@ -2,7 +2,6 @@ package quesma
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
@@ -190,7 +189,6 @@ func TestFieldCapsMultipleIndexesConflictingEntries(t *testing.T) {
 		},
 	})
 	resp, err := handleFieldCapsIndex(ctx, []string{"logs-1", "logs-2", "logs-3"}, *tableMap)
-	fmt.Printf("string(resp): %+v\n", string(resp))
 	assert.NoError(t, err)
 	expectedResp, err := json.MarshalIndent([]byte(`{
   "fields": {

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -437,7 +437,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 			// (go managementConsole.RunOnlyChannelProcessor() above), so we might need to wait a bit
 			assert.Eventually(t, func() bool {
 				return len(managementConsole.QueriesWithUnsupportedType(tt.QueryType)) == 1
-			}, 150*time.Millisecond, 1*time.Millisecond)
+			}, 250*time.Millisecond, 1*time.Millisecond)
 			assert.Equal(t, 1, managementConsole.GetTotalUnsupportedQueries())
 			assert.Equal(t, 1, managementConsole.GetSavedUnsupportedQueries())
 			assert.Equal(t, 1, len(managementConsole.GetUnsupportedTypesWithCount()))
@@ -489,7 +489,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 		// (go managementConsole.RunOnlyChannelProcessor() above), so we might need to wait a bit
 		assert.Eventually(t, func() bool {
 			return len(managementConsole.QueriesWithUnsupportedType(tt.QueryType)) == min(testCounts[i], maxSavedQueriesPerQueryType)
-		}, 500*time.Millisecond, 1*time.Millisecond,
+		}, 600*time.Millisecond, 1*time.Millisecond,
 			tt.TestName+": wanted: %d, got: %d", min(testCounts[i], maxSavedQueriesPerQueryType),
 			len(managementConsole.QueriesWithUnsupportedType(tt.QueryType)),
 		)


### PR DESCRIPTION
Those new tests for errors in UI per query type passed 100/100 times on my PC, also they've been here for some time, and noone reported flakiness. But it happened to me now, so I guess I need to increase timeouts a bit.

I also remove 1 print from tests, I guess it shouldn't be there.