### PR TITLE
Remove no-op content-length override

### DIFF
--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -20,7 +20,6 @@ import (
 	"mitmproxy/quesma/telemetry"
 	"mitmproxy/quesma/tracing"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -58,10 +57,8 @@ func responseFromQuesma(ctx context.Context, unzipped []byte, w http.ResponseWri
 		if err != nil {
 			logger.ErrorWithCtx(ctx).Msgf("Error zipping: %v", err)
 		}
-		w.Header().Add(httpHeaderContentLength, strconv.Itoa(len(zipped)))
 		_, _ = io.Copy(w, bytes.NewBuffer(zipped))
 	} else {
-		w.Header().Add(httpHeaderContentLength, strconv.Itoa(len(unzipped)))
 		_, _ = io.Copy(w, bytes.NewBuffer(unzipped))
 	}
 	if elkResponse != nil {


### PR DESCRIPTION
In Go, you cannot set headers after a call to WriteHeader. Once WriteHeader is called, the HTTP status code and any set headers are sent to the client, and the HTTP response is considered to be in a "header written" state. 

After this point, any attempts to set or modify headers will have no effect.