### PR TITLE
Simplify request preprocessors

### DIFF
--- a/quesma/quesma/processors.go
+++ b/quesma/quesma/processors.go
@@ -10,7 +10,6 @@ import (
 
 type (
 	RequestPreprocessor interface {
-		Applies(req *mux.Request) bool
 		PreprocessRequest(ctx context.Context, req *mux.Request) (context.Context, *mux.Request, error)
 	}
 
@@ -25,15 +24,9 @@ type (
 )
 
 func NewTraceIdPreprocessor() TraceIdPreprocessor {
-	return TraceIdPreprocessor{
-		RequestIdGenerator: func() string {
-			return tracing.GetRequestId()
-		},
-	}
-}
-
-func (t TraceIdPreprocessor) Applies(*mux.Request) bool {
-	return true
+	return TraceIdPreprocessor{RequestIdGenerator: func() string {
+		return tracing.GetRequestId()
+	}}
 }
 
 func (t TraceIdPreprocessor) PreprocessRequest(ctx context.Context, req *mux.Request) (context.Context, *mux.Request, error) {

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -274,11 +274,9 @@ func (r *router) preprocessRequest(ctx context.Context, quesmaRequest *mux.Reque
 	var err error
 	var processedRequest = quesmaRequest
 	for _, preprocessor := range r.requestPreprocessors {
-		if preprocessor.Applies(processedRequest) {
-			ctx, processedRequest, err = preprocessor.PreprocessRequest(ctx, processedRequest)
-			if err != nil {
-				return nil, nil, err
-			}
+		ctx, processedRequest, err = preprocessor.PreprocessRequest(ctx, processedRequest)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
 	return processedRequest, ctx, nil


### PR DESCRIPTION
There's no point in separating `Applies()` from `Preprocess()` - processors should just return the original request when conditions don't apply