### PR TITLE
Separate doc from bulk packages

### DIFF
--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func DualWriteBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *clickhouse.LogManager,
+func Write(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *clickhouse.LogManager,
 	cfg config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []WriteResult) {
 	defer recovery.LogPanic()
 
@@ -91,20 +91,6 @@ func DualWriteBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON,
 		})
 	}
 	return results
-}
-
-func DualWrite(ctx context.Context, tableName string, body types.JSON, lm *clickhouse.LogManager, cfg config.QuesmaConfiguration) error {
-	stats.GlobalStatistics.Process(cfg, tableName, body, clickhouse.NestedSeparator)
-
-	defer recovery.LogPanic()
-	if len(body) == 0 {
-		return nil
-	}
-
-	withConfiguration(ctx, cfg, tableName, body, func() error {
-		return lm.ProcessInsertQuery(ctx, tableName, types.NDJSON{body})
-	})
-	return nil
 }
 
 var insertCounter = atomic.Int32{}

--- a/quesma/quesma/functionality/doc/doc.go
+++ b/quesma/quesma/functionality/doc/doc.go
@@ -1,0 +1,78 @@
+package doc
+
+import (
+	"context"
+	"mitmproxy/quesma/clickhouse"
+	"mitmproxy/quesma/logger"
+	"mitmproxy/quesma/quesma/config"
+	"mitmproxy/quesma/quesma/recovery"
+	"mitmproxy/quesma/quesma/types"
+	"mitmproxy/quesma/stats"
+	"sync/atomic"
+)
+
+func Write(ctx context.Context, tableName string, body types.JSON, lm *clickhouse.LogManager, cfg config.QuesmaConfiguration) error {
+	stats.GlobalStatistics.Process(cfg, tableName, body, clickhouse.NestedSeparator)
+
+	defer recovery.LogPanic()
+	if len(body) == 0 {
+		return nil
+	}
+
+	withConfiguration(ctx, cfg, tableName, body, func() error {
+		return lm.ProcessInsertQuery(ctx, tableName, types.NDJSON{body})
+	})
+	return nil
+}
+
+var insertCounter = atomic.Int32{}
+
+func withConfiguration(ctx context.Context, cfg config.QuesmaConfiguration, indexName string, body types.JSON, action func() error) {
+	if len(cfg.IndexConfig) == 0 {
+		logger.InfoWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s", indexName, body.ShortString())
+		err := action()
+		if err != nil {
+			logger.ErrorWithCtx(ctx).Msg("Can't write to index: " + err.Error())
+		}
+	} else {
+		matchingConfig, ok := findMatchingConfig(indexName, cfg)
+		if !ok {
+			logger.InfoWithCtx(ctx).Msgf("index '%s' is not configured, skipping", indexName)
+			return
+		}
+		if matchingConfig.Enabled {
+			insertCounter.Add(1)
+			if insertCounter.Load()%50 == 1 {
+				logger.DebugWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s, ctr: %d", indexName, body.ShortString(), insertCounter.Load())
+			}
+			err := action()
+			if err != nil {
+				logger.ErrorWithCtx(ctx).Msg("Can't write to Clickhouse: " + err.Error())
+			}
+		} else {
+			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
+		}
+	}
+}
+
+var matchCounter = atomic.Int32{}
+
+func findMatchingConfig(indexPattern string, cfg config.QuesmaConfiguration) (config.IndexConfiguration, bool) {
+	matchCounter.Add(1)
+	for _, indexConfig := range cfg.IndexConfig {
+		if matchCounter.Load()%100 == 1 {
+			logger.Debug().Msgf("matching index %s with config: %+v, ctr: %d", indexPattern, indexConfig.Name, matchCounter.Load())
+		}
+		if config.MatchName(indexPattern, indexConfig.Name) {
+			if matchCounter.Load()%100 == 1 {
+				logger.Debug().Msgf("  ╚═ matched index %s with config: %+v, ctr: %d", indexPattern, indexConfig.Name, matchCounter.Load())
+			}
+			return indexConfig, true
+		} else {
+			if matchCounter.Load()%100 == 1 {
+				logger.Debug().Msgf("  ╚═ not matched index %s with config: %+v, ctr: %d", indexPattern, indexConfig.Name, matchCounter.Load())
+			}
+		}
+	}
+	return config.IndexConfiguration{}, false
+}

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -11,6 +11,7 @@ import (
 	"mitmproxy/quesma/quesma/config"
 	"mitmproxy/quesma/quesma/errors"
 	"mitmproxy/quesma/quesma/functionality/bulk"
+	"mitmproxy/quesma/quesma/functionality/doc"
 	"mitmproxy/quesma/quesma/functionality/field_capabilities"
 	"mitmproxy/quesma/quesma/functionality/terms_enum"
 	"mitmproxy/quesma/quesma/mux"
@@ -49,7 +50,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 			return nil, err
 		}
 
-		results := bulk.DualWriteBulk(ctx, nil, body, lm, cfg, phoneHomeAgent)
+		results := bulk.Write(ctx, nil, body, lm, cfg, phoneHomeAgent)
 		return bulkInsertResult(results), nil
 	})
 
@@ -64,7 +65,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 			return nil, err
 		}
 
-		err = bulk.DualWrite(ctx, req.Params["index"], body, lm, cfg)
+		err = doc.Write(ctx, req.Params["index"], body, lm, cfg)
 		return indexDocResult(req.Params["index"], httpOk), err
 	})
 
@@ -76,7 +77,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 			return nil, err
 		}
 
-		results := bulk.DualWriteBulk(ctx, &index, body, lm, cfg, phoneHomeAgent)
+		results := bulk.Write(ctx, &index, body, lm, cfg, phoneHomeAgent)
 		return bulkInsertResult(results), nil
 	})
 


### PR DESCRIPTION
This introduces duplication in the configuration matching department, but this will be gone soon since this functionality does not belong here anyway.