### PR TITLE
Check against arg nil

### DIFF
--- a/quesma/queryparser/where_clause/string_renderer.go
+++ b/quesma/queryparser/where_clause/string_renderer.go
@@ -40,7 +40,9 @@ func (v *StringRenderer) VisitInfixOp(e *InfixOp) interface{} {
 func (v *StringRenderer) VisitPrefixOp(e *PrefixOp) interface{} {
 	args := make([]string, len(e.Args))
 	for i, arg := range e.Args {
-		args[i] = arg.Accept(v).(string)
+		if arg != nil {
+			args[i] = arg.Accept(v).(string)
+		}
 	}
 
 	argsAsString := strings.Join(args, ", ")
@@ -50,7 +52,9 @@ func (v *StringRenderer) VisitPrefixOp(e *PrefixOp) interface{} {
 func (v *StringRenderer) VisitFunction(e *Function) interface{} {
 	args := make([]string, len(e.Args))
 	for i, arg := range e.Args {
-		args[i] = arg.Accept(v).(string)
+		if arg != nil {
+			args[i] = arg.Accept(v).(string)
+		}
 	}
 
 	argsAsString := strings.Join(args, ",")


### PR DESCRIPTION
I forced panic
```
--- FAIL: Test2AggregationParserExternalTestcases (0.00s)
    --- FAIL: Test2AggregationParserExternalTestcases/histogram,_different_field_than_timestamp(8) (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x100fec7ec]

goroutine 59 [running]:
testing.tRunner.func1.2({0x101497c40, 0x101948d50})
	/opt/homebrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1634 +0x33c
panic({0x101497c40?, 0x101948d50?})
	panic.go:770 +0x124
mitmproxy/quesma/queryparser/where_clause.(*StringRenderer).VisitPrefixOp(0x101a7cce0, 0x140003337d0)
	/Users/pdelewski/Projects/quesma/quesma/queryparser/where_clause/string_renderer.go:43 +0x8c
mitmproxy/quesma/queryparser/where_clause.(*PrefixOp).Accept(0x140002aa8f0?, {0x101556be8?, 0x101a7cce0?})
	/Users/pdelewski/Projects/quesma/quesma/queryparser/where_clause/where_clause.go:102 +0x30
mitmproxy/quesma/queryparser/where_clause.(*StringRenderer).VisitInfixOp(0x101a7cce0?, 0x14000333800)
	/Users/pdelewski/Projects/quesma/quesma/queryparser/where_clause/string_renderer.go:25 +0xac
mitmproxy/quesma/queryparser/where_clause.(*InfixOp).Accept(0x1400031fc90?, {0x101556be8?, 0x101a7cce0?})
	/Users/pdelewski/Projects/quesma/quesma/queryparser/where_clause/where_clause.go:82 +0x30
mitmproxy/quesma/queryparser.(*aggrQueryBuilder).buildAggregationCommon(_, _)
	/Users/pdelewski/Projects/quesma/quesma/queryparser/aggregation_parser.go:58 +0x94
mitmproxy/quesma/queryparser.(*aggrQueryBuilder).buildCountAggregation(_, _)
	/Users/pdelewski/Projects/quesma/quesma/queryparser/aggregation_parser.go:75 +0x44
mitmproxy/quesma/queryparser.(*ClickhouseQueryTranslator).ParseAggregationJson(0x14000180e10, {0x1012b3f01, 0x3d8})
	/Users/pdelewski/Projects/quesma/quesma/queryparser/aggregation_parser.go:223 +0x1f8
mitmproxy/quesma/queryparser.Test2AggregationParserExternalTestcases.func1(0x140002bda00)
	/Users/pdelewski/Projects/quesma/quesma/queryparser/aggregation_parser_test.go:602 +0x330
testing.tRunner(0x140002bda00, 0x140002f4d40)
	/opt/homebrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 50
	/opt/homebrew/Cellar/go/1.22.0/libexec/src/testing/testing.go:1742 +0x318
exit status 2

```