### PR TITLE
Typed SortFields instead of concatenated string

### DIFF
--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -33,7 +33,7 @@ func (cw *ClickhouseEQLQueryTranslator) applySizeLimit(size int) int {
 func (cw *ClickhouseEQLQueryTranslator) BuildNRowsQuery(fieldName string, simpleQuery queryparser.SimpleQuery, limit int) *model.Query {
 	suffixClauses := make([]string, 0)
 	if len(simpleQuery.SortFields) > 0 {
-		suffixClauses = append(suffixClauses, "ORDER BY "+strings.Join(simpleQuery.SortFields, ", "))
+		suffixClauses = append(suffixClauses, "ORDER BY "+queryparser.AsQueryString(simpleQuery.SortFields))
 	}
 	if limit > 0 {
 		suffixClauses = append(suffixClauses, "LIMIT "+strconv.Itoa(cw.applySizeLimit(limit)))
@@ -143,7 +143,7 @@ func (cw *ClickhouseEQLQueryTranslator) ParseQuery(queryAsJson string) (query qu
 
 	query.Sql.Stmt = where
 	query.CanParse = true
-	query.SortFields = []string{"\"@timestamp\""}
+	query.SortFields = []queryparser.SortField{{Field: "@timestamp"}}
 
 	return query, searchQueryInfo, highlighter, nil
 }

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -17,18 +17,24 @@ import (
 
 type QueryMap = map[string]interface{}
 
-type SimpleQuery struct {
-	Sql        Statement
-	CanParse   bool
-	FieldName  string
-	SortFields []string
-}
+type (
+	SimpleQuery struct {
+		Sql        Statement
+		CanParse   bool
+		FieldName  string
+		SortFields []SortField
+	}
+	Statement struct {
+		Stmt       string
+		isCompound bool // "a" -> not compound, "a AND b" -> compound. Used to not make unnecessary brackets (not always, but usually)
+		FieldName  string
+	}
 
-type Statement struct {
-	Stmt       string
-	isCompound bool // "a" -> not compound, "a AND b" -> compound. Used to not make unnecessary brackets (not always, but usually)
-	FieldName  string
-}
+	SortField struct {
+		Field string
+		Desc  bool
+	}
+)
 
 // Added to the generated SQL where the query is fine, but we're sure no rows will match it
 var alwaysFalseStatement = NewSimpleStatement("false")
@@ -1143,10 +1149,10 @@ func (cw *ClickhouseQueryTranslator) extractInterval(queryMap QueryMap) string {
 
 // parseSortFields parses sort fields from the query
 // We're skipping ELK internal fields, like "_doc", "_id", etc. (we only accept field starting with "_" if it exists in our table)
-func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) []string {
+func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields []SortField) {
+	sortFields = make([]SortField, 0)
 	switch sortMaps := sortMaps.(type) {
 	case []any:
-		sortFields := make([]string, 0)
 		for _, sortMapAsAny := range sortMaps {
 			sortMap, ok := sortMapAsAny.(QueryMap)
 			if !ok {
@@ -1165,15 +1171,25 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) []string {
 				case QueryMap:
 					if order, ok := v["order"]; ok {
 						if orderAsString, ok := order.(string); ok {
-							sortFields = append(sortFields, strconv.Quote(fieldName)+" "+orderAsString)
+							orderAsString = strings.ToLower(orderAsString)
+							if orderAsString == "asc" || orderAsString == "desc" {
+								sortFields = append(sortFields, SortField{Field: fieldName, Desc: orderAsString == "desc"})
+							} else {
+								logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", orderAsString)
+							}
 						} else {
 							logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order type: %T, value: %v. Skipping", order, order)
 						}
 					} else {
-						sortFields = append(sortFields, strconv.Quote(fieldName))
+						sortFields = append(sortFields, SortField{Field: fieldName, Desc: false})
 					}
 				case string:
-					sortFields = append(sortFields, strconv.Quote(fieldName)+" "+v)
+					v = strings.ToLower(v)
+					if v == "asc" || v == "desc" {
+						sortFields = append(sortFields, SortField{Field: fieldName, Desc: v == "desc"})
+					} else {
+						logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", v)
+					}
 				default:
 					logger.WarnWithCtx(cw.Ctx).Msgf("unexpected 'sort' value's type: %T (key, value): (%s, %v). Skipping", v, k, v)
 				}
@@ -1181,35 +1197,41 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) []string {
 		}
 		return sortFields
 	case map[string]interface{}:
-		sortFields := make([]string, 0)
-
 		for fieldName, fieldValue := range sortMaps {
 			if strings.HasPrefix(fieldName, "_") && cw.Table.GetFieldInfo(cw.Ctx, fieldName) == clickhouse.NotExists {
 				// TODO Elastic internal fields will need to be supported in the future
 				continue
 			}
 			if fieldValue, ok := fieldValue.(string); ok {
-				sortFields = append(sortFields, fmt.Sprintf("%s %s", strconv.Quote(fieldName), fieldValue))
+				fieldValue = strings.ToLower(fieldValue)
+				if fieldValue == "asc" || fieldValue == "desc" {
+					sortFields = append(sortFields, SortField{Field: fieldName, Desc: fieldValue == "desc"})
+				} else {
+					logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", fieldValue)
+				}
 			}
 		}
 
 		return sortFields
 
 	case map[string]string:
-		sortFields := make([]string, 0)
-
 		for fieldName, fieldValue := range sortMaps {
 			if strings.HasPrefix(fieldName, "_") && cw.Table.GetFieldInfo(cw.Ctx, fieldName) == clickhouse.NotExists {
 				// TODO Elastic internal fields will need to be supported in the future
 				continue
 			}
-			sortFields = append(sortFields, fmt.Sprintf("%s %s", strconv.Quote(fieldName), fieldValue))
+			fieldValue = strings.ToLower(fieldValue)
+			if fieldValue == "asc" || fieldValue == "desc" {
+				sortFields = append(sortFields, SortField{Field: fieldName, Desc: fieldValue == "desc"})
+			} else {
+				logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", fieldValue)
+			}
 		}
 
 		return sortFields
 	default:
 		logger.ErrorWithCtx(cw.Ctx).Msgf("unexpected type of sortMaps: %T, value: %v", sortMaps, sortMaps)
-		return []string{}
+		return []SortField{}
 	}
 }
 

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -443,7 +443,7 @@ func Test_parseSortFields(t *testing.T) {
 	tests := []struct {
 		name       string
 		sortMap    any
-		sortFields []string
+		sortFields []SortField
 	}{
 		{
 			name: "compound",
@@ -454,12 +454,17 @@ func Test_parseSortFields(t *testing.T) {
 				QueryMap{"_table_field_with_underscore": QueryMap{"order": "asc", "unmapped_type": "boolean"}}, // this should be accepted, as it exists in the table
 				QueryMap{"_doc": QueryMap{"order": "desc", "unmapped_type": "boolean"}},                        // this should be discarded, as it doesn't exist in the table
 			},
-			sortFields: []string{`"@timestamp" desc`, `"service.name" asc`, `"no_order_field"`, `"_table_field_with_underscore" asc`},
+			sortFields: []SortField{
+				{Field: "@timestamp", Desc: true},
+				{Field: "service.name", Desc: false},
+				{Field: "no_order_field", Desc: false},
+				{Field: "_table_field_with_underscore", Desc: false},
+			},
 		},
 		{
 			name:       "empty",
 			sortMap:    []any{},
-			sortFields: []string{},
+			sortFields: []SortField{},
 		},
 		{
 			name: "map[string]string",
@@ -467,7 +472,9 @@ func Test_parseSortFields(t *testing.T) {
 				"timestamp": "desc",
 				"_doc":      "desc",
 			},
-			sortFields: []string{`"timestamp" desc`},
+			sortFields: []SortField{
+				{Field: "timestamp", Desc: true},
+			},
 		},
 		{
 			name: "map[string]interface{}",
@@ -475,14 +482,18 @@ func Test_parseSortFields(t *testing.T) {
 				"timestamp": "desc",
 				"_doc":      "desc",
 			},
-			sortFields: []string{`"timestamp" desc`},
+			sortFields: []SortField{
+				{Field: "timestamp", Desc: true},
+			},
 		}, {
 			name: "[]map[string]string",
 			sortMap: []any{
 				QueryMap{"@timestamp": "asc"},
 				QueryMap{"_doc": "asc"},
 			},
-			sortFields: []string{`"@timestamp" asc`},
+			sortFields: []SortField{
+				{Field: "@timestamp", Desc: false},
+			},
 		},
 	}
 	table, _ := clickhouse.NewTable(`CREATE TABLE `+tableName+`

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -579,7 +579,7 @@ func (cw *ClickhouseQueryTranslator) applySizeLimit(size int) int {
 func (cw *ClickhouseQueryTranslator) BuildNRowsQuery(fieldName string, query SimpleQuery, limit int) *model.Query {
 	suffixClauses := make([]string, 0)
 	if len(query.SortFields) > 0 {
-		suffixClauses = append(suffixClauses, "ORDER BY "+strings.Join(query.SortFields, ", "))
+		suffixClauses = append(suffixClauses, "ORDER BY "+AsQueryString(query.SortFields))
 	}
 	if limit > 0 {
 		suffixClauses = append(suffixClauses, "LIMIT "+strconv.Itoa(cw.applySizeLimit(limit)))
@@ -727,4 +727,20 @@ func (cw *ClickhouseQueryTranslator) sortInTopologicalOrder(queries []model.Quer
 		}
 	}
 	return indexesSorted
+}
+
+func AsQueryString(sortFields []SortField) string {
+	if len(sortFields) == 0 {
+		return ""
+	}
+	sortStrings := make([]string, 0, len(sortFields))
+	for _, sortField := range sortFields {
+		query := strings.Builder{}
+		query.WriteString(strconv.Quote(sortField.Field))
+		if sortField.Desc {
+			query.WriteString(" desc")
+		}
+		sortStrings = append(sortStrings, query.String())
+	}
+	return strings.Join(sortStrings, ", ")
 }

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -494,7 +494,7 @@ func (q *QueryRunner) findNonexistingProperties(queryInfo model.SearchQueryInfo,
 	var allReferencedFields = make([]string, 0)
 	allReferencedFields = append(allReferencedFields, queryInfo.RequestedFields...)
 	for _, field := range simpleQuery.SortFields {
-		allReferencedFields = append(allReferencedFields, strings.ReplaceAll(strings.Fields(field)[0], `"`, ""))
+		allReferencedFields = append(allReferencedFields, field.Field)
 	}
 
 	for _, property := range allReferencedFields {


### PR DESCRIPTION
Introducing an intermediate representation of a single sorting order property. Until now, we'd parse into and pass around a string of the form `"property_name" order,` which we'd need to be parsed again later for the sake of response creation.

To avoid that, I introduced a dedicated type that carried information about a field and sorted orders. Later, this type is converted into an SQL-friendly string form. `SortField` itself does not know how to convert itself to SQL, but `QueryTranslators` do.

In the next change, I will use it to expand the response to include _sort_ properties.