### PR TITLE
Add License Header Verification pipeline step

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,6 +30,23 @@ jobs:
         working-directory: ${{ matrix.module }}
         run: gofmt -l -d . | (! grep . -q) || (gofmt -l -d .;exit 1)
 
+      - name: License Header Verification
+        working-directory: ${{ matrix.module }}
+        run: |
+          LICENSE_COMMENT="// Copyright Quesma, licensed under the Elastic License 2.0.
+          // SPDX-License-Identifier: Elastic-2.0"
+          failed=false
+          while IFS= read -r -d '' file; do
+            file_content=$(< "$file")
+
+            if [[ "$file_content" != "$LICENSE_COMMENT"* ]]; then
+              echo "License header missing or incorrect in file: $file"
+              failed=true
+            fi
+          done < <(find . -type f -name "*.go" -print0)
+          if [ "$failed" = true ]; then
+            exit 1
+          fi
       - name: Go Vet
         working-directory: ${{ matrix.module }}
         run: go vet ./...


### PR DESCRIPTION
Adds a GitHub Actions step that verifies if all `*.go` files start with license headers.

Depends on:
- https://github.com/QuesmaOrg/quesma/pull/410

<img width="944" alt="image" src="https://github.com/QuesmaOrg/quesma/assets/2182533/b25c730b-cd29-4aef-a97c-57f00dd8c740">
