### PR TITLE
Attempt to unify sampler

### DIFF
--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -53,5 +53,9 @@ func (query Terms) String() string {
 }
 
 func (query Terms) PostprocessResults(rowsFromDB []model.QueryResultRow) []model.QueryResultRow {
-	return rowsFromDB
+	if len(rowsFromDB) <= query.size {
+		return rowsFromDB
+	} else {
+		return rowsFromDB[:query.size]
+	}
 }

--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -9,10 +9,11 @@ import (
 type Terms struct {
 	ctx         context.Context
 	significant bool // true <=> significant_terms, false <=> terms
+	size        int
 }
 
-func NewTerms(ctx context.Context, significant bool) Terms {
-	return Terms{ctx: ctx, significant: significant}
+func NewTerms(ctx context.Context, significant bool, size int) Terms {
+	return Terms{ctx: ctx, significant: significant, size: size}
 }
 
 func (query Terms) IsBucketAggregation() bool {
@@ -25,7 +26,10 @@ func (query Terms) TranslateSqlResponseToJson(rows []model.QueryResultRow, level
 		logger.ErrorWithCtx(query.ctx).Msgf(
 			"unexpected number of columns in terms aggregation response, len: %d, rows[0]: %v", len(rows[0].Cols), rows[0])
 	}
-	for _, row := range rows {
+	for i, row := range rows {
+		if i >= query.size {
+			break
+		}
 		docCount := row.Cols[len(row.Cols)-1].Value
 		bucket := model.JsonMap{
 			"key":       row.Cols[len(row.Cols)-2].Value,
@@ -37,6 +41,7 @@ func (query Terms) TranslateSqlResponseToJson(rows []model.QueryResultRow, level
 		}
 		response = append(response, bucket)
 	}
+	// TODO: we should return 'doc_count_error_upper_bound' and too 'sum_other_doc_count' too
 	return response
 }
 

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -710,7 +710,6 @@ func (cw *ClickhouseQueryTranslator) tryBucketAggregation(currentAggr *aggrQuery
 	}
 	for _, termsType := range []string{"terms", "significant_terms"} {
 		if terms, ok := queryMap[termsType]; ok {
-			currentAggr.Type = bucket_aggregations.NewTerms(cw.Ctx, termsType == "significant_terms")
 
 			isEmptyGroupBy := len(currentAggr.SelectCommand.GroupBy) == 0
 
@@ -733,6 +732,7 @@ func (cw *ClickhouseQueryTranslator) tryBucketAggregation(currentAggr *aggrQuery
 				currentAggr.SelectCommand.OrderBy = append(currentAggr.SelectCommand.OrderBy, model.NewSortByCountColumn(model.DescOrder))
 				orderByAdded = true
 			}
+			currentAggr.Type = bucket_aggregations.NewTerms(cw.Ctx, termsType == "significant_terms", size)
 			delete(queryMap, termsType)
 			if !orderByAdded {
 				currentAggr.SelectCommand.OrderBy = append(currentAggr.SelectCommand.OrderBy, model.NewOrderByExprWithoutOrder(cw.parseFieldField(terms, termsType)))

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -989,7 +989,7 @@ func (cw *ClickhouseQueryTranslator) parseSampler(sampler any) int {
 		logger.WarnWithCtx(cw.Ctx).Msgf("sampler is not a map, but %v", queryMap)
 		return 0
 	}
-	if shardCountRaw, exists := queryMap["shard_count"]; exists {
+	if shardCountRaw, exists := queryMap["shard_size"]; exists {
 		if shardCount, ok := shardCountRaw.(float64); ok {
 			if shardCount < 0 {
 				logger.WarnWithCtx(cw.Ctx).Msgf("shard_count is negative: %f. Skipping", shardCount)

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -854,6 +854,7 @@ func (cw *ClickhouseQueryTranslator) tryBucketAggregation(currentAggr *aggrQuery
 	if sampler, ok := queryMap["sampler"]; ok {
 		currentAggr.Type = metrics_aggregations.NewCount(cw.Ctx) // TODO: We don't need it always
 		currentAggr.SelectCommand.SampleLimit = cw.parseSampler(sampler)
+		success = false // we are not adding count for sampler
 		delete(queryMap, "sampler")
 		return
 	}

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -540,10 +540,9 @@ var aggregationTests = []struct {
 				  "size": 0
 			}`,
 		[]string{
-			`SELECT floor("bytes"/1782.000000)*1782.000000, count() FROM ` + tableNameQuoted + ` ` +
+			`SELECT floor("bytes"/1782.000000)*1782.000000, count() FROM (SELECT 1 FROM ` + tableNameQuoted + ` LIMIT 20000) ` +
 				`GROUP BY floor("bytes"/1782.000000)*1782.000000 ` +
 				`ORDER BY floor("bytes"/1782.000000)*1782.000000`,
-			`SELECT count() FROM ` + tableNameQuoted,
 		},
 	},
 }

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -540,7 +540,7 @@ var aggregationTests = []struct {
 				  "size": 0
 			}`,
 		[]string{
-			`SELECT floor("bytes"/1782.000000)*1782.000000, count() FROM (SELECT 1 FROM ` + tableNameQuoted + ` LIMIT 20000) ` +
+			`SELECT floor("bytes"/1782.000000)*1782.000000, count() FROM (SELECT "bytes" FROM ` + tableNameQuoted + ` LIMIT 20000) ` +
 				`GROUP BY floor("bytes"/1782.000000)*1782.000000 ` +
 				`ORDER BY floor("bytes"/1782.000000)*1782.000000`,
 		},
@@ -650,6 +650,9 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 			// Let's leave those commented debugs for now, they'll be useful in next PRs
 			for j, query := range queries {
 				// fmt.Printf("--- Aggregation %d: %+v\n\n---SQL string: %s\n\n", j, query, query.String(context.Background()))
+				if j >= len(test.ExpectedSQLs) {
+					t.Fatal("Too many queries in response")
+				}
 				if test.ExpectedSQLs[j] != "NoDBQuery" {
 					util.AssertSqlEqual(t, test.ExpectedSQLs[j], query.SelectCommand.String())
 				}

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"github.com/jinzhu/copier"
-	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
@@ -686,8 +685,9 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 
 			// probability and seed are present in random_sampler aggregation. I'd assume they are not needed, thus let's not care about it for now.
 			acceptableDifference := []string{"doc_count_error_upper_bound", "sum_other_doc_count", "probability", "seed", "bg_count", "doc_count", model.KeyAddedByQuesma}
-			pp.Println("ACTUAL", actualMinusExpected)
-			pp.Println("EXPECTED", expectedMinusActual)
+			// TODO: sum_other_doc_count, doc_count_error_upper_bound, doc_count should be removed
+			// pp.Println("ACTUAL", actualMinusExpected)
+			// pp.Println("EXPECTED", expectedMinusActual)
 			assert.True(t, util.AlmostEmpty(actualMinusExpected, acceptableDifference))
 			assert.True(t, util.AlmostEmpty(expectedMinusActual, acceptableDifference))
 			if body["track_total_hits"] == true { // FIXME some better check after track_total_hits

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"github.com/jinzhu/copier"
+	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
@@ -685,8 +686,8 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 
 			// probability and seed are present in random_sampler aggregation. I'd assume they are not needed, thus let's not care about it for now.
 			acceptableDifference := []string{"doc_count_error_upper_bound", "sum_other_doc_count", "probability", "seed", "bg_count", "doc_count", model.KeyAddedByQuesma}
-			// pp.Println("ACTUAL", actualMinusExpected)
-			// pp.Println("EXPECTED", expectedMinusActual)
+			pp.Println("ACTUAL", actualMinusExpected)
+			pp.Println("EXPECTED", expectedMinusActual)
 			assert.True(t, util.AlmostEmpty(actualMinusExpected, acceptableDifference))
 			assert.True(t, util.AlmostEmpty(expectedMinusActual, acceptableDifference))
 			if body["track_total_hits"] == true { // FIXME some better check after track_total_hits

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -40,17 +40,13 @@ func (cw *ClickhouseQueryTranslator) ParseQuery(body types.JSON) ([]*model.Query
 	if countQuery := cw.buildCountQueryIfNeeded(simpleQuery, queryInfo); countQuery != nil {
 		queries = append(queries, countQuery)
 	}
-	facetsQuery := cw.buildFacetsQueryIfNeeded(simpleQuery, queryInfo)
-	if facetsQuery != nil {
-		queries = append(queries, facetsQuery)
-	} else {
-		aggregationQueries, err := cw.ParseAggregationJson(body)
-		if err != nil {
-			logger.WarnWithCtx(cw.Ctx).Msgf("error parsing aggregation: %v", err)
-		}
-		if aggregationQueries != nil {
-			queries = append(queries, aggregationQueries...)
-		}
+	//facetsQuery cw.buildFacetsQueryIfNeeded(simpleQuery, queryInfo)
+	aggregationQueries, err := cw.ParseAggregationJson(body)
+	if err != nil {
+		logger.WarnWithCtx(cw.Ctx).Msgf("error parsing aggregation: %v", err)
+	}
+	if aggregationQueries != nil {
+		queries = append(queries, aggregationQueries...)
 	}
 	if listQuery := cw.buildListQueryIfNeeded(simpleQuery, queryInfo, highlighter); listQuery != nil {
 		queries = append(queries, listQuery)

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -336,7 +336,7 @@ func TestNumericFacetsQueries(t *testing.T) {
 				}
 
 				// count, present in all tests
-				mock.ExpectQuery(`SELECT count\(\) FROM ` + strconv.Quote(tableName)).WillReturnRows(sqlmock.NewRows([]string{"count"}))
+				mock.ExpectQuery(`SELECT count\(\) FROM `).WillReturnRows(sqlmock.NewRows([]string{"count"}))
 				// Don't care about the query's SQL in this test, it's thoroughly tested in different tests, thus ""
 				mock.ExpectQuery("").WillReturnRows(returnedBuckets)
 

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2156,7 +2156,7 @@ var AggregationTests = []AggregationTestCase{
 				`WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') ` +
 				`AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) ` +
 				`AND "message" iLIKE '%user%') LIMIT 3)`,
-			`SELECT "host.name" AS "key", count() AS "doc_count" ` +
+			`SELECT "host.name", count() ` +
 				`FROM (SELECT "host.name" FROM ` + QuotedTableName + ` ` +
 				`WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') ` +
 				`AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) ` +

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2136,6 +2136,7 @@ var AggregationTests = []AggregationTestCase{
 		}`,
 		[][]model.QueryResultRow{
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(262))}}},
+			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(262))}}},
 			{
 				{Cols: []model.QueryResultCol{model.NewQueryResultCol("key", "hephaestus"), model.NewQueryResultCol("doc_count", uint64(30))}},
 				{Cols: []model.QueryResultCol{model.NewQueryResultCol("key", "poseidon"), model.NewQueryResultCol("doc_count", uint64(29))}},
@@ -2156,6 +2157,12 @@ var AggregationTests = []AggregationTestCase{
 				`WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') ` +
 				`AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) ` +
 				`AND "message" iLIKE '%user%') LIMIT 3)`,
+			`SELECT count() ` + // likely optimization would remove it
+				`FROM (SELECT 1 FROM ` + QuotedTableName + ` ` +
+				`WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') ` +
+				`AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) ` +
+				`AND "message" iLIKE '%user%') ` +
+				`LIMIT 20000)`,
 			`SELECT "host.name", count() ` +
 				`FROM (SELECT "host.name" FROM ` + QuotedTableName + ` ` +
 				`WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') ` +
@@ -2163,7 +2170,8 @@ var AggregationTests = []AggregationTestCase{
 				`AND "message" iLIKE '%user%') ` +
 				`LIMIT 20000) ` +
 				`GROUP BY "host.name" ` +
-				`ORDER BY count() DESC`,
+				`ORDER BY count() DESC ` +
+				`LIMIT 10`,
 		},
 	},
 	{ // [12], "old" test, also can be found in testdata/requests.go TestAsyncSearch[3]

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -147,7 +147,10 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 }`,
 		"no comment yet",
 		model.SearchQueryInfo{Typ: model.Facets, FieldName: "host.name", I1: 10, I2: 5000},
-		[]string{`SELECT "host.name" AS "key", count() AS "doc_count" FROM (SELECT "host.name" FROM "logs-generic-default"  WHERE (("@timestamp".=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') AND "@timestamp".=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND "message" iLIKE '%user%') LIMIT ` + queryparserFacetsSampleSize + `) GROUP BY "host.name" ORDER BY count() DESC`},
+		[]string{
+			`SELECT "host.name", count() FROM (SELECT "host.name" FROM "logs-generic-default"  WHERE (("@timestamp".=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') AND "@timestamp".=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND "message" iLIKE '%user%') LIMIT ` + queryparserFacetsSampleSize + `) GROUP BY "host.name" ORDER BY count() DESC LIMIT 10`,
+			`SELECT count() FROM (SELECT 1 FROM "logs-generic-default" WHERE (("@timestamp".=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z') AND "@timestamp".=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND "message" iLIKE '%user%') LIMIT ` + queryparserFacetsSampleSize + `)`,
+		},
 		true,
 	},
 	{ // [1]


### PR DESCRIPTION
I try to refactor and see if we can fold facets into general aggregation. This is not working fully, but feel that we are close.

Missing pieces are:
- [ ] We generated too many SQL and didn't fold them into one.
- [ ] We can't have an easy way to re-use some results (e.g. a group of facet numeric to count min, max, etc. on them)
- [ ] We can't generate one out of bucket aggregation buckets.

Would need to talk to @trzysiek to see if this is solveable.