### PR TITLE
Decouple schema package from clickhouse package

### DIFF
--- a/quesma/main.go
+++ b/quesma/main.go
@@ -60,7 +60,7 @@ func main() {
 
 	schemaManagement := clickhouse.NewSchemaManagement(connectionPool)
 	schemaLoader := clickhouse.NewTableDiscovery(cfg, schemaManagement)
-	schemaRegistry := schema.NewSchemaRegistry(schemaLoader, cfg, schema.ClickhouseTypeAdapter{}, schema.ElasticsearchTypeAdapter{})
+	schemaRegistry := schema.NewSchemaRegistry(clickhouse.TableDiscoveryTableProviderAdapter{TableDiscovery: schemaLoader}, cfg, schema.ClickhouseTypeAdapter{}, schema.ElasticsearchTypeAdapter{})
 
 	lm := clickhouse.NewEmptyLogManager(cfg, connectionPool, phoneHomeAgent, schemaLoader)
 	im := elasticsearch.NewIndexManagement(cfg.Elasticsearch.Url.String())

--- a/quesma/schema/table_provider.go
+++ b/quesma/schema/table_provider.go
@@ -1,0 +1,14 @@
+package schema
+
+type (
+	Table struct {
+		Columns map[string]Column
+	}
+	Column struct {
+		Name string
+		Type string
+	}
+	TableProvider interface {
+		TableDefinitions() map[string]Table
+	}
+)


### PR DESCRIPTION
The `schema.Registry` should not depend on the `clickhouse`, as it's just one of the potential plugins. This allows moving clickhouse/elasticsearch type adapters to their respective packages. This will be done as the next step.