### PR TITLE
Move common errors to separate package (library)

### DIFF
--- a/quesma/quesma/errors/errors.go
+++ b/quesma/quesma/errors/errors.go
@@ -1,0 +1,16 @@
+package quesma_errors
+
+import "errors"
+
+var (
+	errIndexNotExists       = errors.New("table does not exist")
+	errCouldNotParseRequest = errors.New("parse exception")
+)
+
+func ErrIndexNotExists() error {
+	return errIndexNotExists
+}
+
+func ErrCouldNotParseRequest() error {
+	return errCouldNotParseRequest
+}

--- a/quesma/quesma/field_caps.go
+++ b/quesma/quesma/field_caps.go
@@ -11,6 +11,7 @@ import (
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/plugins/registry"
 	"mitmproxy/quesma/quesma/config"
+	"mitmproxy/quesma/quesma/errors"
 	"mitmproxy/quesma/schema"
 	"mitmproxy/quesma/util"
 )
@@ -112,7 +113,7 @@ func handleFieldCaps(ctx context.Context, cfg config.QuesmaConfiguration, schema
 
 	if len(indexes) == 0 {
 		if !elasticsearch.IsIndexPattern(index) {
-			return nil, errIndexNotExists
+			return nil, quesma_errors.ErrIndexNotExists()
 		}
 	}
 

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -9,6 +9,7 @@ import (
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/queryparser"
 	"mitmproxy/quesma/quesma/config"
+	"mitmproxy/quesma/quesma/errors"
 	"mitmproxy/quesma/quesma/mux"
 	"mitmproxy/quesma/quesma/routes"
 	"mitmproxy/quesma/quesma/termsenum"
@@ -152,7 +153,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 	router.Register(routes.IndexCountPath, and(method("GET"), matchedAgainstPattern(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
 		cnt, err := queryRunner.handleCount(ctx, req.Params["index"])
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &mux.Result{StatusCode: 404}, nil
 			} else {
 				return nil, err
@@ -176,7 +177,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		// TODO we should pass JSON here instead of []byte
 		responseBody, err := queryRunner.handleSearch(ctx, "*", body)
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &mux.Result{StatusCode: 404}, nil
 			} else {
 				return nil, err
@@ -194,9 +195,9 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 
 		responseBody, err := queryRunner.handleSearch(ctx, req.Params["index"], body)
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &mux.Result{StatusCode: 404}, nil
-			} else if errors.Is(err, errCouldNotParseRequest) {
+			} else if errors.Is(err, quesma_errors.ErrCouldNotParseRequest()) {
 				return &mux.Result{
 					Body:       string(queryparser.BadRequestParseError(err)),
 					StatusCode: 400,
@@ -230,9 +231,9 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 
 		responseBody, err := queryRunner.handleAsyncSearch(ctx, req.Params["index"], body, waitForResultsMs, keepOnCompletion)
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &mux.Result{StatusCode: 404}, nil
-			} else if errors.Is(err, errCouldNotParseRequest) {
+			} else if errors.Is(err, quesma_errors.ErrCouldNotParseRequest()) {
 				return &mux.Result{
 					Body:       string(queryparser.BadRequestParseError(err)),
 					StatusCode: 400,
@@ -265,7 +266,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 
 		responseBody, err := handleFieldCaps(ctx, cfg, sr, req.Params["index"], lm)
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				if req.QueryParams.Get("allow_no_indices") == "true" || req.QueryParams.Get("ignore_unavailable") == "true" {
 					return elasticsearchQueryResult(string(EmptyFieldCapsResponse()), httpOk), nil
 				}
@@ -306,7 +307,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 
 		responseBody, err := queryRunner.handleEQLSearch(ctx, req.Params["index"], body)
 		if err != nil {
-			if errors.Is(errIndexNotExists, err) {
+			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &mux.Result{StatusCode: 404}, nil
 			} else {
 				return nil, err


### PR DESCRIPTION
As much as this seems redundant, this will enable extraction of functionalities as separate packages without introducing dependency cycles