### PR TITLE
Fix kibana/lib.sh

### DIFF
--- a/docker/kibana/lib.sh
+++ b/docker/kibana/lib.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-DASHBOARD_URL="http://kibana:5601"
+echo "$@"
+
+DASHBOARD_URL="$1"
+if [ -z "$DASHBOARD_URL" ]; then
+  DASHBOARD_URL="http://kibana:5601"
+fi
+
+echo "$DASHBOARD_URL"
 
 if [ -z "$XSRF_HEADER" ]; then
   XSRF_HEADER="kbn-xsrf: true"


### PR DESCRIPTION
Reverts rogue change introduced in https://github.com/QuesmaOrg/quesma/commit/76a472320468d1d6c8a0eba0123870a86a1a7ad9 which effectively disallowed providing custom Kibana urls

