### PR TITLE
Quickfix: response look for `top_hits`

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -105,7 +105,7 @@ func (cw *ClickhouseQueryTranslator) finishMakeResponse(query *model.Query, Resu
 	} else { // metrics
 		lastAggregator := query.Aggregators[len(query.Aggregators)-1].Name
 		result := query.Type.TranslateSqlResponseToJson(ResultSet, level)[0]
-		if _, ok := query.Type.(metrics_aggregations.TopHits); ok {
+		if _, isTopHits := query.Type.(metrics_aggregations.TopHits); isTopHits {
 			return []model.JsonMap{{
 				lastAggregator: model.JsonMap{
 					"hits:": result,
@@ -113,7 +113,7 @@ func (cw *ClickhouseQueryTranslator) finishMakeResponse(query *model.Query, Resu
 			}}
 		}
 		return []model.JsonMap{{
-			lastAggregator: query.Type.TranslateSqlResponseToJson(ResultSet, level)[0],
+			lastAggregator: result,
 		}}
 	}
 }


### PR DESCRIPTION
Slight formatting change of the response.
Before it looked like this:
```
"destLocation": {
     "hits": [
          {
             "hits": {
                 "lat": "4.70159",
                  "lon": "-74.1469"
              },
              "sort": null
         }
     ]
 }
```
Now it's
```
"destLocation": {
  "hits": {
     "hits": [
               [...]
      ]
   }
}
```
which is what Elastic returns

All aggregations follow the generic approach, only `top_hits` is different, so I think one `if` for that is OK for now. If a lot of aggregations will have different logic as well, we might think of improving our design (which didn't change since my first days of implementing first aggregations, so isn't 100% well-thought, but still seems relatively fine)