### PR TITLE
Remove .env references from the official Docker Compose example

### DIFF
--- a/examples/kibana-sample-data/docker-compose.yml
+++ b/examples/kibana-sample-data/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   quesma:
     image: quesma:latest
-    # TODO remove once license server is implemented
-    env_file:
-      - .env
     environment:
       - QUESMA_elasticsearch_url=http://elasticsearch:9200
       - QUESMA_port=8080

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -1,6 +1,9 @@
 # Default for local-dev.yml
 mode: "dual-write-query-clickhouse"
 port: 8080  # public tcp port to listen for incoming traffic
+connectors:
+  ch:
+    type: "clickhouse-os"
 elasticsearch:
   #url: "http://localhost:9200"
   call: false


### PR DESCRIPTION
The official example should not require `.env` file