### PR TITLE
Remove deprecated DOCKER_BUILD_NO_SUMMARY flag

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         env:
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_SUMMARY: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,7 +91,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         env:
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_SUMMARY: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -126,7 +126,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
         env:
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_SUMMARY: false
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
             QUESMA_BUILD_SHA=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
         env:
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_SUMMARY: false


### PR DESCRIPTION
`DOCKER_BUILD_NO_SUMMARY` is deprecated. Setting `DOCKER_BUILD_SUMMARY` to `false` instead.