### PR TITLE
Less warning logs

### DIFF
--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -305,8 +305,6 @@ func (cw *ClickhouseQueryTranslator) ParseAggregationJson(body types.JSON) ([]*m
 			}
 			currentAggr.Aggregators = currentAggr.Aggregators[:len(currentAggr.Aggregators)-1]
 		}
-	} else {
-		return nil, fmt.Errorf("no aggs -> request is not an aggregation query")
 	}
 
 	return aggregations, nil

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -252,7 +252,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 				}
 
 				if len(results) == 0 {
-					logger.ErrorWithCtx(ctx).Msgf("no hits, queryInfo: %d", translatedQueryBody)
+					logger.ErrorWithCtx(ctx).Msgf("no hits, sqls: %s", translatedQueryBody)
 					doneCh <- AsyncSearchWithError{translatedQueryBody: translatedQueryBody, err: errors.New("no hits")}
 					return
 				}


### PR DESCRIPTION
After latest refactoring, there is huge amount of warnings. They are produced for every non-aggregate query.

Fix this as this is very confusing.