### PR TITLE
🚧  Alias resolution as query transformer

### DIFF
--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -6,7 +6,6 @@ import (
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/queryparser/aexp"
 	"mitmproxy/quesma/queryparser/where_clause"
-	"mitmproxy/quesma/quesma/config"
 	"sort"
 	"strings"
 )
@@ -263,20 +262,6 @@ func (q *Query) HasParentAggregation() bool {
 // IsChild returns true <=> this aggregation is a child of maybeParent (so maybeParent is its parent).
 func (q *Query) IsChild(maybeParent Query) bool {
 	return q.HasParentAggregation() && q.Parent == maybeParent.Name()
-}
-
-// ApplyAliases is effectively a no-op at this point as all the aliasing is resolved during parsing byt Table.ResolveField()
-func (q *Query) ApplyAliases(cfg map[string]config.IndexConfiguration, resolvedTableName string) {
-	if q.WhereClause == nil {
-		return
-	}
-
-	if indexCfg, ok := cfg[resolvedTableName]; ok {
-		resolver := &where_clause.AliasResolver{IndexCfg: indexCfg}
-		q.WhereClause.Accept(resolver)
-	} else { // no aliases for fields this table configured
-		return
-	}
 }
 
 type Aggregator struct {

--- a/quesma/quesma/query_transformers/alias_resolver.go
+++ b/quesma/quesma/query_transformers/alias_resolver.go
@@ -1,0 +1,38 @@
+package query_transformers
+
+import (
+	"mitmproxy/quesma/model"
+	"mitmproxy/quesma/queryparser/where_clause"
+	"mitmproxy/quesma/quesma/config"
+)
+
+// AliasResolver transforms the queries by applying aliases to the fields according to the configuration
+type AliasResolver struct {
+	indexConf map[string]config.IndexConfiguration
+}
+
+func NewAliasResolver(config map[string]config.IndexConfiguration) *AliasResolver {
+	return &AliasResolver{indexConf: config}
+}
+
+func (ar *AliasResolver) Transform(queries []model.Query) (transformedQueries []model.Query, err error) {
+	for _, query := range queries {
+		transformedQueries = append(transformedQueries, *ar.applyAliases(&query))
+	}
+	return transformedQueries, nil
+}
+
+// ApplyAliases is effectively a no-op at this point as all the aliasing is resolved during parsing byt Table.ResolveField()
+func (ar *AliasResolver) applyAliases(query *model.Query) *model.Query {
+	if query.WhereClause == nil {
+		return nil
+	}
+
+	if indexCfg, ok := ar.indexConf[query.FromClause]; ok { // this shall be table reference
+		resolver := &where_clause.AliasResolver{IndexCfg: indexCfg}
+		query.WhereClause.Accept(resolver)
+		return query
+	} else { // no aliases for fields this table configured
+		return nil
+	}
+}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -14,6 +14,7 @@ import (
 	"mitmproxy/quesma/queryparser/aexp"
 	"mitmproxy/quesma/queryparser/query_util"
 	"mitmproxy/quesma/quesma/config"
+	"mitmproxy/quesma/quesma/query_transformers"
 	"mitmproxy/quesma/quesma/recovery"
 	"mitmproxy/quesma/quesma/types"
 	"mitmproxy/quesma/quesma/ui"
@@ -74,6 +75,7 @@ func NewQueryRunner(lm *clickhouse.LogManager, cfg config.QuesmaConfiguration, i
 		transformationPipeline: TransformationPipeline{
 			transformers: []Transformer{
 				&SchemaCheckPass{},
+				query_transformers.NewAliasResolver(cfg.IndexConfig),
 			},
 		}}
 }

--- a/quesma/quesma/transformations.go
+++ b/quesma/quesma/transformations.go
@@ -3,7 +3,7 @@ package quesma
 import "mitmproxy/quesma/model"
 
 type Transformer interface {
-	Transform(query []model.Query) ([]model.Query, error)
+	Transform(queries []model.Query) ([]model.Query, error)
 }
 
 type TransformationPipeline struct {


### PR DESCRIPTION
**PoC**.

The poorest part is `indexCfg, ok := ar.indexConf[query.FromClause];` - I think that's one of the reasons this should wait until the new abstract query object.