### PR TITLE
Fix aggregations with 0 result rows

### DIFF
--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -5493,4 +5493,495 @@ var AggregationTests = []AggregationTestCase{
 				"ORDER BY (toInt64(toUnixTimestamp64Milli(`timestamp`)/600000))",
 		},
 	},
+	{
+		TestName: "0 result rows in 2x terms",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"0": {
+					"aggs": {
+						"1": {
+							"terms": {
+								"field": "message",
+								"order": {
+			  						"_count": "desc"
+								},
+								"shard_size": 25,
+								"size": 3
+							}
+						}
+					},
+					"terms": {
+						"field": "host.name",
+						"order": {
+							"_count": "desc"
+						},
+						"shard_size": 25,
+						"size": 10
+					}
+				}
+			},
+			"fields": [
+				{
+					"field": "@timestamp",
+					"format": "date_time"
+				},
+				{
+					"field": "reqTimeSec",
+					"format": "date_time"
+				}
+			],
+			"query": {
+				"bool": {
+					"filter": [
+						{
+							"exists": {
+								"field": "message"
+							}
+						}
+					],
+					"must": [],
+					"must_not": [
+						{
+							"match_phrase": {
+								"message": "US"
+							}
+						}
+					],
+					"should": []
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `{"response": {"aggregations":{}}}`,
+		ExpectedResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(122))}}},
+			{},
+			{},
+		},
+		ExpectedSQLs: []string{
+			`SELECT count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%'`,
+			`SELECT "host.name", "message", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "message") ` +
+				`ORDER BY ("host.name", "message")`,
+			`SELECT "host.name", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name") ` +
+				`ORDER BY ("host.name")`,
+		},
+	},
+	{
+		TestName: "0 result rows in 3x terms",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"0": {
+					"aggs": {
+						"1": {
+							"terms": {
+								"field": "message",
+								"order": {
+			  						"_count": "desc"
+								},
+								"shard_size": 25,
+								"size": 3
+							},
+							"aggs": {
+								"2": {
+									"terms": {
+										"field": "message",
+										"order": {
+											"_count": "desc"
+										},
+										"shard_size": 25,
+										"size": 3
+									}
+								}
+							},
+						}
+					},
+					"terms": {
+						"field": "host.name",
+						"order": {
+							"_count": "desc"
+						},
+						"shard_size": 25,
+						"size": 10
+					}
+				}
+			},
+			"fields": [
+				{
+					"field": "@timestamp",
+					"format": "date_time"
+				},
+				{
+					"field": "reqTimeSec",
+					"format": "date_time"
+				}
+			],
+			"query": {
+				"bool": {
+					"filter": [
+						{
+							"exists": {
+								"field": "message"
+							}
+						}
+					],
+					"must": [],
+					"must_not": [
+						{
+							"match_phrase": {
+								"message": "US"
+							}
+						}
+					],
+					"should": []
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `{"response": {"aggregations":{}}}`,
+		ExpectedResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(122))}}},
+			{},
+			{},
+			{},
+		},
+		ExpectedSQLs: []string{
+			`SELECT count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%'`,
+			`SELECT "host.name", "message", "message", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "message", "message") ` +
+				`ORDER BY ("host.name", "message", "message")`,
+			`SELECT "host.name", "message", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "message") ` +
+				`ORDER BY ("host.name", "message")`,
+			`SELECT "host.name", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name") ` +
+				`ORDER BY ("host.name")`,
+		},
+	},
+	{
+		TestName: "0 result rows in terms+histogram",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"0": {
+					"aggs": {
+						"1": {
+							"histogram": {
+								"field": "FlightDelayMin",
+								"interval": 1,
+								"min_doc_count": 1
+							}
+						}
+					},
+					"terms": {
+						"field": "host.name",
+						"order": {
+							"_count": "desc"
+						},
+						"shard_size": 25,
+						"size": 10
+					}
+				}
+			},
+			"fields": [
+				{
+					"field": "@timestamp",
+					"format": "date_time"
+				},
+				{
+					"field": "reqTimeSec",
+					"format": "date_time"
+				}
+			],
+			"query": {
+				"bool": {
+					"filter": [
+						{
+							"exists": {
+								"field": "message"
+							}
+						}
+					],
+					"must": [],
+					"must_not": [
+						{
+							"match_phrase": {
+								"message": "US"
+							}
+						}
+					],
+					"should": []
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `{"response": {"aggregations":{}}}`,
+		ExpectedResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(122))}}},
+			{},
+			{},
+		},
+		ExpectedSQLs: []string{
+			`SELECT count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%'`,
+			`SELECT "host.name", "FlightDelayMin", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "FlightDelayMin") ` +
+				`ORDER BY ("host.name", "FlightDelayMin")`,
+			`SELECT "host.name", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name") ` +
+				`ORDER BY ("host.name")`,
+		},
+	},
+	{
+		TestName: "0 result rows in terms+histogram + meta field",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"0": {
+					"aggs": {
+						"1": {
+							"histogram": {
+								"field": "FlightDelayMin",
+								"interval": 1,
+								"min_doc_count": 1
+							}
+						}
+					},
+					"terms": {
+						"field": "host.name",
+						"order": {
+							"_count": "desc"
+						},
+						"shard_size": 25,
+						"size": 10
+					},
+					"meta": {
+						"bucketSize": 3600,
+						"intervalString": "3600s",
+						"seriesId": "61ca57f1-469d-11e7-af02-69e470af7417",
+						"timeField": "timestamp"
+					}
+				}
+			},
+			"fields": [
+				{
+					"field": "@timestamp",
+					"format": "date_time"
+				},
+				{
+					"field": "reqTimeSec",
+					"format": "date_time"
+				}
+			],
+			"query": {
+				"bool": {
+					"filter": [
+						{
+							"exists": {
+								"field": "message"
+							}
+						}
+					],
+					"must": [],
+					"must_not": [
+						{
+							"match_phrase": {
+								"message": "US"
+							}
+						}
+					],
+					"should": []
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `
+		{
+			"response": {
+				"aggregations": {
+					"0": {
+						"meta": {
+							"bucketSize":     3600.000000,
+							"intervalString": "3600s",
+							"seriesId":       "61ca57f1-469d-11e7-af02-69e470af7417",
+							"timeField":      "timestamp"
+						}
+					}
+				}
+			}
+		}`,
+		ExpectedResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(122))}}},
+			{},
+			{},
+		},
+		ExpectedSQLs: []string{
+			`SELECT count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%'`,
+			`SELECT "host.name", "FlightDelayMin", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "FlightDelayMin") ` +
+				`ORDER BY ("host.name", "FlightDelayMin")`,
+			`SELECT "host.name", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name") ` +
+				`ORDER BY ("host.name")`,
+		},
+	},
+	{
+		// Now we don't copy, as it's nested. Tested with Elasticsearch.
+		TestName: "0 result rows in terms+histogram + meta field, meta in subaggregation",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"0": {
+					"aggs": {
+						"1": {
+							"histogram": {
+								"field": "FlightDelayMin",
+								"interval": 1,
+								"min_doc_count": 1
+							},
+							"meta": {
+								"bucketSize": 3600,
+								"intervalString": "3600s",
+								"seriesId": "61ca57f1-469d-11e7-af02-69e470af7417",
+								"timeField": "timestamp"
+							}
+						}
+					},
+					"terms": {
+						"field": "host.name",
+						"order": {
+							"_count": "desc"
+						},
+						"shard_size": 25,
+						"size": 10
+					}
+				}
+			},
+			"fields": [
+				{
+					"field": "@timestamp",
+					"format": "date_time"
+				},
+				{
+					"field": "reqTimeSec",
+					"format": "date_time"
+				}
+			],
+			"query": {
+				"bool": {
+					"filter": [
+						{
+							"exists": {
+								"field": "message"
+							}
+						}
+					],
+					"must": [],
+					"must_not": [
+						{
+							"match_phrase": {
+								"message": "US"
+							}
+						}
+					],
+					"should": []
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `{"response": {"aggregations":{}}}`,
+		ExpectedResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(122))}}},
+			{},
+			{},
+		},
+		ExpectedSQLs: []string{
+			`SELECT count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%'`,
+			`SELECT "host.name", "FlightDelayMin", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name", "FlightDelayMin") ` +
+				`ORDER BY ("host.name", "FlightDelayMin")`,
+			`SELECT "host.name", count() ` +
+				`FROM ` + QuotedTableName + ` ` +
+				`WHERE "message" IS NOT NULL AND NOT "message" iLIKE '%US%' ` +
+				`GROUP BY ("host.name") ` +
+				`ORDER BY ("host.name")`,
+		},
+	},
 }


### PR DESCRIPTION
Small fix to aggregation's response creation. Before such a simple double-terms query
<img width="541" alt="Screenshot 2024-05-27 at 17 56 47" src="https://github.com/QuesmaOrg/quesma/assets/5407146/b2413274-111c-4f99-b2f9-3bc1ab565d5b">
was generating an error like this:
<img width="1720" alt="Screenshot 2024-05-27 at 17 56 34" src="https://github.com/QuesmaOrg/quesma/assets/5407146/fd49eba1-1f29-44c3-9633-a45c98dcc2f9">
You can see that I didn't check for empty result rows, and generated response-tree for the nested aggregation, even though it shouldn't be there as parent aggregation is already empty and has 0 buckets.
Now I cut generating response in case of 0 rows.

After: no more errors
<img width="1728" alt="Screenshot 2024-05-27 at 18 52 59" src="https://github.com/QuesmaOrg/quesma/assets/5407146/790c3a5b-a4a3-462d-94ee-dc59b39f6475">
Added a few tests with/without meta field. They work the same as it's in Elastic.
