### PR TITLE
Our router is missing http header parameters

### DIFF
--- a/quesma/quesma/mux/mux.go
+++ b/quesma/quesma/mux/mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/ucarion/urlpath"
 	"mitmproxy/quesma/logger"
+	"net/http"
 	"strings"
 )
 
@@ -46,7 +47,7 @@ func (p *PathRouter) RegisterPathMatcher(pattern string, httpMethods []string, p
 	}
 }
 
-func (p *PathRouter) Execute(ctx context.Context, path, body, httpMethod string) (*Result, error) {
+func (p *PathRouter) Execute(ctx context.Context, path, body, httpMethod string, headers http.Header) (*Result, error) {
 	handler, meta, found := p.findHandler(path, httpMethod, body)
 	if found {
 		return handler(ctx, body, path, meta.Params)

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -128,7 +128,7 @@ func (r *router) reroute(ctx context.Context, w http.ResponseWriter, req *http.R
 		}
 
 		quesmaResponse, err := recordRequestToClickhouse(req.URL.Path, r.quesmaManagementConsole, func() (*mux.Result, error) {
-			return router.Execute(ctx, req.URL.Path, string(reqBody), req.Method)
+			return router.Execute(ctx, req.URL.Path, string(reqBody), req.Method, req.Header)
 		})
 		var elkRawResponse elasticResult
 		var elkResponse *http.Response


### PR DESCRIPTION
Pass HTTP headers to the internal router - so far, we pass only a subset of a full HTTP request, but this might be needed, for example, for implementing the bypass chain.