### PR TITLE
Enable support for parsing empty query bodies

### DIFF
--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -63,11 +63,13 @@ func NewCompoundStatementNoFieldName(stmt string) Statement {
 func (cw *ClickhouseQueryTranslator) ParseQuery(queryAsJson string) (SimpleQuery, model.SearchQueryInfo, model.Highlighter) {
 	cw.ClearTokensToHighlight()
 	queryAsMap := make(QueryMap)
-	err := json.Unmarshal([]byte(queryAsJson), &queryAsMap)
-	if err != nil {
-		logger.ErrorWithCtx(cw.Ctx).Err(err).Msg("error parsing query request's JSON")
-		return newSimpleQuery(NewSimpleStatement("invalid JSON (ParseQuery)"), false),
-			model.NewSearchQueryInfoNone(), NewEmptyHighlighter()
+	if queryAsJson != "" {
+		err := json.Unmarshal([]byte(queryAsJson), &queryAsMap)
+		if err != nil {
+			logger.ErrorWithCtx(cw.Ctx).Err(err).Msg("error parsing query request's JSON")
+			return newSimpleQuery(NewSimpleStatement("invalid JSON (ParseQuery)"), false),
+				model.NewSearchQueryInfoNone(), NewEmptyHighlighter()
+		}
 	}
 
 	// we must parse "highlights" here, because it is stripped from the queryAsMap later

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -1875,6 +1875,14 @@ var TestsSearch = []SearchTestCase{
 		[]model.Query{justSimplestWhere(`"message" iLIKE '%User logged out%' AND "message" iLIKE '%User logged out%'`)},
 		[]string{qToStr(justSimplestWhere(`"message" iLIKE '%User logged out%' AND "message" iLIKE '%User logged out%'`))},
 	},
+	{ // [31]
+		"Match all (empty query)",
+		``,
+		[]string{""},
+		model.Normal,
+		[]model.Query{newSimplestQuery()},
+		[]string{qToStr(newSimplestQuery())},
+	},
 }
 
 var TestsSearchNoAttrs = []SearchTestCase{


### PR DESCRIPTION
When no body provided when searching, it should be interpreted as `match-all`. This works because later on we search for `query` in the body, and if it's not present, we return `newSimpleQuery(NewSimpleStatement(""), true)`