### PR TITLE
Fix async searches

### DIFF
--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -201,7 +201,7 @@ func configureRouter(cfg config.QuesmaConfiguration, lm *clickhouse.LogManager, 
 		return elasticsearchQueryResult(string(responseBody), httpOk), nil
 	})
 
-	router.RegisterPathMatcher(routes.AsyncSearchIdPath, []string{"POST"}, matchedAgainstAsyncId(), func(ctx context.Context, body string, _ string, params map[string]string) (*mux.Result, error) {
+	router.RegisterPathMatcher(routes.AsyncSearchIdPath, []string{"GET"}, matchedAgainstAsyncId(), func(ctx context.Context, body string, _ string, params map[string]string) (*mux.Result, error) {
 		ctx = context.WithValue(ctx, tracing.AsyncIdCtxKey, params["id"])
 		responseBody, err := queryRunner.handlePartialAsyncSearch(ctx, params["id"])
 		if err != nil {


### PR DESCRIPTION
Recent router refactoring broke all async searches.

<img width="1477" alt="Screenshot 2024-05-16 at 14 32 52" src="https://github.com/QuesmaOrg/quesma/assets/972989/5480eaff-e300-4bc7-afea-0789f138d1e8">

Any search that takes longer than 200ms fals as a result of that.

![Uploading Screenshot 2024-05-16 at 14.37.17.png…]()
