### PR TITLE
Default "String", "LowCardinality(String) type resolution to keyword

### DIFF
--- a/http_requests/field_caps.http
+++ b/http_requests/field_caps.http
@@ -1,4 +1,4 @@
-POST http://localhost:9201/kibana_sample_data_logs/_field_caps
+POST http://localhost:8080/kibana_sample_data_flights/_field_caps
 Content-Type: application/json
 
 {

--- a/quesma/clickhouse/type_adapter.go
+++ b/quesma/clickhouse/type_adapter.go
@@ -21,7 +21,7 @@ func (c SchemaTypeAdapter) Convert(s string) (schema.Type, bool) {
 
 	switch s {
 	case "String", "LowCardinality(String)":
-		return schema.TypeText, true
+		return schema.TypeKeyword, true
 	case "Int", "Int8", "Int16", "Int32", "Int64":
 		return schema.TypeLong, true
 	case "Uint8", "Uint16", "Uint32", "Uint64", "Uint128", "Uint256":

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -38,7 +38,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			}},
 			tableName: "some_table",
 			want: schema.Schema{Fields: map[schema.FieldName]schema.Field{
-				"message":    {Name: "message", Type: schema.TypeText},
+				"message":    {Name: "message", Type: schema.TypeKeyword},
 				"event_date": {Name: "event_date", Type: schema.TypeTimestamp},
 				"count":      {Name: "count", Type: schema.TypeLong}},
 				Aliases: map[schema.FieldName]schema.FieldName{}},


### PR DESCRIPTION
Default "String", "LowCardinality(String) type resolution to keyword to stay backward compatible

![image](https://github.com/QuesmaOrg/quesma/assets/2182533/a5d8a0c3-550a-4577-afcc-3bfa8da64418)
