### PR TITLE
Table autodiscovery

### DIFF
--- a/quesma/clickhouse/schema_loader.go
+++ b/quesma/clickhouse/schema_loader.go
@@ -115,9 +115,9 @@ func (sl *tableDiscovery) ReloadTableDefinitions() {
 				}
 			}
 			for tableName, conf := range configuredTables {
-				autoDiscoResults.WriteString(fmt.Sprintf("(table=[%s] timestampField=[%s]), ", tableName, conf.config.GetTimestampField()))
+				autoDiscoResults.WriteString(fmt.Sprintf("{table: %s, timestampField: %s}, ", tableName, conf.config.GetTimestampField()))
 			}
-			logger.Info().Msgf("Table auto-discovery results: %d tables found, %s", len(configuredTables), strings.TrimSuffix(autoDiscoResults.String(), ", "))
+			logger.Info().Msgf("Table auto-discovery results -> %d tables found: [%s]", len(configuredTables), strings.TrimSuffix(autoDiscoResults.String(), ", "))
 		} else {
 			for table, columns := range tables {
 				if indexConfig, found := sl.cfg.IndexConfig[table]; found {

--- a/quesma/clickhouse/schema_loader.go
+++ b/quesma/clickhouse/schema_loader.go
@@ -146,9 +146,9 @@ func (sl *tableDiscovery) autoConfigureTables(tables map[string]map[string]strin
 		createTableQuery := sl.SchemaManagement.createTableQuery(databaseName, table)
 		var maybeTimestampField string
 		if sl.cfg.Hydrolix.IsNonEmpty() {
-			maybeTimestampField = sl.SchemaManagement.tableTimestampField(databaseName, table, "hydrolix")
+			maybeTimestampField = sl.SchemaManagement.tableTimestampField(databaseName, table, Hydrolix)
 		} else {
-			maybeTimestampField = sl.SchemaManagement.tableTimestampField(databaseName, table, "clickhouse")
+			maybeTimestampField = sl.SchemaManagement.tableTimestampField(databaseName, table, ClickHouse)
 		}
 		if maybeTimestampField != "" {
 			configuredTables[table] = discoveredTable{columns, config.IndexConfiguration{TimestampField: &maybeTimestampField}, comment, createTableQuery}

--- a/quesma/clickhouse/schema_loader.go
+++ b/quesma/clickhouse/schema_loader.go
@@ -115,7 +115,7 @@ func (sl *tableDiscovery) ReloadTableDefinitions() {
 				}
 			}
 			for tableName, conf := range configuredTables {
-				autoDiscoResults.WriteString(fmt.Sprintf("(table=[%s] timestampField=[%s]), ", tableName, *conf.config.TimestampField))
+				autoDiscoResults.WriteString(fmt.Sprintf("(table=[%s] timestampField=[%s]), ", tableName, conf.config.GetTimestampField()))
 			}
 			logger.Info().Msgf("Table auto-discovery results: %d tables found, %s", len(configuredTables), strings.TrimSuffix(autoDiscoResults.String(), ", "))
 		} else {

--- a/quesma/clickhouse/schema_loader.go
+++ b/quesma/clickhouse/schema_loader.go
@@ -93,12 +93,13 @@ func (sl *tableDiscovery) ReloadTableDefinitions() {
 		return
 	} else {
 		if sl.cfg.IndexConfig == nil {
-			logger.Info().Msg("Index configuration empty, Quesma table auto-discovery starts")
+			logger.Info().Msg("Index configuration empty, running table auto-discovery")
 			for table, columns := range tables {
 				comment := sl.SchemaManagement.tableComment(databaseName, table)
 				createTableQuery := sl.SchemaManagement.createTableQuery(databaseName, table)
 				configuredTables[table] = discoveredTable{columns, config.IndexConfiguration{}, comment, createTableQuery}
 			}
+			logger.Info().Msgf("Table discovery results: tables=[%s]", strings.Join(util.MapKeys(configuredTables), ","))
 		} else {
 			for table, columns := range tables {
 				if indexConfig, found := sl.cfg.IndexConfig[table]; found {

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -40,7 +40,7 @@ func (s *SchemaManagement) readTables(database string) (map[string]map[string]st
 	return columnsPerTable, nil
 }
 
-func (s *SchemaManagement) tablePrimaryKey(database, table, dbKind string) (primaryKey string) {
+func (s *SchemaManagement) tableTimestampField(database, table, dbKind string) (primaryKey string) {
 	switch dbKind {
 	case "hydrolix":
 		return s.getTimestampFieldForHydrolix(database, table)

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -19,7 +19,7 @@ func NewSchemaManagement(chDb *sql.DB) *SchemaManagement {
 func (s *SchemaManagement) readTables(database string) (map[string]map[string]string, error) {
 	logger.Debug().Msgf("describing tables: %s", database)
 
-	rows, err := s.chDb.Query("SELECT table, name, type FROM system.columns WHERE database = ? AND database != 'system'", database)
+	rows, err := s.chDb.Query("SELECT table, name, type FROM system.columns WHERE database = ?", database)
 	if err != nil {
 		err = end_user_errors.GuessClickhouseErrorType(err).InternalDetails("reading list of columns from system.columns")
 		return map[string]map[string]string{}, err

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -12,6 +12,19 @@ type SchemaManagement struct {
 	chDb *sql.DB
 }
 
+//enum for dbKind
+
+type DbKind int
+
+const (
+	ClickHouse DbKind = iota //"clickhouse"
+	Hydrolix                 // = "hydrolix"
+)
+
+func (d DbKind) String() string {
+	return [...]string{"clickhouse", "hydrolix"}[d]
+}
+
 func NewSchemaManagement(chDb *sql.DB) *SchemaManagement {
 	return &SchemaManagement{chDb: chDb}
 }
@@ -40,15 +53,14 @@ func (s *SchemaManagement) readTables(database string) (map[string]map[string]st
 	return columnsPerTable, nil
 }
 
-func (s *SchemaManagement) tableTimestampField(database, table, dbKind string) (primaryKey string) {
+func (s *SchemaManagement) tableTimestampField(database, table string, dbKind DbKind) (primaryKey string) {
 	switch dbKind {
-	case "hydrolix":
+	case Hydrolix:
 		return s.getTimestampFieldForHydrolix(database, table)
-	case "clickhouse":
+	case ClickHouse:
 		return s.getTimestampFieldForClickHouse(database, table)
-	default:
-		return ""
 	}
+	return
 }
 
 func (s *SchemaManagement) getTimestampFieldForHydrolix(database, table string) (timestampField string) {

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -40,6 +40,14 @@ func (s *SchemaManagement) readTables(database string) (map[string]map[string]st
 	return columnsPerTable, nil
 }
 
+func (s *SchemaManagement) tablePrimaryKey(database, table string) (primaryKey string) {
+	if err := s.chDb.QueryRow("SELECT primary_key FROM system.tables WHERE database = ? and table = ? AND database != 'system'", database, table).Scan(&primaryKey); err != nil {
+		logger.Error().Msgf("could not get primary key for table %s: %v", table, err)
+	}
+	logger.Info().Msgf("primary key for table %s = %s", table, primaryKey)
+	return primaryKey
+}
+
 func (s *SchemaManagement) tableComment(database, table string) (comment string) {
 
 	err := s.chDb.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ? AND database != 'system'", database, table).Scan(&comment)

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -55,7 +55,7 @@ func (s *SchemaManagement) getTimestampFieldForHydrolix(database, table string) 
 	// In Hydrolix, there's always only one column in a table set as a primary timestamp
 	// Ref: https://docs.hydrolix.io/docs/transforms-and-write-schema#primary-timestamp
 	if err := s.chDb.QueryRow("SELECT primary_key FROM system.tables WHERE database = ? and table = ?", database, table).Scan(&timestampField); err != nil {
-		logger.Error().Msgf("failed fetching primary key for table %s: %v", table, err)
+		logger.Debug().Msgf("failed fetching primary key for table %s: %v", table, err)
 	}
 	return timestampField
 }
@@ -64,7 +64,7 @@ func (s *SchemaManagement) getTimestampFieldForClickHouse(database, table string
 	// In ClickHouse, there's no concept of a primary timestamp field, primary keys are often composite,
 	// hence we have to use following heuristic to determine the timestamp field (also just picking the first column if there are multiple)
 	if err := s.chDb.QueryRow("SELECT name FROM system.columns WHERE database = ? AND table = ? AND is_in_primary_key = 1 AND type iLIKE 'DateTime%'", database, table).Scan(&timestampField); err != nil {
-		logger.Error().Msgf("failed fetching primary key for table %s: %v", table, err)
+		logger.Debug().Msgf("failed fetching primary key for table %s: %v", table, err)
 		return
 	}
 	return timestampField

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -19,7 +19,7 @@ func NewSchemaManagement(chDb *sql.DB) *SchemaManagement {
 func (s *SchemaManagement) readTables(database string) (map[string]map[string]string, error) {
 	logger.Debug().Msgf("describing tables: %s", database)
 
-	rows, err := s.chDb.Query("SELECT table, name, type FROM system.columns WHERE database = ?", database)
+	rows, err := s.chDb.Query("SELECT table, name, type FROM system.columns WHERE database = ? AND database != 'system'", database)
 	if err != nil {
 		err = end_user_errors.GuessClickhouseErrorType(err).InternalDetails("reading list of columns from system.columns")
 		return map[string]map[string]string{}, err
@@ -42,7 +42,7 @@ func (s *SchemaManagement) readTables(database string) (map[string]map[string]st
 
 func (s *SchemaManagement) tableComment(database, table string) (comment string) {
 
-	err := s.chDb.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ? ", database, table).Scan(&comment)
+	err := s.chDb.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ? AND database != 'system'", database, table).Scan(&comment)
 
 	if err != nil {
 		logger.Error().Msgf("could not get table comment: %v", err)

--- a/quesma/clickhouse/schema_management.go
+++ b/quesma/clickhouse/schema_management.go
@@ -40,17 +40,39 @@ func (s *SchemaManagement) readTables(database string) (map[string]map[string]st
 	return columnsPerTable, nil
 }
 
-func (s *SchemaManagement) tablePrimaryKey(database, table string) (primaryKey string) {
-	if err := s.chDb.QueryRow("SELECT primary_key FROM system.tables WHERE database = ? and table = ? AND database != 'system'", database, table).Scan(&primaryKey); err != nil {
-		logger.Error().Msgf("could not get primary key for table %s: %v", table, err)
+func (s *SchemaManagement) tablePrimaryKey(database, table, dbKind string) (primaryKey string) {
+	switch dbKind {
+	case "hydrolix":
+		return s.getTimestampFieldForHydrolix(database, table)
+	case "clickhouse":
+		return s.getTimestampFieldForClickHouse(database, table)
+	default:
+		return ""
 	}
-	logger.Info().Msgf("primary key for table %s = %s", table, primaryKey)
-	return primaryKey
+}
+
+func (s *SchemaManagement) getTimestampFieldForHydrolix(database, table string) (timestampField string) {
+	// In Hydrolix, there's always only one column in a table set as a primary timestamp
+	// Ref: https://docs.hydrolix.io/docs/transforms-and-write-schema#primary-timestamp
+	if err := s.chDb.QueryRow("SELECT primary_key FROM system.tables WHERE database = ? and table = ?", database, table).Scan(&timestampField); err != nil {
+		logger.Error().Msgf("failed fetching primary key for table %s: %v", table, err)
+	}
+	return timestampField
+}
+
+func (s *SchemaManagement) getTimestampFieldForClickHouse(database, table string) (timestampField string) {
+	// In ClickHouse, there's no concept of a primary timestamp field, primary keys are often composite,
+	// hence we have to use following heuristic to determine the timestamp field (also just picking the first column if there are multiple)
+	if err := s.chDb.QueryRow("SELECT name FROM system.columns WHERE database = ? AND table = ? AND is_in_primary_key = 1 AND type iLIKE 'DateTime%'", database, table).Scan(&timestampField); err != nil {
+		logger.Error().Msgf("failed fetching primary key for table %s: %v", table, err)
+		return
+	}
+	return timestampField
 }
 
 func (s *SchemaManagement) tableComment(database, table string) (comment string) {
 
-	err := s.chDb.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ? AND database != 'system'", database, table).Scan(&comment)
+	err := s.chDb.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ?", database, table).Scan(&comment)
 
 	if err != nil {
 		logger.Error().Msgf("could not get table comment: %v", err)

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -30,6 +30,13 @@ func (c IndexConfiguration) HasFullTextField(fieldName string) bool {
 	return slices.Contains(c.FullTextFields, fieldName)
 }
 
+func (c IndexConfiguration) GetTimestampField() (tsField string) {
+	if c.TimestampField != nil {
+		tsField = *c.TimestampField
+	}
+	return
+}
+
 func (c IndexConfiguration) String() string {
 	var extraString string
 	extraString = ""


### PR DESCRIPTION
Adding table auto discovery logic. It's pretty basic for now, but should elevate customer experience when they first set up Quesma.

### How it works
Auto-discovery kicks in whenever `indexes` section in configuration is left empty. Additionally to tables, we try to detect a "timestamp field" via simple heuristics.