### PR TITLE
Decouple logger from quesma/config

### DIFF
--- a/quesma/logger/configuration.go
+++ b/quesma/logger/configuration.go
@@ -1,0 +1,14 @@
+package logger
+
+import (
+	"github.com/rs/zerolog"
+	"net/url"
+)
+
+type Configuration struct {
+	FileLogging       bool
+	Path              string
+	RemoteLogDrainUrl *url.URL
+	Level             zerolog.Level
+	LicenseKey        string
+}

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -45,7 +45,13 @@ func main() {
 
 	var asyncQueryTraceLogger *tracing.AsyncTraceLogger
 
-	qmcLogChannel := logger.InitLogger(cfg, sig, doneCh, asyncQueryTraceLogger)
+	qmcLogChannel := logger.InitLogger(logger.Configuration{
+		FileLogging:       cfg.Logging.FileLogging,
+		Path:              cfg.Logging.Path,
+		RemoteLogDrainUrl: cfg.Logging.RemoteLogDrainUrl.ToUrl(),
+		Level:             cfg.Logging.Level,
+		LicenseKey:        cfg.LicenseKey,
+	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()
 	defer logger.ErrLogFile.Close()
 

--- a/quesma/quesma/config/url.go
+++ b/quesma/quesma/config/url.go
@@ -4,6 +4,10 @@ import "net/url"
 
 type Url url.URL
 
+func (u *Url) ToUrl() *url.URL {
+	return (*url.URL)(u)
+}
+
 func (u *Url) UnmarshalText(text []byte) error {
 	urlValue, err := url.Parse(string(text))
 	if err != nil {

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -38,7 +38,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
 			cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
-			logChan := logger.InitOnlyChannelLoggerForTests(cfg)
+			logChan := logger.InitOnlyChannelLoggerForTests()
 			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 			go managementConsole.RunOnlyChannelProcessor()
 
@@ -89,7 +89,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 
 	lm := clickhouse.NewLogManagerWithConnection(db, table)
 	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
-	logChan := logger.InitOnlyChannelLoggerForTests(cfg)
+	logChan := logger.InitOnlyChannelLoggerForTests()
 	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	go managementConsole.RunOnlyChannelProcessor()
 


### PR DESCRIPTION
This will allow moving some non-trivial config resolution logic into `quesma/config` package. Now, it's impossible due to import cycles.