### PR TITLE
Separate parsing query from its execution

### DIFF
--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -143,7 +143,7 @@ func (cw *ClickhouseEQLQueryTranslator) ParseQuery(queryAsJson string) (query qu
 
 	query.Sql.Stmt = where
 	query.CanParse = true
-	query.SortFields = []queryparser.SortField{{Field: "@timestamp"}}
+	query.SortFields = []model.SortField{{Field: "@timestamp"}}
 
 	return query, searchQueryInfo, highlighter, nil
 }

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -11,6 +11,11 @@ import (
 const RowNumberColumnName = "row_number"
 const EmptyFieldSelection = "''" // we can query SELECT '', that's why such quotes
 
+type SortField struct {
+	Field string
+	Desc  bool
+}
+
 type Highlighter struct {
 	Tokens []string
 	Fields map[string]bool
@@ -35,6 +40,7 @@ type Query struct {
 	Parent          string       // parent aggregation name, used in some pipeline aggregations
 	Aggregators     []Aggregator // keeps names of aggregators, e.g. "0", "1", "2", "suggestions". Needed for JSON response.
 	Type            QueryType
+	SortFields      []SortField // fields to sort by
 	// dictionary to add as 'meta' field in the response.
 	// WARNING: it's probably not passed everywhere where it's needed, just in one place.
 	// But it works for the test + our dashboards, so let's fix it later if necessary.

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -22,17 +22,12 @@ type (
 		Sql        Statement
 		CanParse   bool
 		FieldName  string
-		SortFields []SortField
+		SortFields []model.SortField
 	}
 	Statement struct {
 		Stmt       string
 		isCompound bool // "a" -> not compound, "a AND b" -> compound. Used to not make unnecessary brackets (not always, but usually)
 		FieldName  string
-	}
-
-	SortField struct {
-		Field string
-		Desc  bool
 	}
 )
 
@@ -1149,8 +1144,8 @@ func (cw *ClickhouseQueryTranslator) extractInterval(queryMap QueryMap) string {
 
 // parseSortFields parses sort fields from the query
 // We're skipping ELK internal fields, like "_doc", "_id", etc. (we only accept field starting with "_" if it exists in our table)
-func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields []SortField) {
-	sortFields = make([]SortField, 0)
+func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields []model.SortField) {
+	sortFields = make([]model.SortField, 0)
 	switch sortMaps := sortMaps.(type) {
 	case []any:
 		for _, sortMapAsAny := range sortMaps {
@@ -1173,7 +1168,7 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields [
 						if orderAsString, ok := order.(string); ok {
 							orderAsString = strings.ToLower(orderAsString)
 							if orderAsString == "asc" || orderAsString == "desc" {
-								sortFields = append(sortFields, SortField{Field: fieldName, Desc: orderAsString == "desc"})
+								sortFields = append(sortFields, model.SortField{Field: fieldName, Desc: orderAsString == "desc"})
 							} else {
 								logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", orderAsString)
 							}
@@ -1181,12 +1176,12 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields [
 							logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order type: %T, value: %v. Skipping", order, order)
 						}
 					} else {
-						sortFields = append(sortFields, SortField{Field: fieldName, Desc: false})
+						sortFields = append(sortFields, model.SortField{Field: fieldName, Desc: false})
 					}
 				case string:
 					v = strings.ToLower(v)
 					if v == "asc" || v == "desc" {
-						sortFields = append(sortFields, SortField{Field: fieldName, Desc: v == "desc"})
+						sortFields = append(sortFields, model.SortField{Field: fieldName, Desc: v == "desc"})
 					} else {
 						logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", v)
 					}
@@ -1205,7 +1200,7 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields [
 			if fieldValue, ok := fieldValue.(string); ok {
 				fieldValue = strings.ToLower(fieldValue)
 				if fieldValue == "asc" || fieldValue == "desc" {
-					sortFields = append(sortFields, SortField{Field: fieldName, Desc: fieldValue == "desc"})
+					sortFields = append(sortFields, model.SortField{Field: fieldName, Desc: fieldValue == "desc"})
 				} else {
 					logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", fieldValue)
 				}
@@ -1222,7 +1217,7 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields [
 			}
 			fieldValue = strings.ToLower(fieldValue)
 			if fieldValue == "asc" || fieldValue == "desc" {
-				sortFields = append(sortFields, SortField{Field: fieldName, Desc: fieldValue == "desc"})
+				sortFields = append(sortFields, model.SortField{Field: fieldName, Desc: fieldValue == "desc"})
 			} else {
 				logger.WarnWithCtx(cw.Ctx).Msgf("unexpected order value: %s. Skipping", fieldValue)
 			}
@@ -1231,7 +1226,7 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortFields [
 		return sortFields
 	default:
 		logger.ErrorWithCtx(cw.Ctx).Msgf("unexpected type of sortMaps: %T, value: %v", sortMaps, sortMaps)
-		return []SortField{}
+		return []model.SortField{}
 	}
 }
 

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -443,7 +443,7 @@ func Test_parseSortFields(t *testing.T) {
 	tests := []struct {
 		name       string
 		sortMap    any
-		sortFields []SortField
+		sortFields []model.SortField
 	}{
 		{
 			name: "compound",
@@ -454,7 +454,7 @@ func Test_parseSortFields(t *testing.T) {
 				QueryMap{"_table_field_with_underscore": QueryMap{"order": "asc", "unmapped_type": "boolean"}}, // this should be accepted, as it exists in the table
 				QueryMap{"_doc": QueryMap{"order": "desc", "unmapped_type": "boolean"}},                        // this should be discarded, as it doesn't exist in the table
 			},
-			sortFields: []SortField{
+			sortFields: []model.SortField{
 				{Field: "@timestamp", Desc: true},
 				{Field: "service.name", Desc: false},
 				{Field: "no_order_field", Desc: false},
@@ -464,7 +464,7 @@ func Test_parseSortFields(t *testing.T) {
 		{
 			name:       "empty",
 			sortMap:    []any{},
-			sortFields: []SortField{},
+			sortFields: []model.SortField{},
 		},
 		{
 			name: "map[string]string",
@@ -472,7 +472,7 @@ func Test_parseSortFields(t *testing.T) {
 				"timestamp": "desc",
 				"_doc":      "desc",
 			},
-			sortFields: []SortField{
+			sortFields: []model.SortField{
 				{Field: "timestamp", Desc: true},
 			},
 		},
@@ -482,7 +482,7 @@ func Test_parseSortFields(t *testing.T) {
 				"timestamp": "desc",
 				"_doc":      "desc",
 			},
-			sortFields: []SortField{
+			sortFields: []model.SortField{
 				{Field: "timestamp", Desc: true},
 			},
 		}, {
@@ -491,7 +491,7 @@ func Test_parseSortFields(t *testing.T) {
 				QueryMap{"@timestamp": "asc"},
 				QueryMap{"_doc": "asc"},
 			},
-			sortFields: []SortField{
+			sortFields: []model.SortField{
 				{Field: "@timestamp", Desc: false},
 			},
 		},

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -729,7 +729,7 @@ func (cw *ClickhouseQueryTranslator) sortInTopologicalOrder(queries []model.Quer
 	return indexesSorted
 }
 
-func AsQueryString(sortFields []SortField) string {
+func AsQueryString(sortFields []model.SortField) string {
 	if len(sortFields) == 0 {
 		return ""
 	}


### PR DESCRIPTION
This PR extracts `ParseQuery` function which encapsulates parsing query. 
It wraps parsing without extensive implementation refactoring. This allows doing transformations on results, building transformation pipleline and separates it from query execution. 
Next we can improve interface and build transformation pipeline above it.