### PR TITLE
Panic, wrong columns passed to ProcessQuery

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -266,7 +266,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 					return responseBody, err
 				}
 				countQuery := queryTranslator.BuildSimpleCountQuery(simpleQuery.Sql.Stmt)
-				countResult, err := q.logManager.ProcessQuery(ctx, table, countQuery, q.logManager.GetAllColumns(table, listQuery))
+				countResult, err := q.logManager.ProcessQuery(ctx, table, countQuery, q.logManager.GetAllColumns(table, countQuery))
 				if err != nil {
 					logger.ErrorWithCtx(ctx).Msgf("error processing count query. Err: %v, query: %+v", err, countQuery)
 					pushSecondaryInfo(q.quesmaManagementConsole, id, path, body, translatedQueryBody, responseBody, startTime)


### PR DESCRIPTION
Panic
```
quesma-1                | May 14 11:42:00.643 ERR quesma/quesma/recovery/recovery_strategies.go:28 > Panic recovered: runtime error: index out of range [1] with length 1
quesma-1                | goroutine 4305 [running]:
quesma-1                | runtime/debug.Stack()
quesma-1                | 	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
quesma-1                | mitmproxy/quesma/quesma/recovery.commonRecovery({0x627000?, 0x4002618330?}, 0x4003fd45d0)
quesma-1                | 	/quesma/quesma/recovery/recovery_strategies.go:28 +0x150
quesma-1                | mitmproxy/quesma/quesma/recovery.LogPanicWithCtx({0x7ea418, 0x4002bc3c20})
quesma-1                | 	/quesma/quesma/recovery/recovery_strategies.go:39 +0x60
quesma-1                | panic({0x627000?, 0x4002618330?})
quesma-1                | 	/usr/local/go/src/runtime/panic.go:770 +0x124
quesma-1                | mitmproxy/quesma/clickhouse.read({0x40033b3900, 0xb}, 0x40032f58c0, {0x4003f04288, 0x26, 0x0?}, {0x40000b8490, 0x1, 0x6771bb?})
quesma-1                | 	/quesma/clickhouse/quesma_communicator.go:143 +0x524
quesma-1                | mitmproxy/quesma/clickhouse.executeQuery({0x7ea418, 0x4002bc3c20}, 0x40000deb00, {0x40033b3900, 0xb}, {0x4001ab27e0, 0xdc}, {0x4003f04288, 0x26, 0x26}, ...)
quesma-1                | 	/quesma/clickhouse/quesma_communicator.go:113 +0x16c
quesma-1                | mitmproxy/quesma/clickhouse.(*LogManager).ProcessQuery(0x40000deb00, {0x7ea418, 0x4002bc3c20}, 0x4000839600, 0x4003b45600, {0x4003f04288, 0x26, 0x26})
quesma-1                | 	/quesma/clickhouse/quesma_communicator.go:56 +0x17c
quesma-1                | mitmproxy/quesma/quesma.(*QueryRunner).handleSearchCommon(0x40000dec60, {0x7ea418, 0x4002bc3c20}, {0x4002502ea6, 0xb}, {0x4003e9e000, 0x84b, 0x900}, 0x0, {0x676dcb, ...})
quesma-1                | 	/quesma/quesma/search.go:271 +0x1404
quesma-1                | mitmproxy/quesma/quesma.(*QueryRunner).handleSearch(...)
quesma-1                | 	/quesma/quesma/search.go:85
quesma-1                | mitmproxy/quesma/quesma.configureRouter.func11({0x7ea418, 0x4002bc3c20}, {0x4003621600?, 0x4002502ea0?}, {0x4?, 0x4003621600?}, 0x4003e1f890)
quesma-1                | 	/quesma/quesma/router.go:157 +0xa0
quesma-1                | mitmproxy/quesma/quesma/mux.(*PathRouter).Execute(0x10?, {0x7ea418, 0x4002bc3c20}, {0x4002502ea5, 0x14}, {0x4003621600, 0x84b}, {0x4002502ea0?, 0x4000b8f688?})
quesma-1                | 	/quesma/quesma/mux/mux.go:50 +0x74
quesma-1                | mitmproxy/quesma/quesma.(*router).reroute.func1()
quesma-1                | 	/quesma/quesma/quesma.go:131 +0x8c
quesma-1                | mitmproxy/quesma/quesma.recordRequestToClickhouse({0x4002502ea5?, 0x0?}, 0x40000d4288, 0x4000b8f908)
quesma-1                | 	/quesma/quesma/quesma.go:291 +0x8c
quesma-1                | mitmproxy/quesma/quesma.(*router).reroute(0x400028eb40, {0x7ea418, 0x4002bc3c20}, {0x7e9280, 0x40040430a0}, 0x40035f66c0, {0x40014c9c00, 0x84b, 0xc00}, 0x400009f2d8, ...)
quesma-1                | 	/quesma/quesma/quesma.go:130 +0x1a0
quesma-1                | mitmproxy/quesma/quesma.newDualWriteProxy.func1({0x7e9280, 0x40040430a0}, 0x40035f66c0)
quesma-1                | 	/quesma/quesma/dual_write_proxy.go:86 +0x138
quesma-1                | net/http.HandlerFunc.ServeHTTP(0x4000796ad8?, {0x7e9280?, 0x40040430a0?}, 0x3602d4?)
quesma-1                | 	/usr/local/go/src/net/http/server.go:2166 +0x38
quesma-1                | mitmproxy/quesma/quesma.(*simultaneousClientsLimiter).ServeHTTP(0x10?, {0x7e9280?, 0x40040430a0?}, 0x40040430a0?)
quesma-1                | 	/quesma/quesma/dual_write_proxy.go:48 +0xa4
quesma-1                | net/http.serverHandler.ServeHTTP({0x7e7e58?}, {0x7e9280?, 0x40040430a0?}, 0x6?)
quesma-1                | 	/usr/local/go/src/net/http/server.go:3137 +0xbc
quesma-1                | net/http.(*conn).serve(0x40032f5560, {0x7ea418, 0x400022c1e0})
quesma-1                | 	/usr/local/go/src/net/http/server.go:2039 +0x508
quesma-1                | created by net/http.(*Server).Serve in goroutine 91
quesma-1                | 	/usr/local/go/src/net/http/server.go:3285 +0x3f0
quesma-1                |  path=/device_logs/_search request_id=f86344af-cd89-49a8-84e8-23129e7611b6
```