### PR TITLE
Register /_resolve and /_refresh as not query paths

### DIFF
--- a/quesma/quesma/routes/paths.go
+++ b/quesma/quesma/routes/paths.go
@@ -28,6 +28,8 @@ var notQueryPaths = []string{
 	"_doc",
 	"_field_caps",
 	"_health",
+	"_resolve",
+	"_refresh",
 }
 
 func IsNotQueryPath(path string) bool {


### PR DESCRIPTION
We were missing two entries on our "not a query" list