### PR TITLE
Mark 'ip' type as aggregatable

### DIFF
--- a/quesma/schema/types.go
+++ b/quesma/schema/types.go
@@ -17,7 +17,7 @@ var (
 	TypeObject       = Type{Name: "object", Properties: []TypeProperty{Searchable}}
 	TypeArray        = Type{Name: "array", Properties: []TypeProperty{Searchable}}
 	TypeMap          = Type{Name: "map", Properties: []TypeProperty{Searchable}}
-	TypeIp           = Type{Name: "ip", Properties: []TypeProperty{Searchable}}
+	TypeIp           = Type{Name: "ip", Properties: []TypeProperty{Searchable, Aggregatable}}
 	TypePoint        = Type{Name: "point", Properties: []TypeProperty{Searchable, Aggregatable}}
 	TypeUnknown      = Type{Name: "unknown", Properties: []TypeProperty{Searchable}}
 )


### PR DESCRIPTION
`ip` data type should be marked as aggregatable

Before:
![Screenshot 2024-07-02 at 10 38 33](https://github.com/QuesmaOrg/quesma/assets/2182533/8e23c319-2804-4fd5-9fd1-329f714f9501)
After:
![image](https://github.com/QuesmaOrg/quesma/assets/2182533/480a8534-ac38-46ed-a9e4-eada5e44b859)
