### PR TITLE
Pass request and async id

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -464,7 +464,8 @@ func (q *QueryRunner) searchWorker(ctx context.Context,
 		if q.reachedQueriesLimit(ctx, optAsync.asyncRequestIdStr, doneCh) {
 			return
 		}
-		dbQueryCtx, dbCancel := context.WithCancel(context.Background())
+		// We need different ctx as our cancel is no longer tied to HTTP request, but to overall timeout.
+		dbQueryCtx, dbCancel := context.WithCancel(tracing.NewContextWithRequest(ctx))
 		q.addAsyncQueryContext(dbQueryCtx, dbCancel, optAsync.asyncRequestIdStr)
 		ctx = dbQueryCtx
 	}

--- a/quesma/tracing/context.go
+++ b/quesma/tracing/context.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"context"
 	"github.com/google/uuid"
 )
 
@@ -13,6 +14,19 @@ const (
 	AsyncIdCtxKey   ContextKey = "AsyncId"
 	TraceEndCtxKey  ContextKey = "TraceEnd"
 )
+
+// NewContextWithRequest creates a new context with the request id and async id from the existing context.
+// This is useful for async operations, where we want different cancel functions.
+func NewContextWithRequest(existingCtx context.Context) context.Context {
+	newContext := context.Background()
+	if requestId := existingCtx.Value(RequestIdCtxKey); requestId != nil {
+		newContext = context.WithValue(newContext, RequestIdCtxKey, requestId)
+	}
+	if asyncId := existingCtx.Value(AsyncIdCtxKey); asyncId != nil {
+		newContext = context.WithValue(newContext, AsyncIdCtxKey, asyncId)
+	}
+	return newContext
+}
 
 func GetRequestId() string {
 	return uuid.New().String()


### PR DESCRIPTION
We want to keep the request id and async id for async requests.

As I talked with @pdelewski 