### PR TITLE
Check if table is nil

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -205,7 +205,9 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		var count int
 
 		table, _ := tables.Load(resolvedTableName)
-
+		if table == nil {
+			continue
+		}
 		var simpleQuery queryparser.SimpleQuery
 
 		queryTranslator = NewQueryTranslator(ctx, queryLanguage, table, q.logManager)


### PR DESCRIPTION
```
quesma-1                | May 17 10:00:23.868 ERR quesma/quesma/recovery/recovery_strategies.go:28 > Panic recovered: runtime error: invalid memory address or nil pointer dereference
quesma-1                | goroutine 1896 [running]:
quesma-1                | runtime/debug.Stack()
quesma-1                | 	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
quesma-1                | mitmproxy/quesma/quesma/recovery.commonRecovery({0x5bd260?, 0xbf99c0?}, 0x400380a4f0)
quesma-1                | 	/quesma/quesma/recovery/recovery_strategies.go:28 +0x150
quesma-1                | mitmproxy/quesma/quesma/recovery.LogPanicWithCtx({0x7ebc78, 0x4004a81470})
quesma-1                | 	/quesma/quesma/recovery/recovery_strategies.go:39 +0x60
quesma-1                | panic({0x5bd260?, 0xbf99c0?})
quesma-1                | 	/usr/local/go/src/runtime/panic.go:770 +0x124
quesma-1                | mitmproxy/quesma/clickhouse.(*Table).FullTableName(0x400018d500?)
quesma-1                | 	/quesma/clickhouse/table.go:124 +0x1c
quesma-1                | mitmproxy/quesma/queryparser.(*ClickhouseQueryTranslator).BuildSimpleCountQuery(0x4002d268f0?, {0x0, 0x0})
quesma-1                | 	/quesma/queryparser/query_translator.go:611 +0x28
quesma-1                | mitmproxy/quesma/quesma.(*QueryRunner).makeBasicQuery(0x0?, {0x0?, 0x0?}, {0x7ef330?, 0x4003b54b40?}, 0x4000287f50?, {{{0x0, 0x0}, 0x0, {0x0, ...}}, ...}, ...)
quesma-1                | 	/quesma/quesma/search.go:468 +0x1f0
quesma-1                | mitmproxy/quesma/quesma.(*QueryRunner).handleSearchCommon(0x4000296f20, {0x7ebc78, 0x4004802270}, {0x40024221c6, 0xd}, {0x40026ee340, 0xca, 0xd0}, 0x4003b54a80, {0x677ada, ...})
quesma-1                | 	/quesma/quesma/search.go:232 +0xcf0
quesma-1                | mitmproxy/quesma/quesma.(*QueryRunner).handleAsyncSearch(0x4000296f20, {0x7ebc78, 0x4004a81470}, {0x40024221c6, 0xd}, {0x40026ee340, 0xca, 0xd0}, 0x3e8, 0x0)
quesma-1                | 	/quesma/quesma/search.go:106 +0x224
quesma-1                | mitmproxy/quesma/quesma.configureRouter.func12({0x7ebc78, 0x4004a81470}, {0x40026ee1a0, 0xca}, {0x4?, 0x40026ee1a0?}, 0x40038616e0, 0x0?, 0x4002422100?)
quesma-1                | 	/quesma/quesma/router.go:190 +0x1c0
quesma-1                | mitmproxy/quesma/quesma/mux.(*PathRouter).Execute(0x400380b628?, {0x7ebc78, 0x4004a81470}, {0x40024221c5, 0x1c}, {0x40026ee1a0, 0xca}, {0x40024221c0?, 0x0?}, 0x4004a81350, ...)
quesma-1                | 	/quesma/quesma/mux/mux.go:54 +0x84
quesma-1                | mitmproxy/quesma/quesma.(*router).reroute.func1()
quesma-1                | 	/quesma/quesma/quesma.go:129 +0xb4
quesma-1                | mitmproxy/quesma/quesma.recordRequestToClickhouse({0x40024221c5?, 0x0?}, 0x4000292288, 0x400380b908)
quesma-1                | 	/quesma/quesma/quesma.go:289 +0x8c
quesma-1                | mitmproxy/quesma/quesma.(*router).reroute(0x40002fe8c0, {0x7ebc78, 0x4004a81470}, {0x7eaf20, 0x4000257180}, 0x4002d28b40, {0x4001967800, 0xca, 0x200}, 0x400000d380, ...)
quesma-1                | 	/quesma/quesma/quesma.go:128 +0x1b0
quesma-1                | mitmproxy/quesma/quesma.newDualWriteProxy.func1({0x7eaf20, 0x4000257180}, 0x4002d28b40)
quesma-1                | 	/quesma/quesma/dual_write_proxy.go:86 +0x138
quesma-1                | net/http.HandlerFunc.ServeHTTP(0x400380bad8?, {0x7eaf20?, 0x4000257180?}, 0x360504?)
quesma-1                | 	/usr/local/go/src/net/http/server.go:2166 +0x38
quesma-1                | mitmproxy/quesma/quesma.(*simultaneousClientsLimiter).ServeHTTP(0x10?, {0x7eaf20?, 0x4000257180?}, 0x4000257180?)
quesma-1                | 	/quesma/quesma/dual_write_proxy.go:48 +0xa4
quesma-1                | net/http.serverHandler.ServeHTTP({0x7e9af8?}, {0x7eaf20?, 0x4000257180?}, 0x6?)
quesma-1                | 	/usr/local/go/src/net/http/server.go:3137 +0xbc
quesma-1                | net/http.(*conn).serve(0x400164e120, {0x7ebc78, 0x4000179ad0})
quesma-1                | 	/usr/local/go/src/net/http/server.go:2039 +0x508
quesma-1                | created by net/http.(*Server).Serve in goroutine 82
quesma-1                | 	/usr/local/go/src/net/http/server.go:3285 +0x3f0
```