### PR TITLE
Add an example /_mapping http call

### DIFF
--- a/http_requests/_mapping.http
+++ b/http_requests/_mapping.http
@@ -1,0 +1,1 @@
+GET http://localhost:8080/kibana_sample_data_ecommerce/_mapping


### PR DESCRIPTION
Add an example `/_mapping` http call. 

It should be useful when used with the existing example `_field_caps` http call. 

`kibana_sample_data_ecommerce` was chosen in this example because it has a quite diverse mapping response.