### PR TITLE
Terms aggregation - add support to 'missing' parameter

### DIFF
--- a/http_requests/search-terms-missing.http
+++ b/http_requests/search-terms-missing.http
@@ -1,0 +1,14 @@
+GET http://localhost:8080/windows_logs/_search
+Content-Type: application/json
+
+
+{
+  "aggs": {
+    "tags": {
+      "terms": {
+        "field": "registry::key",
+        "missing": "n/a"
+      }
+    }
+  }
+}

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2414,16 +2414,16 @@ var AggregationTests = []AggregationTestCase{
 			},
 		},
 		ExpectedSQLs: []string{
-			`SELECT "event.dataset", toInt64(toUnixTimestamp64Milli("@timestamp") / 60000), count() ` +
+			`SELECT COALESCE("event.dataset",'unknown'), toInt64(toUnixTimestamp64Milli("@timestamp") / 60000), count() ` +
 				`FROM ` + QuotedTableName + ` ` +
 				`WHERE ("@timestamp">parseDateTime64BestEffort('2024-01-25T14:53:59.033Z') AND "@timestamp"<=parseDateTime64BestEffort('2024-01-25T15:08:59.033Z')) ` +
-				`GROUP BY "event.dataset", toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) ` +
-				`ORDER BY "event.dataset", toInt64(toUnixTimestamp64Milli("@timestamp") / 60000)`,
-			`SELECT "event.dataset", count() FROM ` + QuotedTableName + ` ` +
+				`GROUP BY COALESCE("event.dataset",'unknown'), toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) ` +
+				`ORDER BY COALESCE("event.dataset",'unknown'), toInt64(toUnixTimestamp64Milli("@timestamp") / 60000)`,
+			`SELECT COALESCE("event.dataset",'unknown'), count() FROM ` + QuotedTableName + ` ` +
 				`WHERE ("@timestamp">parseDateTime64BestEffort('2024-01-25T14:53:59.033Z') ` +
 				`AND "@timestamp"<=parseDateTime64BestEffort('2024-01-25T15:08:59.033Z')) ` +
-				`GROUP BY "event.dataset" ` +
-				`ORDER BY "event.dataset"`,
+				`GROUP BY COALESCE("event.dataset",'unknown') ` +
+				`ORDER BY COALESCE("event.dataset",'unknown')`,
 		},
 	},
 	{ // [14], "old" test, also can be found in testdata/requests.go TestAsyncSearch[5]

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -727,18 +727,18 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 		"no comment yet",
 		model.SearchQueryInfo{Typ: model.Normal},
 		[]string{
-			`SELECT "event.dataset", ` +
+			`SELECT COALESCE("event.dataset",'unknown'), ` +
 				groupBySQL("@timestamp", clickhouse.DateTime64, time.Minute) +
 				`, count() FROM ` + QuotedTableName + ` ` +
 				`WHERE ("@timestamp".*parseDateTime64BestEffort('2024-01-25T1.:..:59.033Z') ` +
 				`AND "@timestamp".*parseDateTime64BestEffort('2024-01-25T1.:..:59.033Z')) ` +
-				`GROUP BY "event.dataset", ` + groupBySQL("@timestamp", clickhouse.DateTime64, time.Minute) + ` ` +
-				`ORDER BY "event.dataset", ` + groupBySQL("@timestamp", clickhouse.DateTime64, time.Minute),
-			`SELECT "event.dataset", count() FROM ` + QuotedTableName + ` ` +
+				`GROUP BY COALESCE("event.dataset",'unknown'), ` + groupBySQL("@timestamp", clickhouse.DateTime64, time.Minute) + ` ` +
+				`ORDER BY COALESCE("event.dataset",'unknown'), ` + groupBySQL("@timestamp", clickhouse.DateTime64, time.Minute),
+			`SELECT COALESCE("event.dataset",'unknown'), count() FROM ` + QuotedTableName + ` ` +
 				`WHERE ("@timestamp".*parseDateTime64BestEffort('2024-01-25T1.:..:59.033Z') ` +
 				`AND "@timestamp".*parseDateTime64BestEffort('2024-01-25T1.:..:59.033Z')) ` +
-				`GROUP BY "event.dataset" ` +
-				`ORDER BY "event.dataset"`,
+				`GROUP BY COALESCE("event.dataset",'unknown') ` +
+				`ORDER BY COALESCE("event.dataset",'unknown')`,
 		},
 		true,
 	},


### PR DESCRIPTION
It adds support to 'missing' parameter.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_missing_value_5

@trzysiek Please take a look.