### PR TITLE
Fixing nil rhs branch in InfixOp

### DIFF
--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -3,8 +3,6 @@ package queryparser
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/k0kubun/pp"
-	"github.com/relvacode/iso8601"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/k0kubun/pp"
+	"github.com/relvacode/iso8601"
 )
 
 type QueryMap = map[string]interface{}
@@ -555,7 +556,9 @@ func (cw *ClickhouseQueryTranslator) parseMatch(queryMap QueryMap, matchPhrase b
 		cw.AddTokenToHighlight(vUnNested)
 
 		// so far we assume that only strings can be ORed here
-		return model.NewSimpleQuery(model.NewSimpleStatement(strconv.Quote(fieldName)+" == "+sprint(vUnNested)), true)
+		statement := model.NewSimpleStatement(strconv.Quote(fieldName) + " == " + sprint(vUnNested))
+		statement.WhereStatement = wc.NewInfixOp(wc.NewColumnRef(fieldName), "==", wc.NewLiteral(sprint(vUnNested)))
+		return model.NewSimpleQuery(statement, true)
 	}
 
 	// unreachable unless something really weird happens


### PR DESCRIPTION
Before 
```
"-- Expected:"
SELECT "OriginCityName", count()
FROM "logs-generic-default"
WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z')) AND
  "FlightDelay" == true
GROUP BY ("OriginCityName")
ORDER BY ("OriginCityName")
"---- Actual:"
SELECT "OriginCityName", count()
FROM "logs-generic-default"
WHERE "timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z') AND < RHS
  NIL >
GROUP BY ("OriginCityName")
ORDER BY ("OriginCityName")
```
