### PR TITLE
Quickfix aggregations

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -46,12 +46,16 @@ func (lm *LogManager) ProcessQuery(ctx context.Context, table *Table, query *mod
 		return make([]model.QueryResultRow, 0), nil
 	}
 	colNames, err := table.extractColumns(query, false)
-	sort.Strings(colNames)
+	if query.IsWildcard() {
+		sort.Strings(colNames)
+	}
 	if columns == nil {
 		columns = lm.GetAllColumns(table, query)
 		// We should sort only if columns are not provided
 		// Caller is responsible for providing columns in the right order
-		sort.Strings(columns)
+		if query.IsWildcard() {
+			sort.Strings(columns)
+		}
 	}
 	rowToScan := make([]interface{}, len(colNames)+len(query.NonSchemaFields))
 	if err != nil {


### PR DESCRIPTION
Well, sorting columns in any query besides `SELECT *` looks really bad to me. E.g. in all aggregations we rely on the order of fields we select - they are in the order of aggregations nesting. Look at screen below, order is reversed, and we return some gibberish response, thus `percentiles`, `median`, etc. stops working
`Timestamp` should be `572...` and `quantile_50`: `9432`, not the other way around.
![Screenshot 2024-05-22 at 11 13 49](https://github.com/QuesmaOrg/quesma/assets/5407146/c5b745ed-9082-4ab8-844b-fa78295ebae4)
After they work fine:
![Screenshot 2024-05-22 at 11 19 30](https://github.com/QuesmaOrg/quesma/assets/5407146/27c23fb3-159f-4c60-8837-d49fc94748ce)
![Screenshot 2024-05-22 at 11 19 21](https://github.com/QuesmaOrg/quesma/assets/5407146/d02cf54e-7732-48bf-88be-4e8a2e2d7b89)
![Screenshot 2024-05-22 at 11 19 12](https://github.com/QuesmaOrg/quesma/assets/5407146/2e58461b-add1-4551-a1f1-e38b3edba7b9)
I refreshed `Explorer` 10 times, and it still works too.
![Screenshot 2024-05-22 at 11 27 14](https://github.com/QuesmaOrg/quesma/assets/5407146/0c9dbdfd-3c65-429e-b7fa-6ddd6e00c547)


CC @pdelewski 