### PR TITLE
QueryTranslator needs an access to schema registry

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -13,6 +13,7 @@ import (
 	"quesma/model/typical_queries"
 	"quesma/queryparser/query_util"
 	"quesma/queryprocessor"
+	"quesma/schema"
 	"quesma/util"
 )
 
@@ -26,6 +27,7 @@ type ClickhouseQueryTranslator struct {
 	Ctx          context.Context
 
 	DateMathRenderer string // "clickhouse_interval" or "literal"  if not set, we use "clickhouse_interval"
+	SchemaRegistry   schema.Registry
 }
 
 var completionStatusOK = func() *int { value := 200; return &value }()

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -9,6 +9,7 @@ import (
 	"quesma/model"
 	"quesma/queryparser"
 	"quesma/quesma/types"
+	"quesma/schema"
 )
 
 // This is an extracted interface for query translation.
@@ -31,11 +32,11 @@ const (
 	QueryLanguageEQL     = "eql"
 )
 
-func NewQueryTranslator(ctx context.Context, language QueryLanguage, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string) (queryTranslator IQueryTranslator) {
+func NewQueryTranslator(ctx context.Context, language QueryLanguage, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, schemaRegistry schema.Registry) (queryTranslator IQueryTranslator) {
 	switch language {
 	case QueryLanguageEQL:
 		return &eql.ClickhouseEQLQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx}
 	default:
-		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer}
+		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer, SchemaRegistry: schemaRegistry}
 	}
 }

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -222,7 +222,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			return []byte{}, end_user_errors.ErrNoSuchTable.New(fmt.Errorf("can't load %s table", resolvedTableName)).Details("Table: %s", resolvedTableName)
 		}
 
-		queryTranslator := NewQueryTranslator(ctx, queryLanguage, table, q.logManager, q.DateMathRenderer)
+		queryTranslator := NewQueryTranslator(ctx, queryLanguage, table, q.logManager, q.DateMathRenderer, q.schemaRegistry)
 
 		queries, canParse, err := queryTranslator.ParseQuery(body)
 		if err != nil {


### PR DESCRIPTION
In order to do some semantic checks, `QueryTranslator` and as a consequence `QueryParser` needs to have an access to `schema registry`