### PR TITLE
Rename 'Schema' tab to 'Tables'

### DIFF
--- a/quesma/quesma/ui/asset/head.html
+++ b/quesma/quesma/ui/asset/head.html
@@ -436,52 +436,52 @@
             top: 79%;
         }
 
-        #schema table {
+        #tables table {
             border-collapse: collapse;
             table-layout: fixed;
             width: 98%;
             word-wrap: break-word;
         }
 
-        #schema .tableName {
+        #tables .tableName {
             font-size: larger;
             font-weight: bold;
         }
 
-        #schema th,
-        #schema td {
+        #tables th,
+        #tables td {
             padding: 0 3px;
             border: 1px solid black;
             font-family: Courier;
             font-size: small;
         }
 
-        #schema .columnName {
+        #tables .columnName {
             width: 50%;
         }
 
-        #schema .columnType {
+        #tables .columnType {
             width: 50%;
         }
 
-        #schema .columnAttribute  {
+        #tables .columnAttribute  {
             font-style: italic;
         }
 
-        #schema .columnWarning {
+        #tables .columnWarning {
             background-color: yellow;
         }
 
-        #schema .columnWarningText {
+        #tables .columnWarningText {
             color: red;
             font-weight: bold;
         }
 
-        #schema .create-table-query {
+        #tables .create-table-query {
             padding: 1em;
         }
 
-        #schema tr:hover {
+        #tables tr:hover {
             background-color: #dddddd;
         }
 

--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -45,13 +45,13 @@ func (qmc *QuesmaManagementConsole) createRouting() *mux.Router {
 		_, _ = writer.Write(buf)
 	})
 
-	router.HandleFunc("/schema/reload", func(writer http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/tables/reload", func(writer http.ResponseWriter, req *http.Request) {
 		qmc.logManager.ReloadTables()
 		buf := qmc.generateSchema()
 		_, _ = writer.Write(buf)
 	}).Methods("POST")
 
-	router.HandleFunc("/schema", func(writer http.ResponseWriter, req *http.Request) {
+	router.HandleFunc("/tables", func(writer http.ResponseWriter, req *http.Request) {
 		buf := qmc.generateSchema()
 		_, _ = writer.Write(buf)
 	})

--- a/quesma/quesma/ui/html_utils.go
+++ b/quesma/quesma/ui/html_utils.go
@@ -46,10 +46,10 @@ func generateTopNavigation(target string) []byte {
 	buffer.Html(`><a href="/routing-statistics">Routing</a></li>`)
 
 	buffer.Html("<li")
-	if target == "schema" {
+	if target == "tables" {
 		buffer.Html(` class="active"`)
 	}
-	buffer.Html(`><a href="/schema">Schema</a></li>`)
+	buffer.Html(`><a href="/tables">Tables</a></li>`)
 
 	buffer.Html("<li")
 	if target == "phone-home" {
@@ -66,7 +66,7 @@ func generateTopNavigation(target string) []byte {
 	buffer.Html("\n</ul>\n")
 	buffer.Html("\n</div>\n")
 
-	if target != "schema" && target != "telemetry" {
+	if target != "tables" && target != "telemetry" {
 		buffer.Html(`<div class="autorefresh-box">` + "\n")
 		buffer.Html(`<div class="autorefresh">`)
 		buffer.Html(fmt.Sprintf(

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -27,8 +27,8 @@ func (qmc *QuesmaManagementConsole) generateSchema() []byte {
 	}
 
 	buffer := newBufferWithHead()
-	buffer.Write(generateTopNavigation("schema"))
-	buffer.Html(`<main id="schema">`)
+	buffer.Write(generateTopNavigation("tables"))
+	buffer.Html(`<main id="tables">`)
 
 	var schema clickhouse.TableMap
 	var hasSchema bool
@@ -297,7 +297,7 @@ func (qmc *QuesmaManagementConsole) generateSchema() []byte {
 	buffer.Html(`<h3>Admin actions</h3>`)
 	buffer.Html(`<ul>`)
 
-	buffer.Html(`<li><button hx-post="/schema/reload" hx-target="body">Reload Schemas</button></li>`)
+	buffer.Html(`<li><button hx-post="/tables/reload" hx-target="body">Reload Tables</button></li>`)
 
 	buffer.Html(`</ul>`)
 


### PR DESCRIPTION
We'll have separate tab for Quesma's internal schema and better to avoid name clashes.

<img width="1725" alt="image" src="https://github.com/QuesmaOrg/quesma/assets/2182533/0ed8526e-75f0-4abb-a9e7-65b414c35085">
