### PR TITLE
Move tracing.LogWithLevel to logger.LogWithLevel

### DIFF
--- a/quesma/logger/channelWriter.go
+++ b/quesma/logger/channelWriter.go
@@ -2,21 +2,20 @@ package logger
 
 import (
 	"github.com/rs/zerolog"
-	"mitmproxy/quesma/tracing"
 )
 
 type channelWriter struct {
-	ch chan tracing.LogWithLevel
+	ch chan LogWithLevel
 }
 
 func (w channelWriter) Write(p []byte) (n int, err error) {
 	s := string(p)
-	w.ch <- tracing.LogWithLevel{Level: zerolog.NoLevel, Msg: s}
+	w.ch <- LogWithLevel{Level: zerolog.NoLevel, Msg: s}
 	return len(s), nil
 }
 
 func (w channelWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
 	s := string(p)
-	w.ch <- tracing.LogWithLevel{Level: level, Msg: s}
+	w.ch <- LogWithLevel{Level: level, Msg: s}
 	return len(s), nil
 }

--- a/quesma/logger/log.go
+++ b/quesma/logger/log.go
@@ -1,4 +1,4 @@
-package tracing
+package logger
 
 import "github.com/rs/zerolog"
 

--- a/quesma/logger/logger.go
+++ b/quesma/logger/logger.go
@@ -40,13 +40,13 @@ const (
 var logger zerolog.Logger
 
 // InitLogger returns channel where log messages will be sent
-func InitLogger(cfg config.QuesmaConfiguration, sig chan os.Signal, doneCh chan struct{}, asyncQueryTraceLogger *tracing.AsyncTraceLogger) <-chan tracing.LogWithLevel {
+func InitLogger(cfg config.QuesmaConfiguration, sig chan os.Signal, doneCh chan struct{}, asyncQueryTraceLogger *tracing.AsyncTraceLogger) <-chan LogWithLevel {
 	zerolog.TimeFieldFormat = time.RFC3339Nano // without this we don't have milliseconds timestamp precision
 	var output io.Writer = zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.StampMilli}
 	if os.Getenv("GO_ENV") == "production" { // ConsoleWriter is slow, disable it in production
 		output = os.Stderr
 	}
-	logChannel := make(chan tracing.LogWithLevel, 50000) // small number like 5 or 10 made entire Quesma totally unresponsive during the few seconds where Kibana spams with messages
+	logChannel := make(chan LogWithLevel, 50000) // small number like 5 or 10 made entire Quesma totally unresponsive during the few seconds where Kibana spams with messages
 	chanWriter := channelWriter{ch: logChannel}
 
 	var logWriters []io.Writer
@@ -120,9 +120,9 @@ func InitSimpleLoggerForTests() {
 		Logger()
 }
 
-func InitOnlyChannelLoggerForTests(cfg config.QuesmaConfiguration) <-chan tracing.LogWithLevel {
-	zerolog.TimeFieldFormat = time.RFC3339Nano           // without this we don't have milliseconds timestamp precision
-	logChannel := make(chan tracing.LogWithLevel, 50000) // small number like 5 or 10 made entire Quesma totally unresponsive during the few seconds where Kibana spams with messages
+func InitOnlyChannelLoggerForTests(cfg config.QuesmaConfiguration) <-chan LogWithLevel {
+	zerolog.TimeFieldFormat = time.RFC3339Nano   // without this we don't have milliseconds timestamp precision
+	logChannel := make(chan LogWithLevel, 50000) // small number like 5 or 10 made entire Quesma totally unresponsive during the few seconds where Kibana spams with messages
 	chanWriter := channelWriter{ch: logChannel}
 
 	logger = zerolog.New(chanWriter).

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -86,7 +86,7 @@ func main() {
 
 }
 
-func constructQuesma(cfg config.QuesmaConfiguration, sl clickhouse.TableDiscovery, lm *clickhouse.LogManager, im elasticsearch.IndexManagement, schemaRegistry schema.Registry, phoneHomeAgent telemetry.PhoneHomeAgent, logChan <-chan tracing.LogWithLevel) *quesma.Quesma {
+func constructQuesma(cfg config.QuesmaConfiguration, sl clickhouse.TableDiscovery, lm *clickhouse.LogManager, im elasticsearch.IndexManagement, schemaRegistry schema.Registry, phoneHomeAgent telemetry.PhoneHomeAgent, logChan <-chan logger.LogWithLevel) *quesma.Quesma {
 
 	switch cfg.Mode {
 	case config.Proxy:

--- a/quesma/quesma/functionality/terms_enum/terms_enum_test.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
+	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/queryparser"
 	"mitmproxy/quesma/quesma/config"
@@ -76,7 +77,7 @@ func TestHandleTermsEnumRequest(t *testing.T) {
 		Created: true,
 	}
 
-	managementConsole := ui.NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(testTableName, table))

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -105,7 +105,7 @@ func sendElkResponseToQuesmaConsole(ctx context.Context, elkResponse elasticResu
 	console.PushPrimaryInfo(&ui.QueryDebugPrimarySource{Id: id, QueryResp: body, PrimaryTook: elkResponse.took})
 }
 
-func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.QuesmaConfiguration, logChan <-chan tracing.LogWithLevel, inspect bool) *Quesma {
+func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.QuesmaConfiguration, logChan <-chan logger.LogWithLevel, inspect bool) *Quesma {
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(config, nil, nil, logChan, phoneHomeAgent, emptySchemasProvider{})
 	return &Quesma{
 		processor:               proxy.NewTcpProxy(config.PublicTcpPort, config.Elasticsearch.Url.Host, inspect),
@@ -115,7 +115,7 @@ func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.Qu
 	}
 }
 
-func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, schemaLoader clickhouse.TableDiscovery, indexManager elasticsearch.IndexManagement, schemaRegistry schema.Registry, config config.QuesmaConfiguration, logChan <-chan tracing.LogWithLevel) *Quesma {
+func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, schemaLoader clickhouse.TableDiscovery, indexManager elasticsearch.IndexManagement, schemaRegistry schema.Registry, config config.QuesmaConfiguration, logChan <-chan logger.LogWithLevel) *Quesma {
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(config, logManager, indexManager, logChan, phoneHomeAgent, schemaRegistry)
 	queryRunner := NewQueryRunner(logManager, config, indexManager, quesmaManagementConsole, schemaRegistry)
 

--- a/quesma/quesma/quesma_test.go
+++ b/quesma/quesma/quesma_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/quesma/config"
 	"mitmproxy/quesma/telemetry"
-	"mitmproxy/quesma/tracing"
 	"net/http"
 	"testing"
 	"time"
@@ -19,7 +19,7 @@ func TestShouldExposePprof(t *testing.T) {
 	quesma := NewQuesmaTcpProxy(telemetry.NoopPhoneHomeAgent(), config.QuesmaConfiguration{
 		PublicTcpPort: 8080,
 		Elasticsearch: config.ElasticsearchConfiguration{Url: &config.Url{}},
-	}, make(<-chan tracing.LogWithLevel), false)
+	}, make(<-chan logger.LogWithLevel), false)
 	quesma.Start()
 	waitForHealthyQuesma(t)
 	t.Cleanup(func() {

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
+	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/queryparser"
 	"mitmproxy/quesma/quesma/config"
@@ -13,7 +14,6 @@ import (
 	"mitmproxy/quesma/quesma/ui"
 	"mitmproxy/quesma/telemetry"
 	"mitmproxy/quesma/testdata"
-	"mitmproxy/quesma/tracing"
 	"mitmproxy/quesma/util"
 	"strconv"
 	"testing"
@@ -37,7 +37,7 @@ func TestSearchOpensearch(t *testing.T) {
 			db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 			defer db.Close()
 			lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 			cw := queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background()}
 
 			body, parseErr := types.ParseJSON(tt.QueryJson)
@@ -178,7 +178,7 @@ func TestHighlighter(t *testing.T) {
 	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 	mock.ExpectQuery("").WillReturnRows(sqlmock.NewRows([]string{"message$*%:;", "host.name", "@timestamp"}). // careful, it's not always in this order, order is nondeterministic
 															AddRow("abcd", "abcd", "abcd").

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
+	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/queryparser"
 	"mitmproxy/quesma/quesma/config"
@@ -78,7 +79,7 @@ func TestAsyncSearchHandler(t *testing.T) {
 			db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 			defer db.Close()
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 			for _, wantedRegex := range tt.WantedRegexes {
 				if tt.WantedParseResult.Typ == model.ListAllFields {
@@ -123,7 +124,7 @@ func TestAsyncSearchHandlerSpecialCharacters(t *testing.T) {
 			db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 			defer db.Close()
 			lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 			for _, expectedSql := range tt.ExpectedSQLs {
 				mock.ExpectQuery(testdata.EscapeBrackets(expectedSql)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
@@ -163,7 +164,7 @@ func TestSearchHandler(t *testing.T) {
 			defer db.Close()
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 			for _, wantedRegex := range tt.WantedRegexes {
 				mock.ExpectQuery(testdata.EscapeWildcard(testdata.EscapeBrackets(wantedRegex))).
 					WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
@@ -187,7 +188,7 @@ func TestSearchHandlerNoAttrsConfig(t *testing.T) {
 			defer db.Close()
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 			for _, wantedRegex := range tt.WantedRegexes {
 				mock.ExpectQuery(testdata.EscapeBrackets(wantedRegex)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
@@ -209,7 +210,7 @@ func TestAsyncSearchFilter(t *testing.T) {
 			defer db.Close()
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 			for _, wantedRegex := range tt.WantedRegexes {
 				mock.ExpectQuery(testdata.EscapeBrackets(wantedRegex)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
@@ -279,7 +280,7 @@ func TestHandlingDateTimeFields(t *testing.T) {
 
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 	for _, fieldName := range []string{dateTimeTimestampField, dateTime64TimestampField, dateTime64OurTimestampField} {
 
@@ -328,7 +329,7 @@ func TestNumericFacetsQueries(t *testing.T) {
 				db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 				defer db.Close()
 				lm := clickhouse.NewLogManagerWithConnection(db, table)
-				managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+				managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 				returnedBuckets := sqlmock.NewRows([]string{"", ""})
 				for _, row := range tt.ResultRows {
@@ -387,7 +388,7 @@ func TestSearchTrackTotalCount(t *testing.T) {
 		db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 		defer db.Close()
 		lm := clickhouse.NewLogManagerWithConnection(db, table)
-		managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan tracing.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+		managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 		for i, sql := range testcase.ExpectedSQLs {
 			rows := sqlmock.NewRows([]string{testcase.ExpectedSQLResults[i][0].Cols[0].ColName})

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"mitmproxy/quesma/clickhouse"
 	"mitmproxy/quesma/concurrent"
+	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/quesma/config"
 	"mitmproxy/quesma/quesma/types"
 	"mitmproxy/quesma/stats"
 	"mitmproxy/quesma/telemetry"
-	"mitmproxy/quesma/tracing"
 	"testing"
 )
 
@@ -18,7 +18,7 @@ func TestHtmlPages(t *testing.T) {
 	xss := "<script>alert('xss')</script>"
 	xssBytes := []byte(xss)
 	id := "b1c4a89e-4905-5e3c-b57f-dc92627d011e"
-	logChan := make(chan tracing.LogWithLevel, 5)
+	logChan := make(chan logger.LogWithLevel, 5)
 	qmc := NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	qmc.PushPrimaryInfo(&QueryDebugPrimarySource{Id: id, QueryResp: xssBytes})
 	qmc.PushSecondaryInfo(&QueryDebugSecondarySource{Id: id,
@@ -28,7 +28,7 @@ func TestHtmlPages(t *testing.T) {
 		QueryTranslatedResults: xssBytes,
 	})
 	log := fmt.Sprintf(`{"request_id": "%s", "message": "%s"}`, id, xss)
-	logChan <- tracing.LogWithLevel{Level: zerolog.ErrorLevel, Msg: log}
+	logChan <- logger.LogWithLevel{Level: zerolog.ErrorLevel, Msg: log}
 	// Manually process channel
 	for i := 0; i < 3; i++ {
 		qmc.processChannelMessage()
@@ -71,7 +71,7 @@ func TestHtmlPages(t *testing.T) {
 func TestHtmlSchemaPage(t *testing.T) {
 	xss := "<script>alert('xss')</script>"
 
-	logChan := make(chan tracing.LogWithLevel, 5)
+	logChan := make(chan logger.LogWithLevel, 5)
 
 	var columnsMap = make(map[string]*clickhouse.Column)
 

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -5,7 +5,6 @@ import (
 	"mitmproxy/quesma/elasticsearch"
 	"mitmproxy/quesma/schema"
 	"mitmproxy/quesma/telemetry"
-	"mitmproxy/quesma/tracing"
 	"mitmproxy/quesma/util"
 
 	"mitmproxy/quesma/clickhouse"
@@ -75,7 +74,7 @@ type (
 	QuesmaManagementConsole struct {
 		queryDebugPrimarySource   chan *QueryDebugPrimarySource
 		queryDebugSecondarySource chan *QueryDebugSecondarySource
-		queryDebugLogs            <-chan tracing.LogWithLevel
+		queryDebugLogs            <-chan logger.LogWithLevel
 		ui                        *http.Server
 		mutex                     sync.Mutex
 		debugInfoMessages         map[string]queryDebugInfo
@@ -98,7 +97,7 @@ type (
 	}
 )
 
-func NewQuesmaManagementConsole(config config.QuesmaConfiguration, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, logChan <-chan tracing.LogWithLevel, phoneHomeAgent telemetry.PhoneHomeAgent, schemasProvider SchemasProvider) *QuesmaManagementConsole {
+func NewQuesmaManagementConsole(config config.QuesmaConfiguration, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, logChan <-chan logger.LogWithLevel, phoneHomeAgent telemetry.PhoneHomeAgent, schemasProvider SchemasProvider) *QuesmaManagementConsole {
 	return &QuesmaManagementConsole{
 		queryDebugPrimarySource:   make(chan *QueryDebugPrimarySource, 10),
 		queryDebugSecondarySource: make(chan *QueryDebugSecondarySource, 10),

--- a/quesma/quesma/ui/unsupported_queries.go
+++ b/quesma/quesma/ui/unsupported_queries.go
@@ -6,7 +6,6 @@ import (
 	"mitmproxy/quesma/logger"
 	"mitmproxy/quesma/model"
 	"mitmproxy/quesma/quesma/ui/internal/builder"
-	"mitmproxy/quesma/tracing"
 	"net/url"
 	"regexp"
 	"sort"
@@ -16,7 +15,7 @@ const UnrecognizedQueryType = "unrecognized"
 
 var unsupportedSearchQueryRegex, _ = regexp.Compile(logger.Reason + `":"` + logger.ReasonPrefixUnsupportedQueryType + `([[:word:]]+)"`)
 
-func processUnsupportedLogMessage(log tracing.LogWithLevel) *string {
+func processUnsupportedLogMessage(log logger.LogWithLevel) *string {
 	if log.Level != zerolog.ErrorLevel && log.Level != zerolog.WarnLevel { // only error and log
 		return nil
 	}


### PR DESCRIPTION
`mitmproxy/quesma/logger` module depends on `mitmproxy/quesma/tracing` only because it relies on `LogWithLevel` which is not used in `mitmproxy/quesma/tracing` module