### PR TITLE
Quesma Schema representation

### DIFF
--- a/docker/quesma/config/local-dev.yaml
+++ b/docker/quesma/config/local-dev.yaml
@@ -33,6 +33,14 @@ indexes:
     enabled: true
   logs-generic-default:
     enabled: true
+    static-schema:
+      fields:
+        message:
+          type: "text"
+        host.name:
+          type: "text"
+        severity:
+          type: "keyword"
     fullTextFields: [ "message", "host.name" ]
   device_logs:
     enabled: true

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -33,7 +33,7 @@ type (
 		ctx            context.Context
 		cancel         context.CancelFunc
 		chDb           *sql.DB
-		schemaLoader   *schemaLoader
+		schemaLoader   *SchemaLoader
 		cfg            config.QuesmaConfiguration
 		phoneHomeAgent telemetry.PhoneHomeAgent
 	}
@@ -493,31 +493,28 @@ func (lm *LogManager) Ping() error {
 	return lm.chDb.Ping()
 }
 
-func NewEmptyLogManager(cfg config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent) *LogManager {
+func NewEmptyLogManager(cfg config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader *SchemaLoader) *LogManager {
 	ctx, cancel := context.WithCancel(context.Background())
-	var schemaManagement = NewSchemaManagement(chDb)
-	var tableDefinitions = atomic.Pointer[TableMap]{}
-	tableDefinitions.Store(NewTableMap())
-	return &LogManager{ctx: ctx, cancel: cancel, chDb: chDb, schemaLoader: &schemaLoader{SchemaManagement: schemaManagement, tableDefinitions: &tableDefinitions, cfg: cfg}, cfg: cfg, phoneHomeAgent: phoneHomeAgent}
+	return &LogManager{ctx: ctx, cancel: cancel, chDb: chDb, schemaLoader: loader, cfg: cfg, phoneHomeAgent: phoneHomeAgent}
 }
 
 func NewLogManager(tables *TableMap, cfg config.QuesmaConfiguration) *LogManager {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(tables)
-	return &LogManager{chDb: nil, schemaLoader: &schemaLoader{tableDefinitions: &tableDefinitions}, cfg: cfg, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
+	return &LogManager{chDb: nil, schemaLoader: &SchemaLoader{tableDefinitions: &tableDefinitions}, cfg: cfg, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
 }
 
 // right now only for tests purposes
 func NewLogManagerWithConnection(db *sql.DB, tables *TableMap) *LogManager {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(tables)
-	return &LogManager{chDb: db, schemaLoader: &schemaLoader{tableDefinitions: &tableDefinitions, SchemaManagement: NewSchemaManagement(db)}, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
+	return &LogManager{chDb: db, schemaLoader: &SchemaLoader{tableDefinitions: &tableDefinitions, SchemaManagement: NewSchemaManagement(db)}, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
 }
 
 func NewLogManagerEmpty() *LogManager {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(NewTableMap())
-	return &LogManager{schemaLoader: &schemaLoader{tableDefinitions: &tableDefinitions}, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
+	return &LogManager{schemaLoader: &SchemaLoader{tableDefinitions: &tableDefinitions}, phoneHomeAgent: telemetry.NewPhoneHomeEmptyAgent()}
 }
 
 func NewOnlySchemaFieldsCHConfig() *ChTableConfig {

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -916,7 +916,7 @@ func TestLogManager_ResolveIndexes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var tableDefinitions = atomic.Pointer[TableMap]{}
 			tableDefinitions.Store(tt.tables)
-			lm := &LogManager{schemaLoader: &schemaLoader{tableDefinitions: &tableDefinitions}}
+			lm := &LogManager{schemaLoader: &SchemaLoader{tableDefinitions: &tableDefinitions}}
 			indexes, err := lm.ResolveIndexes(context.Background(), tt.patterns)
 			assert.NoError(t, err)
 			assert.Equalf(t, tt.resolved, indexes, tt.patterns, "ResolveIndexes(%v)", tt.patterns)

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -41,7 +41,7 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 
 	cfg.IndexConfig[indexConfig.Name] = indexConfig
 
-	lm := clickhouse.NewEmptyLogManager(cfg, nil, telemetry.NewPhoneHomeEmptyAgent())
+	lm := clickhouse.NewEmptyLogManager(cfg, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewSchemaLoader(config.QuesmaConfiguration{}, nil))
 	lm.AddTableIfDoesntExist(table)
 
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background()}
@@ -82,7 +82,7 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 		},
 		Created: true,
 	}
-	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent())
+	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewSchemaLoader(config.QuesmaConfiguration{}, nil))
 	lm.AddTableIfDoesntExist(&table)
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background()}
 

--- a/quesma/quesma/highlight_test.go
+++ b/quesma/quesma/highlight_test.go
@@ -105,7 +105,7 @@ func TestParseHighLight(t *testing.T) {
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
 
-	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent())
+	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 	cw := queryparser.ClickhouseQueryTranslator{
 		ClickhouseLM: lm,

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -21,6 +21,7 @@ import (
 	"mitmproxy/quesma/quesma/routes"
 	"mitmproxy/quesma/quesma/types"
 	"mitmproxy/quesma/quesma/ui"
+	"mitmproxy/quesma/schema"
 	"mitmproxy/quesma/telemetry"
 	"mitmproxy/quesma/tracing"
 	"net/http"
@@ -114,7 +115,7 @@ func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.Qu
 	}
 }
 
-func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, config config.QuesmaConfiguration, logChan <-chan tracing.LogWithLevel) *Quesma {
+func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, schemaLoader *clickhouse.SchemaLoader, indexManager elasticsearch.IndexManagement, schemaRegistry schema.Registry, config config.QuesmaConfiguration, logChan <-chan tracing.LogWithLevel) *Quesma {
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(config, logManager, indexManager, logChan, phoneHomeAgent)
 	queryRunner := NewQueryRunner(logManager, config, indexManager, quesmaManagementConsole)
 
@@ -126,7 +127,7 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhous
 	router := configureRouter(config, logManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)
 	return &Quesma{
 		telemetryAgent:          phoneHomeAgent,
-		processor:               newDualWriteProxy(logManager, indexManager, config, router, quesmaManagementConsole, phoneHomeAgent, queryRunner),
+		processor:               newDualWriteProxy(schemaLoader, logManager, indexManager, schemaRegistry, config, router, quesmaManagementConsole, phoneHomeAgent, queryRunner),
 		publicTcpPort:           config.PublicTcpPort,
 		quesmaManagementConsole: quesmaManagementConsole,
 		config:                  config,
@@ -384,6 +385,7 @@ func (q *Quesma) Close(ctx context.Context) {
 func (q *Quesma) Start() {
 	defer recovery.LogPanic()
 	logger.Info().Msgf("starting quesma in the mode: %v", q.config.Mode)
+
 	go q.processor.Ingest()
 	go q.quesmaManagementConsole.Run()
 }

--- a/quesma/schema/schema.go
+++ b/quesma/schema/schema.go
@@ -1,0 +1,146 @@
+package schema
+
+import (
+	"fmt"
+	"mitmproxy/quesma/clickhouse"
+	"mitmproxy/quesma/concurrent"
+	"mitmproxy/quesma/logger"
+	"mitmproxy/quesma/quesma/config"
+	"sync/atomic"
+)
+
+type (
+	Schema struct {
+		Fields map[FieldName]Field
+	}
+	Field struct {
+		Name FieldName
+		Type Type
+	}
+	TableName string
+	FieldName string
+	Type      string
+)
+
+type (
+	Registry interface {
+		AllSchemas() map[TableName]Schema
+		FindSchema(name TableName) (Schema, bool)
+		Load() error
+		Start()
+	}
+	schemaRegistry struct {
+		started                atomic.Bool
+		schemas                *concurrent.Map[TableName, Schema]
+		configuration          config.QuesmaConfiguration
+		clickhouseSchemaLoader *clickhouse.SchemaLoader
+		ClickhouseTypeAdapter  ClickhouseTypeAdapter
+	}
+)
+
+func (s *schemaRegistry) Start() {
+	if s.started.CompareAndSwap(false, true) {
+		s.loadTypeMappingsFromConfiguration()
+		if err := s.Load(); err != nil {
+			logger.Error().Msgf("error loading schemas: %v", err)
+		}
+
+		for name, schema := range s.schemas.Snapshot() {
+			logger.Debug().Msgf("schema: %s", name)
+			for fieldName, field := range schema.Fields {
+				logger.Debug().Msgf("field: %s, type: %s", fieldName, field.Type)
+			}
+		}
+	}
+}
+
+func (s *schemaRegistry) loadTypeMappingsFromConfiguration() {
+	for _, indexConfiguration := range s.configuration.IndexConfig {
+		if !indexConfiguration.Enabled {
+			continue
+		}
+		if indexConfiguration.SchemaConfiguration != nil {
+			logger.Debug().Msgf("loading schema for index %s", indexConfiguration.Name)
+			fields := make(map[FieldName]Field)
+			for _, field := range indexConfiguration.SchemaConfiguration.Fields {
+				fieldName := FieldName(field.Name)
+				if resolvedType, valid := IsValid(field.Type.AsString()); valid {
+					fields[fieldName] = Field{
+						Name: fieldName,
+						Type: resolvedType,
+					}
+				} else {
+					logger.Error().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type)
+				}
+			}
+			s.schemas.Store(TableName(indexConfiguration.Name), Schema{Fields: fields})
+		}
+	}
+}
+
+func (s *schemaRegistry) Load() error {
+	if !s.started.Load() {
+		return fmt.Errorf("schema registry not started")
+	}
+	// refreshed periodically by LogManager
+	definitions := s.clickhouseSchemaLoader.TableDefinitions()
+	schemas := s.schemas.Snapshot()
+	definitions.Range(func(indexName string, value *clickhouse.Table) bool {
+		logger.Debug().Msgf("loading schema for table %s", indexName)
+		fields := make(map[FieldName]Field)
+		if schema, found := schemas[TableName(indexName)]; found {
+			fields = schema.Fields
+		}
+		for _, col := range value.Cols {
+			indexConfig := s.configuration.IndexConfig[indexName]
+			if explicitType, found := indexConfig.TypeMappings[col.Name]; found {
+				logger.Debug().Msgf("found explicit type mapping for column %s: %s", col.Name, explicitType)
+				fields[FieldName(col.Name)] = Field{
+					Name: FieldName(col.Name),
+					Type: Type(explicitType),
+				}
+				continue
+			}
+			if _, exists := fields[FieldName(col.Name)]; !exists {
+				if quesmaType, found := s.ClickhouseTypeAdapter.Adapt(col.Type.String()); found {
+					fields[FieldName(col.Name)] = Field{
+						Name: FieldName(col.Name),
+						Type: quesmaType,
+					}
+				} else {
+					logger.Error().Msgf("type %s not supported", col.Type.String())
+				}
+			}
+		}
+		s.schemas.Store(TableName(indexName), Schema{Fields: fields})
+		return true
+	})
+	for name, schema := range s.schemas.Snapshot() {
+		logger.Debug().Msgf("schema: %s", name)
+		for fieldName, field := range schema.Fields {
+			logger.Debug().Msgf("\tfield: %s, type: %s", fieldName, field.Type)
+		}
+
+		break
+	}
+	return nil
+}
+
+func (s *schemaRegistry) AllSchemas() map[TableName]Schema {
+	return s.schemas.Snapshot()
+}
+
+func (s *schemaRegistry) FindSchema(name TableName) (Schema, bool) {
+	schema, found := s.schemas.Load(name)
+	return schema, found
+}
+
+func NewSchemaRegistry(schemaManagement *clickhouse.SchemaLoader, configuration config.QuesmaConfiguration) Registry {
+	return &schemaRegistry{
+		schemas:                concurrent.NewMap[TableName, Schema](),
+		started:                atomic.Bool{},
+		configuration:          configuration,
+		clickhouseSchemaLoader: schemaManagement,
+		ClickhouseTypeAdapter:  NewClickhouseTypeAdapter(),
+	}
+}

--- a/quesma/schema/type_adapter.go
+++ b/quesma/schema/type_adapter.go
@@ -1,0 +1,5 @@
+package schema
+
+type TypeAdapter interface {
+	Adapt(string) (Type, bool)
+}

--- a/quesma/schema/types.go
+++ b/quesma/schema/types.go
@@ -1,0 +1,113 @@
+package schema
+
+import (
+	"mitmproxy/quesma/elasticsearch/elasticsearch_field_types"
+	"strings"
+)
+
+const (
+	// TODO add more and review existing
+	TypeText        Type = "text"
+	TypeKeyword     Type = "keyword"
+	TypeLong        Type = "long"
+	TypeTimestamp   Type = "timestamp"
+	TypeDate        Type = "date"
+	TypeFloat       Type = "float"
+	TypeBoolean     Type = "bool"
+	TypeJSON        Type = "json"
+	TypeArray       Type = "array"
+	TypeMap         Type = "map"
+	TypeIp          Type = "ip"
+	TypePoint       Type = "point"
+	TypeStringArray Type = "string_array"
+)
+
+func IsValid(t string) (Type, bool) {
+	switch t {
+	case "text":
+		return TypeText, true
+	case "keyword":
+		return TypeKeyword, true
+	case "long":
+		return TypeLong, true
+	case "timestamp":
+		return TypeTimestamp, true
+	case "date":
+		return TypeDate, true
+	case "float":
+		return TypeFloat, true
+	case "bool":
+		return TypeBoolean, true
+	case "json":
+		return TypeJSON, true
+	case "array":
+		return TypeArray, true
+	case "map":
+		return TypeMap, true
+	case "ip":
+		return TypeIp, true
+	case "point":
+		return TypePoint, true
+	case "string_array":
+		return TypeStringArray, true
+	default:
+		return "", false
+	}
+}
+
+type ClickhouseTypeAdapter struct {
+}
+
+func (c ClickhouseTypeAdapter) Adapt(s string) (Type, bool) {
+	if strings.HasPrefix(s, "Unknown") {
+		return TypeText, true // TODO
+	}
+	switch s {
+	case "String", "LowCardinality(String)":
+		return TypeText, true
+	case "Int64", "Int":
+		return TypeLong, true
+	case "Bool":
+		return TypeBoolean, true
+	case "Float64", "Float32":
+		return TypeFloat, true
+	case "DateTime", "DateTime64":
+		return TypeTimestamp, true
+	case "Date":
+		return TypeDate, true
+	case "Array(String)":
+		return TypeStringArray, true
+	default:
+		return "", false
+	}
+}
+
+func NewClickhouseTypeAdapter() ClickhouseTypeAdapter {
+	return ClickhouseTypeAdapter{}
+}
+
+type ElasticsearchTypeAdapter struct {
+}
+
+func (e ElasticsearchTypeAdapter) Adapt(s string) (Type, bool) {
+	switch s {
+	case elasticsearch_field_types.FieldTypeText:
+		return TypeText, true
+	case elasticsearch_field_types.FieldTypeKeyword:
+		return TypeKeyword, true
+	case elasticsearch_field_types.FieldTypeLong:
+		return TypeLong, true
+	case elasticsearch_field_types.FieldTypeDate:
+		return TypeDate, true
+	case elasticsearch_field_types.FieldTypeDateNanos:
+		return TypeDate, true
+	case elasticsearch_field_types.FieldTypeDouble:
+		return TypeFloat, true
+	case elasticsearch_field_types.FieldTypeBoolean:
+		return TypeBoolean, true
+	case elasticsearch_field_types.FieldTypeTypeIp:
+		return TypeIp, true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
Introduced an intermediate Quesma schema representation, which will eventually become the source of truth about data and their types. It defines its own types of "search types" which map independently to Elasticsearch/Opensearch and Clickhouse/Hydrolix.

This change is transparent, it introduces the concept, which is not yet used anywhere. In the next changes, I will start relying on it instead of `IsFullTextMatch` flag.

The set of recognized types is incomplete, naming might be confusing (SchemaLoader/SchemaRegistry), there's also excessive copying and suboptimal error handling. To be evened out incrementally.

Tests are coming after SchemaLoader/SchemaManagement refactoring - don't want to engage in SQLMock fun if I am able to stub.

