### PR TITLE
Handle 'allow_no_indices' and 'ignore_unavailable' query params for /field_caps

### DIFF
--- a/quesma/quesma/field_caps.go
+++ b/quesma/quesma/field_caps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/elasticsearch"
 	"mitmproxy/quesma/model"
@@ -187,8 +188,11 @@ func EmptyFieldCapsResponse() []byte {
 		Fields:  make(map[string]map[string]model.FieldCapability),
 		Indices: []string{},
 	}
-	serialized, _ := json.Marshal(response)
-	return serialized
+	if serialized, err := json.Marshal(response); err != nil {
+		panic(fmt.Sprintf("Failed to serialize empty field caps response: %v, this should never happen", err))
+	} else {
+		return serialized
+	}
 }
 
 func isInternalColumn(col *clickhouse.Column) bool {

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -224,10 +224,7 @@ func configureRouter(cfg config.QuesmaConfiguration, lm *clickhouse.LogManager, 
 		responseBody, err := handleFieldCaps(ctx, params["index"], []byte(body), lm)
 		if err != nil {
 			if errors.Is(errIndexNotExists, err) {
-				if queryParams.Get("allow_no_indices") == "true" {
-					return elasticsearchQueryResult(string(EmptyFieldCapsResponse()), httpOk), nil
-				}
-				if queryParams.Get("ignore_unavailable") == "true" {
+				if queryParams.Get("allow_no_indices") == "true" || queryParams.Get("ignore_unavailable") == "true" {
 					return elasticsearchQueryResult(string(EmptyFieldCapsResponse()), httpOk), nil
 				}
 				return &mux.Result{StatusCode: 404}, nil


### PR DESCRIPTION
Fixes data view management/settings panel in Kibana. Since we don't close/open indices, both options behave the same

Depends on:
- https://github.com/QuesmaOrg/quesma/pull/126