### PR TITLE
Quickfix incorrect tests

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -2,7 +2,6 @@ package queryparser
 
 import (
 	"context"
-	"fmt"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/kibana"
 	"mitmproxy/quesma/logger"
@@ -224,7 +223,6 @@ func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []*mo
 		if i >= len(ResultSets) || query_util.IsNonAggregationQuery(query) {
 			continue
 		}
-		fmt.Println(i, query.Type, query)
 		aggregation := cw.makeResponseAggregationRecursive(query, ResultSets[i], 0, 0)
 		if len(aggregation) != 0 {
 			aggregations = util.MergeMaps(cw.Ctx, aggregations, aggregation[0]) // result of root node is always a single map, thus [0]

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -1355,7 +1355,10 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListAllFields,
 		//[]model.Query{newSimplestQuery()},
-		[]string{`SELECT "message" FROM ` + QuotedTableName},
+		[]string{
+			`SELECT count() FROM ` + QuotedTableName,
+			`SELECT "message" FROM ` + QuotedTableName,
+		},
 	},
 	{ // [16]
 		"Simplest 'match_phrase'",
@@ -1931,7 +1934,10 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListByField,
 		//[]model.Query{withLimit(newSimplestQuery(), 500)},
-		[]string{`SELECT "message" FROM ` + QuotedTableName + ` LIMIT 500`},
+		[]string{
+			`SELECT count() FROM ` + QuotedTableName,
+			`SELECT "message" FROM ` + QuotedTableName + ` LIMIT 500`,
+		},
 	},
 	{ // [26]
 		"Empty must",
@@ -2001,7 +2007,10 @@ var TestsSearch = []SearchTestCase{
 		[]string{``},
 		model.ListAllFields,
 		//[]model.Query{justSimplestWhere(``)},
-		[]string{`SELECT "message" FROM ` + QuotedTableName},
+		[]string{
+			`SELECT count() FROM ` + QuotedTableName,
+			`SELECT "message" FROM ` + QuotedTableName,
+		},
 	},
 	{ // [30]
 		"Some bools empty, some not",
@@ -2043,7 +2052,10 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListAllFields,
 		//[]model.Query{newSimplestQuery()},
-		[]string{`SELECT "message" FROM ` + QuotedTableName},
+		[]string{
+			`SELECT count() FROM ` + QuotedTableName,
+			`SELECT "message" FROM ` + QuotedTableName,
+		},
 	},
 	{ // [32]
 		"Constant score query",


### PR DESCRIPTION
It's a bit concerning that these tests passed most of the time, even though we expected 1 query in mock, but actually sent 2 to the DB...
Maybe it's introduced by this newly added `mock.MatchExpectationsInOrder(false)`? Maybe sqlmock's bug? Maybe my bug?
I'll try to inspect that for a bit, but it seems to solve the flakiness + results should **now** be correct

