### PR TITLE
[WiP]Decouple logger from config (this hangs sometimes locally, do not merge)

### DIFF
--- a/quesma/logger/log_sender.go
+++ b/quesma/logger/log_sender.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"mitmproxy/quesma/quesma/config"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,12 +11,14 @@ import (
 )
 
 type LogSender struct {
-	Url          *url.URL
-	LicenseKey   string
-	LogBuffer    []byte
-	LastSendTime time.Time
-	Interval     time.Duration
-	httpClient   *http.Client
+	Url             *url.URL
+	LicenseKey      string
+	LogBuffer       []byte
+	LastSendTime    time.Time
+	Interval        time.Duration
+	httpClient      *http.Client
+	remoteLogHeader string
+	licenseHeader   string
 }
 
 func (logSender *LogSender) EatLogMessage(msg []byte) struct {
@@ -86,8 +87,8 @@ func (logSender *LogSender) sendLogs() error {
 		return err
 	}
 	req.Header.Set("Content-Type", "text/plain")
-	req.Header.Set(config.RemoteLogHeader, "true") // value is arbitrary, just have to be non-empty
-	req.Header.Set(config.LicenseHeader, logSender.LicenseKey)
+	req.Header.Set(logSender.remoteLogHeader, "true") // value is arbitrary, just have to be non-empty
+	req.Header.Set(logSender.licenseHeader, logSender.LicenseKey)
 	resp, err := logSender.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/quesma/logger/logging_config.go
+++ b/quesma/logger/logging_config.go
@@ -1,0 +1,16 @@
+package logger
+
+import (
+	"github.com/rs/zerolog"
+	"net/url"
+)
+
+type Configuration struct {
+	FileLogging       bool
+	Path              string
+	RemoteLogDrainUrl *url.URL
+	Level             zerolog.Level
+	LicenseKey        string
+	RemoteLogHeader   string
+	LicenseHeader     string
+}

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -45,7 +45,15 @@ func main() {
 
 	var asyncQueryTraceLogger *tracing.AsyncTraceLogger
 
-	qmcLogChannel := logger.InitLogger(cfg, sig, doneCh, asyncQueryTraceLogger)
+	qmcLogChannel := logger.InitLogger(logger.Configuration{
+		FileLogging:       cfg.Logging.FileLogging,
+		Path:              cfg.Logging.Path,
+		RemoteLogDrainUrl: cfg.Logging.RemoteLogDrainUrl.ToUrl(),
+		Level:             cfg.Logging.Level,
+		LicenseKey:        cfg.LicenseKey,
+		RemoteLogHeader:   config.RemoteLogHeader,
+		LicenseHeader:     config.LicenseHeader,
+	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()
 	defer logger.ErrLogFile.Close()
 

--- a/quesma/quesma/config/url.go
+++ b/quesma/quesma/config/url.go
@@ -4,6 +4,10 @@ import "net/url"
 
 type Url url.URL
 
+func (u *Url) ToUrl() *url.URL {
+	return (*url.URL)(u)
+}
+
 func (u *Url) UnmarshalText(text []byte) error {
 	urlValue, err := url.Parse(string(text))
 	if err != nil {

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -38,7 +38,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
 			cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
-			logChan := logger.InitOnlyChannelLoggerForTests(cfg)
+			logChan := logger.InitOnlyChannelLoggerForTests(logger.Configuration{})
 			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 			go managementConsole.RunOnlyChannelProcessor()
 
@@ -89,7 +89,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 
 	lm := clickhouse.NewLogManagerWithConnection(db, table)
 	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
-	logChan := logger.InitOnlyChannelLoggerForTests(cfg)
+	logChan := logger.InitOnlyChannelLoggerForTests(logger.Configuration{})
 	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	go managementConsole.RunOnlyChannelProcessor()
 


### PR DESCRIPTION
`logger` module should not depend on Quesma configuration - this is inducing import cycles