### PR TITLE
Don't respond with 500 on multi-source-multi-index search

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -132,8 +132,13 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 
 	switch sources {
 	case sourceBoth:
-		logger.Error().Msgf("index pattern [%s] resolved to both elasticsearch indices: [%s] and clickhouse tables: [%s]", indexPattern, sourcesElastic, sourcesClickhouse)
-		return nil, errors.New("querying data in elasticsearch and clickhouse is not supported at the moment")
+		logger.Error().Msgf("querying data in elasticsearch and clickhouse is not supported at the moment, index pattern [%s] resolved to both elasticsearch indices: [%s] and clickhouse tables: [%s]", indexPattern, sourcesElastic, sourcesClickhouse)
+		// TODO replace with actual handling
+		if optAsync != nil {
+			return queryparser.EmptyAsyncSearchResponse(optAsync.asyncRequestIdStr, false, 200)
+		} else {
+			return queryparser.EmptySearchResponse(ctx), nil
+		}
 	case sourceNone:
 		if elasticsearch.IsIndexPattern(indexPattern) {
 			if optAsync != nil {


### PR DESCRIPTION
Throwing too many errors can cause Kibana to shut down:

```
 FATAL  Error: Unable to complete saved object migrations for the [.kibana] index. Please check the health of your Elasticsearch cluster and try again. Unexpected Elasticsearch ResponseError: statusCode: 500, method: POST, url: /_search?allow_partial_search_results=false&sort=_shard_doc%3Aasc error: [undefined]: Internal server error. Request ID: b200bce5-9d02-4c9f-a4aa-d3432142d53e
```

Better return a default response, and log error instead.