### PR TITLE
category mapping for kibana_sample_data_ecommerce

### DIFF
--- a/docker/quesma/config/local-dev.yaml
+++ b/docker/quesma/config/local-dev.yaml
@@ -20,6 +20,7 @@ indexes:
     enabled: true
     mappings:
       products.manufacturer: "text"
+      category: "text"
   kibana_sample_data_flights:
     enabled: true
     mappings:


### PR DESCRIPTION
Fixes `Breakdown by category` panel in the example dashboard. The result is incorrect due to our lack of array support for now, but at least it displays values and not an error.

<img width="851" alt="Screenshot 2024-06-27 at 08 05 50" src="https://github.com/QuesmaOrg/quesma/assets/2182533/7bbd75cf-56d2-481d-ba63-46c78332940c">
