### PR TITLE
Move telemetry headers from separate package

### DIFF
--- a/quesma/logger/log_sender.go
+++ b/quesma/logger/log_sender.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"quesma/telemetry/headers"
+	"quesma/telemetry"
 	"strconv"
 	"time"
 )
@@ -88,8 +88,8 @@ func (logSender *LogSender) sendLogs() error {
 		return err
 	}
 	req.Header.Set("Content-Type", "text/plain")
-	req.Header.Set(telemetry_headers.XTelemetryRemoteLog, "true") // value is arbitrary, just have to be non-empty
-	req.Header.Set(telemetry_headers.ClientId, logSender.ClientId)
+	req.Header.Set(telemetry.RemoteLogHeaderName, "true") // value is arbitrary, just have to be non-empty
+	req.Header.Set(telemetry.ClientIdHeaderName, logSender.ClientId)
 	resp, err := logSender.httpClient.Do(req)
 	if err != nil {
 		return err

--- a/quesma/telemetry/headers.go
+++ b/quesma/telemetry/headers.go
@@ -1,0 +1,10 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package telemetry
+
+// RemoteLogHeaderName informs the telemetry endpoint that the payload contains logs instead of classic phone home data.
+const RemoteLogHeaderName = "X-Telemetry-Remote-Log"
+
+// ClientIdHeaderName This header is used to identify the client in telemetry data.
+// It has been introduced after creating Quesma licensing module and it is obtained from a validated license.
+const ClientIdHeaderName = "X-Client-Id"

--- a/quesma/telemetry/headers/header.go
+++ b/quesma/telemetry/headers/header.go
@@ -1,7 +1,0 @@
-// Copyright Quesma, licensed under the Elastic License 2.0.
-// SPDX-License-Identifier: Elastic-2.0
-package telemetry_headers
-
-// XTelemetryRemoteLog Used to inform telemetry endpoint that the payload contains logs
-const XTelemetryRemoteLog = "X-Telemetry-Remote-Log"
-const ClientId = "X-Client-Id"

--- a/quesma/telemetry/phone_home.go
+++ b/quesma/telemetry/phone_home.go
@@ -16,8 +16,6 @@ import (
 	"os"
 	"quesma/buildinfo"
 	"quesma/health"
-	telemetry_headers "quesma/telemetry/headers"
-
 	"quesma/logger"
 	"quesma/quesma/config"
 	"quesma/quesma/recovery"
@@ -556,7 +554,7 @@ func (a *agent) phoneHomeRemoteEndpoint(ctx context.Context, body []byte) (err e
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", "quesma/"+buildinfo.Version)
-	request.Header.Set(telemetry_headers.ClientId, a.clientId)
+	request.Header.Set(ClientIdHeaderName, a.clientId)
 
 	resp, err := a.httpClient.Do(request)
 	if err != nil {
@@ -591,7 +589,7 @@ func (a *agent) phoneHomeLocalQuesma(ctx context.Context, body []byte) (err erro
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("User-Agent", "quesma/"+buildinfo.Version)
-	request.Header.Set(telemetry_headers.ClientId, a.clientId)
+	request.Header.Set(ClientIdHeaderName, a.clientId)
 
 	resp, err := a.httpClient.Do(request)
 	if err != nil {


### PR DESCRIPTION
IMO that whole package was unnecessary. 

Initially reported by @pivovarit in https://github.com/QuesmaOrg/quesma/pull/396#discussion_r1665613885