### PR TITLE
kibana_sample_data_logs.extension as 'text' and not 'keyword'

### DIFF
--- a/docker/quesma/config/local-dev.yaml
+++ b/docker/quesma/config/local-dev.yaml
@@ -34,6 +34,7 @@ indexes:
       ip: "ip"
       clientip: "ip"
       geo::coordinates: "point"
+      extension: "text"
     aliases:
       timestamp:
         source: "timestamp"


### PR DESCRIPTION
The default Kibana dashboard expects `extension` to be of a `text` type and not `keyword`

Before:
![Screenshot 2024-07-02 at 10 59 29](https://github.com/QuesmaOrg/quesma/assets/2182533/d1040398-c01c-469c-9d49-0ec47b6f067e)

After:
![Screenshot 2024-07-02 at 11 00 27](https://github.com/QuesmaOrg/quesma/assets/2182533/d35ddcfc-01ef-4bd7-a1cf-27eee10a68bd)
