### PR TITLE
Resolve schema on each call

### DIFF
--- a/quesma/quesma/dual_write_proxy.go
+++ b/quesma/quesma/dual_write_proxy.go
@@ -131,7 +131,6 @@ func (q *dualWriteHttpProxy) Close(ctx context.Context) {
 
 func (q *dualWriteHttpProxy) Ingest() {
 	q.schemaLoader.ReloadTableDefinitions()
-	q.schemaRegistry.Start()
 	q.logManager.Start()
 	q.indexManagement.Start()
 	go q.asyncQueriesEvictor.asyncQueriesGC()

--- a/quesma/quesma/field_capabilities/field_caps_test.go
+++ b/quesma/quesma/field_capabilities/field_caps_test.go
@@ -427,6 +427,3 @@ func (e staticRegistry) FindSchema(name schema.TableName) (schema.Schema, bool) 
 	s, found := e.tables[name]
 	return s, found
 }
-
-func (e staticRegistry) Start() {
-}

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -53,7 +53,6 @@ func Test_ipRangeTransform(t *testing.T) {
 			}},
 		}}
 	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{}, elasticsearch.SchemaTypeAdapter{})
-	s.Start()
 	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s}
 
 	expectedQueries := []*model.Query{

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -1,22 +1,16 @@
 package schema
 
 import (
-	"fmt"
-	"mitmproxy/quesma/concurrent"
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/quesma/config"
-	"sync/atomic"
 )
 
 type (
 	Registry interface {
 		AllSchemas() map[TableName]Schema
 		FindSchema(name TableName) (Schema, bool)
-		Start()
 	}
 	schemaRegistry struct {
-		started                 atomic.Bool
-		schemas                 *concurrent.Map[TableName, Schema]
 		configuration           config.QuesmaConfiguration
 		dataSourceTableProvider TableProvider
 		dataSourceTypeAdapter   typeAdapter
@@ -37,184 +31,110 @@ type (
 	}
 )
 
-func (s *schemaRegistry) Start() {
-	if s.started.CompareAndSwap(false, true) {
-		s.loadTypeMappingsFromConfiguration()
-		if err := s.Load(); err != nil {
-			logger.Error().Msgf("error loading schemas: %v", err)
-		}
-	}
-}
-
-func (s *schemaRegistry) loadTypeMappingsFromConfiguration() {
-	for _, indexConfiguration := range s.configuration.IndexConfig {
-		if !indexConfiguration.Enabled {
-			continue
-		}
-
-		fields := make(map[FieldName]Field)
-
-		if indexConfiguration.SchemaConfiguration != nil {
-			logger.Debug().Msgf("loading schema for index %s", indexConfiguration.Name)
-			for _, field := range indexConfiguration.SchemaConfiguration.Fields {
-				fieldName := FieldName(field.Name)
-				if resolvedType, valid := ParseType(field.Type.AsString()); valid {
-					fields[fieldName] = Field{
-						Name: fieldName,
-						Type: resolvedType,
-					}
-				} else if field.Type.AsString() != config.TypeAlias {
-					logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type)
-				}
-			}
-			s.schemas.Store(TableName(indexConfiguration.Name), Schema{Fields: fields})
-		} else {
-			for fieldName, fieldType := range indexConfiguration.TypeMappings {
-				if resolvedType, valid := ParseType(fieldType); valid {
-					fields[FieldName(fieldName)] = Field{Name: FieldName(fieldName), Type: resolvedType}
-				} else {
-					logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", fieldType)
-				}
-			}
-		}
-	}
-}
-
-func (s *schemaRegistry) Load() error {
-	if !s.started.Load() {
-		return fmt.Errorf("schema registry not started")
-	}
-	// refreshed periodically by LogManager
+func (s *schemaRegistry) loadSchemas() (map[TableName]Schema, error) {
 	definitions := s.dataSourceTableProvider.TableDefinitions()
-	schemas := s.schemas.Snapshot()
+	schemas := make(map[TableName]Schema)
 
 	for indexName, indexConfiguration := range s.configuration.IndexConfig {
 		fields := make(map[FieldName]Field)
 		aliases := make(map[FieldName]FieldName)
 
-		if value, found := definitions[indexName]; found {
-			logger.Debug().Msgf("loading schema for table %s", indexName)
-
-			if schema, found := schemas[TableName(indexName)]; found {
-				fields = schema.Fields
-			}
-			for _, col := range value.Columns {
-				indexConfig := s.configuration.IndexConfig[indexName]
-
-				// TODO replace with dedicated schema config
-				if indexConfig.SchemaConfiguration == nil {
-					logger.Debug().Msgf("using deprecated type mappings for index %s", indexName)
-					if explicitType, found := indexConfig.TypeMappings[col.Name]; found {
-						if resolvedQuesmaType, found := s.connectorTypeAdapter.Convert(explicitType); found {
-							logger.Debug().Msgf("found explicit type mapping for column %s: %s", col.Name, resolvedQuesmaType)
-							fields[FieldName(col.Name)] = Field{
-								Name: FieldName(col.Name),
-								Type: resolvedQuesmaType,
-							}
-						} else {
-							// TODO those will need to be validated at config stage
-							logger.Error().Msgf("type %s not supported", explicitType)
-						}
-					}
-				} else {
-					logger.Debug().Msgf("using schema configuration for index %s", indexName)
-					if fieldConfiguration, found := indexConfig.SchemaConfiguration.Fields[config.FieldName(col.Name)]; found {
-						if resolvedQuesmaType, found := s.connectorTypeAdapter.Convert(fieldConfiguration.Type.AsString()); found {
-							logger.Debug().Msgf("found explicit type mapping for column %s: %s", col.Name, resolvedQuesmaType)
-							fields[FieldName(col.Name)] = Field{
-								Name: FieldName(col.Name),
-								Type: resolvedQuesmaType,
-							}
-						} else {
-							// TODO those will need to be validated at config stage
-							logger.Error().Msgf("type %s not supported", fieldConfiguration)
-						}
-					}
-				}
-
-				if _, exists := fields[FieldName(col.Name)]; !exists {
-					if quesmaType, found := s.dataSourceTypeAdapter.Convert(col.Type); found {
-						fields[FieldName(col.Name)] = Field{
-							Name: FieldName(col.Name),
-							Type: quesmaType,
-						}
-					} else {
-						logger.Debug().Msgf("type %s not supported, falling back to text", col.Type)
-						fields[FieldName(col.Name)] = Field{
-							Name: FieldName(col.Name),
-							Type: TypeText,
-						}
-					}
-				}
-			}
-
-		}
-
-		if indexConfiguration.SchemaConfiguration != nil {
-			for _, field := range indexConfiguration.SchemaConfiguration.Fields {
-				if resolvedType, valid := ParseType(field.Type.AsString()); valid {
-					fields[FieldName(field.Name.AsString())] = Field{Name: FieldName(field.Name.AsString()), Type: resolvedType}
-				} else {
-					logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type.AsString())
-				}
-			}
-		} else {
-			for fieldName, fieldType := range indexConfiguration.TypeMappings {
-				if resolvedType, valid := ParseType(fieldType); valid {
-					fields[FieldName(fieldName)] = Field{Name: FieldName(fieldName), Type: resolvedType}
-				} else {
-					logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", fieldType)
-				}
-			}
-		}
-
-		if indexConfiguration.SchemaConfiguration != nil {
-			for _, field := range indexConfiguration.SchemaConfiguration.Fields {
-				if field.Type.AsString() == config.TypeAlias {
-					if _, exists := fields[FieldName(field.AliasedField)]; exists {
-						aliases[FieldName(field.Name)] = FieldName(field.AliasedField)
-					} else {
-						logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", field.AliasedField)
-					}
-				}
-			}
-		} else {
-			for aliasName, aliasConfig := range indexConfiguration.Aliases {
-				if _, exists := fields[FieldName(aliasConfig.SourceFieldName)]; exists {
-					aliases[FieldName(aliasName)] = FieldName(aliasConfig.SourceFieldName)
-				} else {
-					logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", aliasConfig.SourceFieldName)
-				}
-			}
-		}
-		s.schemas.Store(TableName(indexName), Schema{Fields: fields, Aliases: aliases})
+		s.populateSchemaFromStaticConfiguration(indexConfiguration, fields)
+		s.populateSchemaFromTableDefinition(definitions, indexName, fields)
+		s.populateAliases(indexConfiguration, fields, aliases)
+		schemas[TableName(indexName)] = Schema{Fields: fields, Aliases: aliases}
 	}
 
-	return nil
+	return schemas, nil
+}
+
+func deprecatedConfigInUse(indexConfig config.IndexConfiguration) bool {
+	return indexConfig.SchemaConfiguration == nil
 }
 
 func (s *schemaRegistry) AllSchemas() map[TableName]Schema {
-	if err := s.Load(); err != nil {
+	if schemas, err := s.loadSchemas(); err != nil {
 		logger.Error().Msgf("error loading schemas: %v", err)
+		return make(map[TableName]Schema)
+	} else {
+		return schemas
 	}
-	return s.schemas.Snapshot()
 }
 
 func (s *schemaRegistry) FindSchema(name TableName) (Schema, bool) {
-	if err := s.Load(); err != nil {
+	if schemas, err := s.loadSchemas(); err != nil {
 		logger.Error().Msgf("error loading schemas: %v", err)
+		return Schema{}, false
+	} else {
+		schema, found := schemas[name]
+		return schema, found
 	}
-	schema, found := s.schemas.Load(name)
-	return schema, found
 }
 
 func NewSchemaRegistry(tableProvider TableProvider, configuration config.QuesmaConfiguration, dataSourceTypeAdapter, connectorTypeAdapter typeAdapter) Registry {
 	return &schemaRegistry{
-		schemas:                 concurrent.NewMap[TableName, Schema](),
-		started:                 atomic.Bool{},
 		configuration:           configuration,
 		dataSourceTableProvider: tableProvider,
 		dataSourceTypeAdapter:   dataSourceTypeAdapter,
 		connectorTypeAdapter:    connectorTypeAdapter,
+	}
+}
+
+func (s *schemaRegistry) populateSchemaFromStaticConfiguration(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field) {
+	if deprecatedConfigInUse(indexConfiguration) {
+		for fieldName, fieldType := range indexConfiguration.TypeMappings {
+			if resolvedType, valid := ParseType(fieldType); valid {
+				fields[FieldName(fieldName)] = Field{Name: FieldName(fieldName), Type: resolvedType}
+			} else {
+				logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", fieldType)
+			}
+		}
+	} else {
+		for _, field := range indexConfiguration.SchemaConfiguration.Fields {
+			if resolvedType, valid := ParseType(field.Type.AsString()); valid {
+				fields[FieldName(field.Name.AsString())] = Field{Name: FieldName(field.Name.AsString()), Type: resolvedType}
+			} else {
+				logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type.AsString())
+			}
+		}
+	}
+}
+
+func (s *schemaRegistry) populateAliases(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field, aliases map[FieldName]FieldName) {
+	if deprecatedConfigInUse(indexConfiguration) {
+		for aliasName, aliasConfig := range indexConfiguration.Aliases {
+			if _, exists := fields[FieldName(aliasConfig.SourceFieldName)]; exists {
+				aliases[FieldName(aliasName)] = FieldName(aliasConfig.SourceFieldName)
+			} else {
+				logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", aliasConfig.SourceFieldName)
+			}
+		}
+	} else {
+		for _, field := range indexConfiguration.SchemaConfiguration.Fields {
+			if field.Type.AsString() == config.TypeAlias {
+				if _, exists := fields[FieldName(field.AliasedField)]; exists {
+					aliases[FieldName(field.Name)] = FieldName(field.AliasedField)
+				} else {
+					logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", field.AliasedField)
+				}
+			}
+		}
+	}
+}
+
+func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[string]Table, indexName string, fields map[FieldName]Field) {
+	if tableDefinition, found := definitions[indexName]; found {
+		logger.Debug().Msgf("loading schema for table %s", indexName)
+
+		for _, column := range tableDefinition.Columns {
+			if _, exists := fields[FieldName(column.Name)]; !exists {
+				if quesmaType, found2 := s.dataSourceTypeAdapter.Convert(column.Type); found2 {
+					fields[FieldName(column.Name)] = Field{Name: FieldName(column.Name), Type: quesmaType}
+				} else {
+					logger.Debug().Msgf("type %s not supported, falling back to text", column.Type)
+					fields[FieldName(column.Name)] = Field{Name: FieldName(column.Name), Type: TypeText}
+				}
+			}
+		}
 	}
 }

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -211,13 +211,12 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := schema.NewSchemaRegistry(tt.tableDiscovery, tt.cfg, clickhouse.SchemaTypeAdapter{}, elasticsearch.SchemaTypeAdapter{})
-			s.Start()
-			got, got1 := s.FindSchema(tt.tableName)
-			if got1 != tt.exists {
-				t.Errorf("FindSchema() got1 = %v, want %v", got1, tt.exists)
+			resultSchema, resultFound := s.FindSchema(tt.tableName)
+			if resultFound != tt.exists {
+				t.Errorf("FindSchema() got1 = %v, want %v", resultFound, tt.exists)
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("FindSchema() got = %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(resultSchema, tt.want) {
+				t.Errorf("FindSchema() got = %v, want %v", resultSchema, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
In order to minimize complexity and eventual consistency, resolve schemas on each call and don't cache them and use this opportunity to simplify code.

Depends on:
- https://github.com/QuesmaOrg/quesma/pull/364