### PR TITLE
Fix mapping of product_name in kibana_sample_data_ecommerce

### DIFF
--- a/docker/quesma/config/local-dev.yaml
+++ b/docker/quesma/config/local-dev.yaml
@@ -20,6 +20,7 @@ indexes:
     enabled: true
     mappings:
       products.manufacturer: "text"
+      products.product_name: "text"
       geoip.location: "geo_point"
       category: "text"
   kibana_sample_data_flights:


### PR DESCRIPTION
Before this change, the "Top products last week" panel on "[eCommerce] Revenue Dashboard" would fail to properly render with the following error:

> Field products.product_name.keyword was not found.

!["Top products last week" error](https://github.com/QuesmaOrg/quesma/assets/10003183/e9f51126-6b67-4916-a7cb-14453fde0bcf)

The issue was that `products.product_name` was a keyword - making `.keyword` on a keyword a failure.

Fix the issue by mapping `products.product_name` to `text`. The panel after the fix:

!["Top products last week" after the fix](https://github.com/QuesmaOrg/quesma/assets/10003183/f5b2de71-104b-46c7-adb3-d1be2f48d221)

Please note that this panel doesn't yet match the (direct) ElasticSearch panel output:

!["Top products last week" direct ElasticSearch](https://github.com/QuesmaOrg/quesma/assets/10003183/7840969f-eca9-489a-95e9-1284e824be88)

however this discrepancy is currently being worked on by @pdelewski and this PR should not conflict with it.

