### PR TITLE
Propagate SortFields to query_translator

### DIFF
--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -48,7 +48,7 @@ func (cw *ClickhouseEQLQueryTranslator) BuildNRowsQuery(fieldName string, simple
 	}
 }
 
-func (cw *ClickhouseEQLQueryTranslator) MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) (*model.SearchResp, error) {
+func (cw *ClickhouseEQLQueryTranslator) MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, sortFields []string) (*model.SearchResp, error) {
 
 	// This shares a lot of code with the ClickhouseQueryTranslator
 	//

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -31,8 +31,9 @@ type Query struct {
 	CanParse        bool     // true <=> query is valid
 	QueryInfo       SearchQueryInfo
 	Highlighter     Highlighter
-	NoDBQuery       bool   // true <=> we don't need query to DB here, true in some pipeline aggregations
-	Parent          string // parent aggregation name, used in some pipeline aggregations
+	NoDBQuery       bool     // true <=> we don't need query to DB here, true in some pipeline aggregations
+	Parent          string   // parent aggregation name, used in some pipeline aggregations
+	SortFields      []string // fields to sort by
 }
 
 var NoMetadataField JsonMap = nil

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -78,7 +78,8 @@ func (cw *ClickhouseQueryTranslator) highlightHit(hit *model.SearchHit, highligh
 	}
 }
 
-func (cw *ClickhouseQueryTranslator) makeSearchResponseNormal(ResultSet []model.QueryResultRow, highlighter model.Highlighter) *model.SearchResp {
+func (cw *ClickhouseQueryTranslator) makeSearchResponseNormal(ResultSet []model.QueryResultRow, highlighter model.Highlighter, sortFields []string) *model.SearchResp {
+	// TODO sortFields
 	hits := make([]model.SearchHit, len(ResultSet))
 	for i, row := range ResultSet {
 		hits[i] = model.SearchHit{
@@ -172,21 +173,21 @@ type (
 	}
 )
 
-func (cw *ClickhouseQueryTranslator) MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) (*model.SearchResp, error) {
+func (cw *ClickhouseQueryTranslator) MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, sortFields []string) (*model.SearchResp, error) {
 	switch typ {
 	case model.Normal:
-		return cw.makeSearchResponseNormal(ResultSet, highlighter), nil
+		return cw.makeSearchResponseNormal(ResultSet, highlighter, sortFields), nil
 	case model.Facets, model.FacetsNumeric:
 		return cw.makeSearchResponseFacets(ResultSet, typ), nil
 	case model.ListByField, model.ListAllFields:
-		return cw.makeSearchResponseList(ResultSet, typ, highlighter), nil
+		return cw.makeSearchResponseList(ResultSet, typ, highlighter, sortFields), nil
 	default:
 		return nil, fmt.Errorf("unknown SearchQueryType: %v", typ)
 	}
 }
 
-func (cw *ClickhouseQueryTranslator) MakeSearchResponseMarshalled(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) ([]byte, error) {
-	response, err := cw.MakeSearchResponse(ResultSet, typ, highlighter)
+func (cw *ClickhouseQueryTranslator) MakeSearchResponseMarshalled(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, sortFields []string) ([]byte, error) {
+	response, err := cw.MakeSearchResponse(ResultSet, typ, highlighter, sortFields)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +316,8 @@ func (cw *ClickhouseQueryTranslator) makeSearchResponseFacets(ResultSet []model.
 	}
 }
 
-func (cw *ClickhouseQueryTranslator) makeSearchResponseList(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) *model.SearchResp {
+func (cw *ClickhouseQueryTranslator) makeSearchResponseList(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, sortFields []string) *model.SearchResp {
+	// TODO sortFields
 	hits := make([]model.SearchHit, len(ResultSet))
 	for i := range ResultSet {
 		hits[i].Fields = make(map[string][]interface{})
@@ -350,7 +352,7 @@ func (cw *ClickhouseQueryTranslator) makeSearchResponseList(ResultSet []model.Qu
 }
 
 func (cw *ClickhouseQueryTranslator) MakeAsyncSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, asyncRequestIdStr string, isPartial bool) (*model.AsyncSearchEntireResp, error) {
-	searchResponse, err := cw.MakeSearchResponse(ResultSet, typ, highlighter)
+	searchResponse, err := cw.MakeSearchResponse(ResultSet, typ, highlighter, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/quesma/queryparser/query_translator_test.go
+++ b/quesma/queryparser/query_translator_test.go
@@ -140,7 +140,7 @@ func TestMakeResponseSearchQuery(t *testing.T) {
 	cw := ClickhouseQueryTranslator{Table: &clickhouse.Table{Name: "test"}, Ctx: context.Background()}
 	for i, tt := range args {
 		t.Run(tt.queryType.String(), func(t *testing.T) {
-			ourResponse, err := cw.MakeSearchResponseMarshalled(args[i].ourQueryResult, args[i].queryType, NewEmptyHighlighter())
+			ourResponse, err := cw.MakeSearchResponseMarshalled(args[i].ourQueryResult, args[i].queryType, NewEmptyHighlighter(), []string{})
 			assert.NoError(t, err)
 			actualMinusExpected, expectedMinusActual, err := util.JsonDifference(string(ourResponse), args[i].elasticResponseJson)
 			if err != nil {
@@ -472,7 +472,7 @@ func TestMakeResponseSearchQueryIsProperJson(t *testing.T) {
 		for _, field := range query.NonSchemaFields {
 			resultRow.Cols = append(resultRow.Cols, model.QueryResultCol{ColName: field, Value: "not-important"})
 		}
-		_, err := cw.MakeSearchResponse([]model.QueryResultRow{resultRow}, model.Normal, NewEmptyHighlighter())
+		_, err := cw.MakeSearchResponse([]model.QueryResultRow{resultRow}, model.Normal, NewEmptyHighlighter(), []string{})
 		assert.NoError(t, err)
 	}
 }

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -25,7 +25,7 @@ type IQueryTranslator interface {
 	BuildNRowsQuery(fieldName string, simpleQuery queryparser.SimpleQuery, limit int) *model.Query
 	BuildFacetsQuery(fieldName string, simpleQuery queryparser.SimpleQuery, limit int) *model.Query
 
-	MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter) (*model.SearchResp, error)
+	MakeSearchResponse(ResultSet []model.QueryResultRow, typ model.SearchQueryType, highlighter model.Highlighter, sortFields []string) (*model.SearchResp, error)
 	MakeResponseAggregation(aggregations []model.QueryWithAggregation, aggregationResults [][]model.QueryResultRow) *model.SearchResp
 }
 


### PR DESCRIPTION
Parse `sort` part in the form:
```
    "sort": {
        "@timestamp": "desc",
        "_doc": "desc"
    },
```
and propagate SortFields to the response generator. This will be needed to include real `sort` in responses