### PR TITLE
Don't display empty elastic responses when no calls made

### DIFF
--- a/quesma/quesma/ui/dashboard.go
+++ b/quesma/quesma/ui/dashboard.go
@@ -38,23 +38,23 @@ func (qmc *QuesmaManagementConsole) generateDashboard() []byte {
 	// One limitation is that, we don't update color of paths after initial draw.
 	// They rarely change, so it's not a big deal for now.
 	// Clickhouse -> Kibana
-	if qmc.config.ReadsFromClickhouse() {
+	if qmc.cfg.ReadsFromClickhouse() {
 		status, _ := qmc.generateDashboardTrafficText(RequestStatisticKibana2Clickhouse)
 		buffer.Html(fmt.Sprintf(`<path d="M 0 250 L 1000 250" fill="none" stroke="%s" />`, status))
 	}
 	// Elasticsearch -> Kibana
-	if qmc.config.ReadsFromElasticsearch() {
+	if qmc.cfg.ReadsFromElasticsearch() {
 		status, _ := qmc.generateDashboardTrafficText(RequestStatisticKibana2Elasticsearch)
 		buffer.Html(fmt.Sprintf(`<path d="M 0 350 L 150 350 L 150 700 L 1000 700" fill="none" stroke="%s" />`, status))
 	}
 
 	// Ingest -> Clickhouse
-	if qmc.config.WritesToClickhouse() {
+	if qmc.cfg.WritesToClickhouse() {
 		status, _ := qmc.generateDashboardTrafficText(RequestStatisticIngest2Clickhouse)
 		buffer.Html(fmt.Sprintf(`<path d="M 1000 350 L 300 350 L 300 650 L 0 650" fill="none" stroke="%s" />`, status))
 	}
 	// Ingest -> Elasticsearch
-	if qmc.config.WritesToElasticsearch() {
+	if qmc.cfg.WritesToElasticsearch() {
 		status, _ := qmc.generateDashboardTrafficText(RequestStatisticIngest2Elasticsearch)
 		buffer.Html(fmt.Sprintf(`<path d="M 1000 800 L 0 800" fill="none" stroke="%s" />`, status))
 	}
@@ -93,22 +93,22 @@ func (qmc *QuesmaManagementConsole) generateDashboardTrafficPanel() []byte {
 	var buffer builder.HtmlBuffer
 
 	// Clickhouse -> Kibana
-	if qmc.config.ReadsFromClickhouse() {
+	if qmc.cfg.ReadsFromClickhouse() {
 		buffer.Html(qmc.generateDashboardTrafficElement(RequestStatisticKibana2Clickhouse, 21))
 	}
 
 	// Elasticsearch -> Kibana
-	if qmc.config.ReadsFromElasticsearch() {
+	if qmc.cfg.ReadsFromElasticsearch() {
 		buffer.Html(qmc.generateDashboardTrafficElement(RequestStatisticKibana2Elasticsearch, 66))
 	}
 
 	// Ingest -> Clickhouse
-	if qmc.config.WritesToClickhouse() {
+	if qmc.cfg.WritesToClickhouse() {
 		buffer.Html(qmc.generateDashboardTrafficElement(RequestStatisticIngest2Clickhouse, 31))
 	}
 
 	// Ingest -> Elasticsearch
-	if qmc.config.WritesToElasticsearch() {
+	if qmc.cfg.WritesToElasticsearch() {
 		buffer.Html(qmc.generateDashboardTrafficElement(RequestStatisticIngest2Elasticsearch, 76))
 	}
 
@@ -128,22 +128,22 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 
 	dashboardName := "<h3>Kibana</h3>"
 	storeName := "<h3>Elasticsearch</h3>"
-	if qmc.config.Elasticsearch.Url != nil && strings.Contains(qmc.config.Elasticsearch.Url.String(), "opensearch") {
+	if qmc.cfg.Elasticsearch.Url != nil && strings.Contains(qmc.cfg.Elasticsearch.Url.String(), "opensearch") {
 		dashboardName = "<h3>OpenSearch</h3><h3>Dashboards</h3>"
 		storeName = "<h3>OpenSearch</h3>"
 	}
 
 	clickhouseName := "<h3>ClickHouse</h3>"
-	if qmc.config.Hydrolix.Url != nil {
+	if qmc.cfg.Hydrolix.Url != nil {
 		clickhouseName = "<h3>Hydrolix</h3>"
 	}
 
 	buffer.Html(`<div id="dashboard-kibana" class="component">`)
-	if qmc.config.Elasticsearch.AdminUrl != nil {
-		buffer.Html(`<a href="`).Text(qmc.config.Elasticsearch.AdminUrl.String()).Html(`">`)
+	if qmc.cfg.Elasticsearch.AdminUrl != nil {
+		buffer.Html(`<a href="`).Text(qmc.cfg.Elasticsearch.AdminUrl.String()).Html(`">`)
 	}
 	buffer.Html(dashboardName)
-	if qmc.config.Elasticsearch.AdminUrl != nil {
+	if qmc.cfg.Elasticsearch.AdminUrl != nil {
 		buffer.Html(`</a>`)
 	}
 	buffer.Html(statusToDiv(qmc.checkKibana()))
@@ -160,11 +160,11 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 	buffer.Html(`</div>`)
 
 	buffer.Html(`<div id="dashboard-clickhouse" class="component">`)
-	if qmc.config.ClickHouse.AdminUrl != nil {
-		buffer.Html(`<a href="`).Text(qmc.config.ClickHouse.AdminUrl.String()).Html(`">`)
+	if qmc.cfg.ClickHouse.AdminUrl != nil {
+		buffer.Html(`<a href="`).Text(qmc.cfg.ClickHouse.AdminUrl.String()).Html(`">`)
 	}
 	buffer.Html(clickhouseName)
-	if qmc.config.ClickHouse.AdminUrl != nil {
+	if qmc.cfg.ClickHouse.AdminUrl != nil {
 		buffer.Html(`</a>`)
 	}
 	buffer.Html(statusToDiv(qmc.checkClickhouseHealth()))
@@ -198,7 +198,7 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 	duration := uint64(time.Since(qmc.startedAt).Seconds())
 
 	buffer.Html(fmt.Sprintf(`<div class="status">Started: %s ago</div>`, secondsToTerseString(duration)))
-	buffer.Html(fmt.Sprintf(`<div class="status">Mode: %s</div>`, qmc.config.Mode.String()))
+	buffer.Html(fmt.Sprintf(`<div class="status">Mode: %s</div>`, qmc.cfg.Mode.String()))
 
 	if h, errH := host.Info(); errH == nil {
 		buffer.Html(fmt.Sprintf(`<div class="status">Host uptime: %s</div>`, secondsToTerseString(h.Uptime)))

--- a/quesma/quesma/ui/dashboard_healthcheck.go
+++ b/quesma/quesma/ui/dashboard_healthcheck.go
@@ -49,7 +49,7 @@ type healthCheckStatus struct {
 }
 
 func (qmc *QuesmaManagementConsole) checkClickhouseHealth() healthCheckStatus {
-	if !qmc.config.WritesToClickhouse() && !qmc.config.ReadsFromClickhouse() {
+	if !qmc.cfg.WritesToClickhouse() && !qmc.cfg.ReadsFromClickhouse() {
 		return healthCheckStatus{"grey", "N/A (not writing)", ""}
 	}
 
@@ -64,12 +64,12 @@ func (qmc *QuesmaManagementConsole) checkClickhouseHealth() healthCheckStatus {
 }
 
 func (qmc *QuesmaManagementConsole) checkElasticsearch() healthCheckStatus {
-	if !qmc.config.WritesToElasticsearch() && !qmc.config.ReadsFromElasticsearch() {
+	if !qmc.cfg.WritesToElasticsearch() && !qmc.cfg.ReadsFromElasticsearch() {
 		return healthCheckStatus{"grey", "N/A (not writing)", ""}
 	}
 
 	return qmc.elasticStatusCache.check(func() healthCheckStatus {
-		resp, err := http.Get(qmc.config.Elasticsearch.Url.String())
+		resp, err := http.Get(qmc.cfg.Elasticsearch.Url.String())
 		if err != nil {
 			return healthCheckStatus{"red", "Ping failed", err.Error()}
 		}

--- a/quesma/quesma/ui/data_sources.go
+++ b/quesma/quesma/ui/data_sources.go
@@ -36,7 +36,7 @@ func (qmc *QuesmaManagementConsole) generateDatasources() []byte {
 	buffer.Html(`<ul>`)
 
 	tableNames := []string{}
-	for tableName := range qmc.config.IndexConfig {
+	for tableName := range qmc.cfg.IndexConfig {
 		tableNames = append(tableNames, tableName)
 	}
 	slices.Sort(tableNames)

--- a/quesma/quesma/ui/ingest.go
+++ b/quesma/quesma/ui/ingest.go
@@ -31,7 +31,7 @@ func (qmc *QuesmaManagementConsole) generateStatistics() []byte {
 	var buffer builder.HtmlBuffer
 	const maxTopValues = 5
 
-	if !qmc.config.IngestStatistics {
+	if !qmc.cfg.IngestStatistics {
 		buffer.Html("<h2>Statistics are disabled.</h2>\n")
 		buffer.Html("<p>&nbsp;You can enable them by changing ingest_statistics setting to true.</p>\n")
 		return buffer.Bytes()

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -289,7 +289,7 @@ func (qmc *QuesmaManagementConsole) generateReportForRequests(title string, requ
 
 	buffer.Html(`<main id="queries">`)
 
-	buffer.Write(generateQueries(requests, true))
+	buffer.Write(qmc.populateQueries(requests, true))
 
 	buffer.Html("\n</main>\n\n")
 

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -78,7 +78,7 @@ type QuesmaManagementConsole struct {
 	debugInfoMessages         map[string]queryDebugInfo
 	debugLastMessages         []string
 	responseMatcherChannel    chan queryDebugInfo
-	config                    config.QuesmaConfiguration
+	cfg                       config.QuesmaConfiguration
 	requestsStore             *stats.RequestStatisticStore
 	requestsSource            chan *recordRequests
 	startedAt                 time.Time
@@ -98,7 +98,7 @@ func NewQuesmaManagementConsole(config config.QuesmaConfiguration, logManager *c
 		debugInfoMessages:         make(map[string]queryDebugInfo),
 		debugLastMessages:         make([]string, 0),
 		responseMatcherChannel:    make(chan queryDebugInfo, 5),
-		config:                    config,
+		cfg:                       config,
 		requestsStore:             stats.NewRequestStatisticStore(),
 		requestsSource:            make(chan *recordRequests, 100),
 		startedAt:                 time.Now(),

--- a/quesma/quesma/ui/schema.go
+++ b/quesma/quesma/ui/schema.go
@@ -97,7 +97,7 @@ func (qmc *QuesmaManagementConsole) generateSchema() []byte {
 				columnMap[k] = c
 			}
 
-			for _, a := range qmc.config.AliasFields(table.Name) {
+			for _, a := range qmc.cfg.AliasFields(table.Name) {
 
 				// check for collisions
 				if field, collide := columnMap[a.SourceFieldName]; collide {
@@ -238,7 +238,7 @@ func (qmc *QuesmaManagementConsole) generateSchema() []byte {
 
 	buffer.Html(`</tr>`)
 
-	for _, cfg := range qmc.config.IndexConfig {
+	for _, cfg := range qmc.cfg.IndexConfig {
 		buffer.Html(`<tr>`)
 		buffer.Html(`<td>`)
 		buffer.Text(cfg.Name)


### PR DESCRIPTION
Disabled the Elasticsearch Response view when using a mode that never calls Elasticsearch

<img width="1381" alt="image" src="https://github.com/QuesmaOrg/quesma/assets/2182533/fb03391b-87a5-47f3-a874-2a158a2c5b6c">

instead of:

<img width="1382" alt="image" src="https://github.com/QuesmaOrg/quesma/assets/2182533/2b81aabc-07bf-45c2-84a0-a0b69330eb4c">



