### PR TITLE
Handle gzip-compressed requests in the proxy

### DIFF
--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -363,8 +363,7 @@ func peekBody(r *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	contentEncoding := r.Header.Get("Content-Encoding")
-	switch contentEncoding {
+	switch r.Header.Get("Content-Encoding") {
 	case "":
 		// No compression, leaving reqBody as-is
 	case "gzip":


### PR DESCRIPTION
Before this change, Quesma did not decompress incoming requests that used gzip compression (`Content-Encoding: gzip`).

It turns out that Filebeat by default compresses its requests to Elastic (https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#compression-level-option). Those requests would not get decompressed, which caused the routing code to be unable to parse them and always decide to forward them to Elastic (instead of Clickhouse).

Fix the problem by extending peekBody to be able to decompress the incoming HTTP request.

After the fix Quesma can correctly handle Filebeat bulk insert requests with default Filebeat configuration (compression turned on).