### PR TITLE
Unify searchworker - combine Query with QueryWithAggregation

### DIFF
--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -158,7 +158,7 @@ func (cw *ClickhouseEQLQueryTranslator) BuildSimpleSelectQuery(whereClause strin
 	panic("EQL does not support this method")
 }
 
-func (cw *ClickhouseEQLQueryTranslator) MakeResponseAggregation(aggregations []model.QueryWithAggregation, aggregationResults [][]model.QueryResultRow) *model.SearchResp {
+func (cw *ClickhouseEQLQueryTranslator) MakeResponseAggregation(aggregations []model.Query, aggregationResults [][]model.QueryResultRow) *model.SearchResp {
 	panic("EQL does not support aggregations")
 }
 
@@ -166,6 +166,6 @@ func (cw *ClickhouseEQLQueryTranslator) BuildFacetsQuery(fieldName string, simpl
 	panic("EQL does not support facets")
 }
 
-func (cw *ClickhouseEQLQueryTranslator) ParseAggregationJson(aggregationJson string) ([]model.QueryWithAggregation, error) {
+func (cw *ClickhouseEQLQueryTranslator) ParseAggregationJson(aggregationJson string) ([]model.Query, error) {
 	panic("EQL does not support aggregations")
 }

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -29,7 +29,7 @@ func newFilter(name string, sql SimpleQuery) filter {
 }
 
 type aggrQueryBuilder struct {
-	model.QueryWithAggregation
+	model.Query
 	whereBuilder SimpleQuery // during building this is used for where clause, not `aggr.Where`
 	ctx          context.Context
 }
@@ -48,12 +48,12 @@ type metricsAggregation struct {
 
 const metricsAggregationDefaultFieldType = clickhouse.Invalid
 
-func (b *aggrQueryBuilder) buildAggregationCommon(metadata model.JsonMap) model.QueryWithAggregation {
-	query := b.QueryWithAggregation
+func (b *aggrQueryBuilder) buildAggregationCommon(metadata model.JsonMap) model.Query {
+	query := b.Query
 	query.WhereClause = b.whereBuilder.Sql.Stmt
 
 	// Need to copy, as we might be proceeding to modify 'b' pointer
-	query.CopyAggregationFields(b.QueryWithAggregation)
+	query.CopyAggregationFields(b.Query)
 	if len(query.Fields) > 0 && query.Fields[len(query.Fields)-1] == model.EmptyFieldSelection { // TODO 99% sure it's removed in next PR, let's leave for now
 		query.Fields = query.Fields[:len(query.Fields)-1]
 	}
@@ -63,19 +63,19 @@ func (b *aggrQueryBuilder) buildAggregationCommon(metadata model.JsonMap) model.
 	return query
 }
 
-func (b *aggrQueryBuilder) buildCountAggregation(metadata model.JsonMap) model.QueryWithAggregation {
+func (b *aggrQueryBuilder) buildCountAggregation(metadata model.JsonMap) model.Query {
 	query := b.buildAggregationCommon(metadata)
 	query.Type = metrics_aggregations.NewCount(b.ctx)
 	query.NonSchemaFields = append(query.NonSchemaFields, "count()")
 	return query
 }
 
-func (b *aggrQueryBuilder) buildBucketAggregation(metadata model.JsonMap) model.QueryWithAggregation {
+func (b *aggrQueryBuilder) buildBucketAggregation(metadata model.JsonMap) model.Query {
 	query := b.buildAggregationCommon(metadata)
 	query.NonSchemaFields = append(query.NonSchemaFields, "count()")
 	return query
 }
-func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregation, metadata model.JsonMap) model.QueryWithAggregation {
+func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregation, metadata model.JsonMap) model.Query {
 	getFirstFieldName := func() string {
 		if len(metricsAggr.FieldNames) > 0 {
 			return metricsAggr.FieldNames[0]
@@ -126,7 +126,7 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 	case "top_metrics":
 		// This appending of `metricsAggr.SortBy` and having it duplicated in SELECT block
 		// is a way to pass value we're sorting by to the query result. In the future we might add SQL aliasing support, e.g. SELECT x AS 'sort_by' FROM ...
-		if len(b.QueryWithAggregation.Query.GroupByFields) > 0 {
+		if len(b.Query.GroupByFields) > 0 {
 			var ordFunc string
 			switch metricsAggr.Order {
 			case "asc":
@@ -140,7 +140,7 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 				topSelectFields = append(topSelectFields, fmt.Sprintf(`%s("%s") AS "windowed_%s"`, ordFunc, field, field))
 			}
 			query.NonSchemaFields = append(query.NonSchemaFields, topSelectFields...)
-			partitionBy := strings.Join(b.QueryWithAggregation.Query.GroupByFields, "")
+			partitionBy := strings.Join(b.Query.GroupByFields, "")
 			fieldsAsString := strings.Join(quoteArray(innerFields), ", ") // need those fields in the inner clause
 			query.FromClause = fmt.Sprintf(
 				"(SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s %s) AS %s FROM %s WHERE %s)",
@@ -193,7 +193,7 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 
 // ParseAggregationJson parses JSON with aggregation query and returns array of queries with aggregations.
 // If there are no aggregations, returns nil.
-func (cw *ClickhouseQueryTranslator) ParseAggregationJson(queryAsJson string) ([]model.QueryWithAggregation, error) {
+func (cw *ClickhouseQueryTranslator) ParseAggregationJson(queryAsJson string) ([]model.Query, error) {
 	queryAsMap := make(QueryMap)
 	err := json.Unmarshal([]byte(queryAsJson), &queryAsMap)
 	if err != nil {
@@ -212,7 +212,7 @@ func (cw *ClickhouseQueryTranslator) ParseAggregationJson(queryAsJson string) ([
 
 	// COUNT(*) is needed for every request. We should change it and don't duplicate it, as some
 	// requests also ask for that themselves, but let's leave it for later.
-	aggregations := []model.QueryWithAggregation{currentAggr.buildCountAggregation(model.NoMetadataField)}
+	aggregations := []model.Query{currentAggr.buildCountAggregation(model.NoMetadataField)}
 
 	if aggsRaw, ok := queryAsMap["aggs"]; ok {
 		aggs, ok := aggsRaw.(QueryMap)
@@ -256,7 +256,7 @@ func (cw *ClickhouseQueryTranslator) ParseAggregationJson(queryAsJson string) ([
 // Notice that on 0, 2, ..., level of nesting we have "aggs" key or aggregation type.
 // On 1, 3, ... level of nesting we have names of aggregations, which can be any arbitrary strings.
 // This function is called on those 1, 3, ... levels, and parses and saves those aggregation names.
-func (cw *ClickhouseQueryTranslator) parseAggregationNames(currentAggr *aggrQueryBuilder, queryMap QueryMap, resultAccumulator *[]model.QueryWithAggregation) {
+func (cw *ClickhouseQueryTranslator) parseAggregationNames(currentAggr *aggrQueryBuilder, queryMap QueryMap, resultAccumulator *[]model.Query) {
 	// We process subaggregations, introduced via (k, v), meaning 'aggregation_name': { dict }
 	for k, v := range queryMap {
 		// I assume it's new aggregator name
@@ -292,7 +292,7 @@ func (cw *ClickhouseQueryTranslator) parseAggregationNames(currentAggr *aggrQuer
 // Notice that on 0, 2, ..., level of nesting we have "aggs" key or aggregation type.
 // On 1, 3, ... level of nesting we have names of aggregations, which can be any arbitrary strings.
 // This function is called on those 0, 2, ... levels, and parses the actual aggregations.
-func (cw *ClickhouseQueryTranslator) parseAggregation(currentAggr *aggrQueryBuilder, queryMap QueryMap, resultAccumulator *[]model.QueryWithAggregation) {
+func (cw *ClickhouseQueryTranslator) parseAggregation(currentAggr *aggrQueryBuilder, queryMap QueryMap, resultAccumulator *[]model.Query) {
 	if len(queryMap) == 0 {
 		return
 	}

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -529,8 +529,8 @@ func TestAggregationParser(t *testing.T) {
 }
 
 // Used in tests to make processing `aggregations` in a deterministic way
-func sortAggregations(aggregations []model.QueryWithAggregation) {
-	slices.SortFunc(aggregations, func(a, b model.QueryWithAggregation) int {
+func sortAggregations(aggregations []model.Query) {
+	slices.SortFunc(aggregations, func(a, b model.Query) int {
 		for i := range min(len(a.Aggregators), len(b.Aggregators)) {
 			if a.Aggregators[i].Name != b.Aggregators[i].Name {
 				return cmp.Compare(a.Aggregators[i].Name, b.Aggregators[i].Name)

--- a/quesma/queryparser/pipeline_aggregations.go
+++ b/quesma/queryparser/pipeline_aggregations.go
@@ -105,7 +105,7 @@ func (cw *ClickhouseQueryTranslator) parseBucketScriptBasic(queryMap QueryMap) (
 	return pipeline_aggregations.NewBucketScript(cw.Ctx), true
 }
 
-func (b *aggrQueryBuilder) buildPipelineAggregation(aggregationType model.QueryType, metadata model.JsonMap) model.QueryWithAggregation {
+func (b *aggrQueryBuilder) buildPipelineAggregation(aggregationType model.QueryType, metadata model.JsonMap) model.Query {
 	query := b.buildAggregationCommon(metadata)
 	query.Type = aggregationType
 	switch aggrType := aggregationType.(type) {

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -376,7 +376,7 @@ func (cw *ClickhouseQueryTranslator) MakeAsyncSearchResponseMarshalled(ResultSet
 	return response.Marshal()
 }
 
-func (cw *ClickhouseQueryTranslator) finishMakeResponse(query model.QueryWithAggregation, ResultSet []model.QueryResultRow, level int) []model.JsonMap {
+func (cw *ClickhouseQueryTranslator) finishMakeResponse(query model.Query, ResultSet []model.QueryResultRow, level int) []model.JsonMap {
 	// fmt.Println("FinishMakeResponse", query, ResultSet, level, query.Type.String())
 	if query.Type.IsBucketAggregation() {
 		return query.Type.TranslateSqlResponseToJson(ResultSet, level)
@@ -426,7 +426,7 @@ func (cw *ClickhouseQueryTranslator) splitResultSetIntoBuckets(ResultSet []model
 // DFS algorithm
 // 'aggregatorsLevel' - index saying which (sub)aggregation we're handling
 // 'selectLevel' - which field from select we're grouping by at current level (or not grouping by, if query.Aggregators[aggregatorsLevel].Empty == true)
-func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query model.QueryWithAggregation,
+func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query model.Query,
 	ResultSet []model.QueryResultRow, aggregatorsLevel, selectLevel int) []model.JsonMap {
 
 	// either we finish
@@ -486,7 +486,7 @@ func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query mode
 	return []model.JsonMap{result}
 }
 
-func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []model.QueryWithAggregation, ResultSets [][]model.QueryResultRow) model.JsonMap {
+func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []model.Query, ResultSets [][]model.QueryResultRow) model.JsonMap {
 	const aggregation_start_index = 1
 	aggregations := model.JsonMap{}
 	if len(queries) <= aggregation_start_index {
@@ -505,7 +505,7 @@ func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []mod
 	return aggregations
 }
 
-func (cw *ClickhouseQueryTranslator) MakeResponseAggregation(queries []model.QueryWithAggregation, ResultSets [][]model.QueryResultRow) *model.SearchResp {
+func (cw *ClickhouseQueryTranslator) MakeResponseAggregation(queries []model.Query, ResultSets [][]model.QueryResultRow) *model.SearchResp {
 	var totalCount uint64
 	if len(ResultSets) > 0 && len(ResultSets[0]) > 0 && len(ResultSets[0][0].Cols) > 0 {
 		// This if: doesn't hurt much, but mostly for tests, never seen need for this on "production".
@@ -535,7 +535,7 @@ func (cw *ClickhouseQueryTranslator) MakeResponseAggregation(queries []model.Que
 	}
 }
 
-func (cw *ClickhouseQueryTranslator) MakeResponseAggregationMarshalled(queries []model.QueryWithAggregation, ResultSets [][]model.QueryResultRow) ([]byte, error) {
+func (cw *ClickhouseQueryTranslator) MakeResponseAggregationMarshalled(queries []model.Query, ResultSets [][]model.QueryResultRow) ([]byte, error) {
 	response := cw.MakeResponseAggregation(queries, ResultSets)
 	return response.Marshal()
 }
@@ -554,7 +554,7 @@ func SearchToAsyncSearchResponse(searchResponse *model.SearchResp, asyncRequestI
 	return &response
 }
 
-func (cw *ClickhouseQueryTranslator) postprocessPipelineAggregations(queries []model.QueryWithAggregation, ResultSets [][]model.QueryResultRow) {
+func (cw *ClickhouseQueryTranslator) postprocessPipelineAggregations(queries []model.Query, ResultSets [][]model.QueryResultRow) {
 	queryIterationOrder := cw.sortInTopologicalOrder(queries)
 	// fmt.Println("qwerty", queryIterationOrder) let's remove all prints in this function after all pipeline aggregations are merged
 	for _, queryIndex := range queryIterationOrder {
@@ -739,7 +739,7 @@ func (cw *ClickhouseQueryTranslator) createHistogramPartOfQuery(queryMap QueryMa
 // Probably you can create a query with loops in pipeline aggregations, but you can't do it in Kibana from Visualize view,
 // so I don't handle it here. We won't panic in such case, only log a warning/error + return non-full results, which is expected,
 // as you can't really compute cycled pipeline aggregations.
-func (cw *ClickhouseQueryTranslator) sortInTopologicalOrder(queries []model.QueryWithAggregation) []int {
+func (cw *ClickhouseQueryTranslator) sortInTopologicalOrder(queries []model.Query) []int {
 	nameToIndex := make(map[string]int, len(queries))
 	for i, query := range queries {
 		nameToIndex[query.Name()] = i

--- a/quesma/queryparser/query_translator_test.go
+++ b/quesma/queryparser/query_translator_test.go
@@ -723,32 +723,32 @@ func Test_makeSearchResponseFacetsNumericFloats(t *testing.T) {
 
 func Test_sortInTopologicalOrder(t *testing.T) {
 	var testcases = []struct {
-		queries                []model.QueryWithAggregation
+		queries                []model.Query
 		wantedTopologicalOrder []int
 	}{
 		{
-			queries: []model.QueryWithAggregation{
-				{Query: model.Query{Parent: "b", NoDBQuery: true}, Aggregators: []model.Aggregator{{Name: "c"}}},
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "b"}}},
-				{Query: model.Query{Parent: "c", NoDBQuery: true}, Aggregators: []model.Aggregator{{Name: "d"}}},
+			queries: []model.Query{
+				{Parent: "b", NoDBQuery: true, Aggregators: []model.Aggregator{{Name: "c"}}},
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "b"}}},
+				{Parent: "c", NoDBQuery: true, Aggregators: []model.Aggregator{{Name: "d"}}},
 			},
 			wantedTopologicalOrder: []int{1, 0, 2},
 		},
 		{
-			queries: []model.QueryWithAggregation{
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "c"}}},
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "b"}}},
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "d"}}},
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "e"}}},
+			queries: []model.Query{
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "c"}}},
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "b"}}},
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "d"}}},
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "e"}}},
 			},
 			wantedTopologicalOrder: []int{0, 1, 2, 3},
 		},
 		{
-			queries: []model.QueryWithAggregation{
-				{Query: model.Query{Parent: "a", NoDBQuery: true}, Aggregators: []model.Aggregator{{Name: "b1"}}},
-				{Query: model.Query{Parent: "a", NoDBQuery: true}, Aggregators: []model.Aggregator{{Name: "b2"}}},
-				{Query: model.Query{Parent: ""}, Aggregators: []model.Aggregator{{Name: "a"}}},
-				{Query: model.Query{Parent: "b2", NoDBQuery: true}, Aggregators: []model.Aggregator{{Name: "c"}}},
+			queries: []model.Query{
+				{Parent: "a", NoDBQuery: true, Aggregators: []model.Aggregator{{Name: "b1"}}},
+				{Parent: "a", NoDBQuery: true, Aggregators: []model.Aggregator{{Name: "b2"}}},
+				{Parent: "", Aggregators: []model.Aggregator{{Name: "a"}}},
+				{Parent: "b2", NoDBQuery: true, Aggregators: []model.Aggregator{{Name: "c"}}},
 			},
 			wantedTopologicalOrder: []int{2, 0, 1, 3},
 		},

--- a/quesma/queryparser/range_aggregation.go
+++ b/quesma/queryparser/range_aggregation.go
@@ -54,7 +54,7 @@ func (cw *ClickhouseQueryTranslator) parseRangeAggregation(rangePart QueryMap) b
 }
 
 func (cw *ClickhouseQueryTranslator) processRangeAggregation(currentAggr *aggrQueryBuilder, Range bucket_aggregations.Range,
-	queryCurrentLevel QueryMap, aggregationsAccumulator *[]model.QueryWithAggregation, metadata JsonMap) {
+	queryCurrentLevel QueryMap, aggregationsAccumulator *[]model.Query, metadata JsonMap) {
 
 	// build this aggregation
 	for _, interval := range Range.Intervals {

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -18,7 +18,7 @@ import (
 
 type IQueryTranslator interface {
 	ParseQuery(queryAsJson string) (queryparser.SimpleQuery, model.SearchQueryInfo, model.Highlighter, error)
-	ParseAggregationJson(aggregationJson string) ([]model.QueryWithAggregation, error)
+	ParseAggregationJson(aggregationJson string) ([]model.Query, error)
 
 	BuildSimpleCountQuery(whereClause string) *model.Query
 	BuildSimpleSelectQuery(whereClause string, size int) *model.Query
@@ -26,7 +26,7 @@ type IQueryTranslator interface {
 	BuildFacetsQuery(fieldName string, simpleQuery queryparser.SimpleQuery, limit int) *model.Query
 
 	MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) (*model.SearchResp, error)
-	MakeResponseAggregation(aggregations []model.QueryWithAggregation, aggregationResults [][]model.QueryResultRow) *model.SearchResp
+	MakeResponseAggregation(aggregations []model.Query, aggregationResults [][]model.QueryResultRow) *model.SearchResp
 }
 
 type QueryLanguage string

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -199,7 +199,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 	for _, resolvedTableName := range sourcesClickhouse {
 		var queryTranslator IQueryTranslator
 		var highlighter model.Highlighter
-		var aggregations []model.QueryWithAggregation
+		var aggregations []model.Query
 		var err error
 		var queryInfo model.SearchQueryInfo
 		var count int
@@ -525,7 +525,7 @@ func (q *QueryRunner) searchWorkerCommon(ctx context.Context, fullQuery model.Qu
 	return
 }
 
-func (q *QueryRunner) searchAggregationWorkerCommon(ctx context.Context, aggregations []model.QueryWithAggregation,
+func (q *QueryRunner) searchAggregationWorkerCommon(ctx context.Context, aggregations []model.Query,
 	columns []string,
 	queryTranslator IQueryTranslator, table *clickhouse.Table,
 	optAsync *AsyncQuery) (translatedQueryBody []byte, resultRows [][]model.QueryResultRow) {
@@ -550,9 +550,9 @@ func (q *QueryRunner) searchAggregationWorkerCommon(ctx context.Context, aggrega
 			logger.InfoWithCtx(ctx).Msgf("pipeline query: %+v", agg)
 		} else {
 			logger.InfoWithCtx(ctx).Msgf("SQL: %s", agg.String())
-			sqls += agg.Query.String() + "\n"
+			sqls += agg.String() + "\n"
 		}
-		rows, err := q.logManager.ProcessQuery(dbQueryCtx, table, &agg.Query, nil)
+		rows, err := q.logManager.ProcessQuery(dbQueryCtx, table, &agg, nil)
 		if err != nil {
 			logger.ErrorWithCtx(ctx).Msg(err.Error())
 			continue
@@ -588,7 +588,7 @@ func (q *QueryRunner) searchWorker(ctx context.Context,
 }
 
 func (q *QueryRunner) searchAggregationWorker(ctx context.Context,
-	aggregations []model.QueryWithAggregation,
+	aggregations []model.Query,
 	columns []string,
 	queryTranslator IQueryTranslator,
 	table *clickhouse.Table,


### PR DESCRIPTION
This PR
- Moves additional `QueryWithAggreation` fields into `Query` as there should not be distinction between them. This opens additonal unifications possible.
- minor changes