### PR TITLE
Aggregation refactor

### DIFF
--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -282,14 +282,13 @@ func (cw *ClickhouseQueryTranslator) ParseAggregationJson(body types.JSON) ([]*m
 	aggregations := make([]*model.Query, 0)
 
 	if aggsRaw, ok := queryAsMap["aggs"]; ok {
-		aggs, ok := aggsRaw.(QueryMap)
-		if !ok {
+		if aggs, okType := aggsRaw.(QueryMap); okType {
+			err := cw.parseAggregationNames(&currentAggr, aggs, &aggregations)
+			if err != nil {
+				return nil, err
+			}
+		} else {
 			logger.WarnWithCtx(cw.Ctx).Msgf("aggs is not a map, but %T, aggs: %v", aggsRaw, aggsRaw)
-			return aggregations, nil
-		}
-		err := cw.parseAggregationNames(&currentAggr, aggs, &aggregations)
-		if err != nil {
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
I was thinking of bigger change, but there are several ways we can improve code now:
- deduplicate aggregation for names
- rename `resultAccumulator` to `resultQueries`
- the restoration logic seems prone to bugs and complex, copied variable instead

Some parts still could be further improved, though tried to make this PR small and simple.

Has to be approved by @trzysiek .