### PR TITLE
Compact table discovery logs

### DIFF
--- a/quesma/clickhouse/schema_loader.go
+++ b/quesma/clickhouse/schema_loader.go
@@ -111,12 +111,16 @@ func (sl *schemaLoader) populateTableDefinitions(configuredTables map[string]dis
 		}
 		return true
 	})
+	discoveredTables := make([]string, 0)
 	tableMap.Range(func(key string, _ *Table) bool {
 		if !existing.Has(key) {
-			logger.Info().Msgf("discovered new table: %s", key)
+			discoveredTables = append(discoveredTables, key)
 		}
 		return true
 	})
+	if len(discoveredTables) > 0 {
+		logger.Info().Msgf("discovered new tables: %s", discoveredTables)
+	}
 	sl.tableDefinitions.Store(tableMap)
 }
 


### PR DESCRIPTION
Before:
<img width="1568" alt="Screenshot 2024-05-20 at 09 46 36" src="https://github.com/QuesmaOrg/quesma/assets/2182533/65ac1e4d-9f9e-4205-8a61-2875ac1c1911">

After:
<img width="1668" alt="Screenshot 2024-05-20 at 09 46 50" src="https://github.com/QuesmaOrg/quesma/assets/2182533/fe045121-dcb9-4ec7-9f31-104e6dc791a9">
