### PR TITLE
Quickfix: `must_not` generated incorrect SQL

### DIFF
--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -1203,9 +1203,9 @@ var TestsSearch = []SearchTestCase{
 			`SELECT "message" ` +
 				`FROM ` + QuotedTableName + ` ` +
 				`WHERE ("type"='upgrade-assistant-reindex-operation' ` +
-				`AND (NOT ((has("attributes_string_key","namespace") ` +
-				`AND "attributes_string_value"[indexOf("attributes_string_key","namespace")] IS NOT NULL)) ` +
-				`OR NOT ((has("attributes_string_key","namespaces") ` +
+				`AND NOT (((has("attributes_string_key","namespace") ` +
+				`AND "attributes_string_value"[indexOf("attributes_string_key","namespace")] IS NOT NULL) ` +
+				`OR (has("attributes_string_key","namespaces") ` +
 				`AND "attributes_string_value"[indexOf("attributes_string_key","namespaces")] IS NOT NULL))))`,
 		},
 	},

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -1194,7 +1194,10 @@ var TestsSearch = []SearchTestCase{
 			},
 			"track_total_hits": false
 		}`,
-		[]string{`("type"='upgrade-assistant-reindex-operation' AND (NOT ((has("attributes_string_key","namespace") AND "attributes_string_value"[indexOf("attributes_string_key","namespace")] IS NOT NULL)) OR NOT ((has("attributes_string_key","namespaces") AND "attributes_string_value"[indexOf("attributes_string_key","namespaces")] IS NOT NULL))))`},
+		[]string{
+			`("type"='upgrade-assistant-reindex-operation' AND NOT ` +
+				`(((has("attributes_string_key","namespace") AND "attributes_string_value"[indexOf("attributes_string_key","namespace")] IS NOT NULL) ` +
+				`OR (has("attributes_string_key","namespaces") AND "attributes_string_value"[indexOf("attributes_string_key","namespaces")] IS NOT NULL))))`},
 		model.ListAllFields,
 		////[]model.Query{
 		//	justSimplestWhere(`("type"='upgrade-assistant-reindex-operation' AND (NOT ((has("attributes_string_key","namespace") AND "attributes_string_value"[indexOf("attributes_string_key","namespace")] IS NOT NULL)) OR NOT ((has("attributes_string_key","namespaces") AND "attributes_string_value"[indexOf("attributes_string_key","namespaces")] IS NOT NULL))))`),


### PR DESCRIPTION
Simple error, we translated `must_not (a && b)` into `NOT a OR NOT b` which of course isn't correct. Changed it to `not (a or b)`.
Before (we should have 0 results as all `@timestamp`s fall into second `range`):
<img width="1495" alt="Cursor_and_Console_-_Dev_Tools_-_Elastic" src="https://github.com/QuesmaOrg/quesma/assets/5407146/c15e91bc-ef86-4753-b035-0709601d9ff1">
After:
<img width="1396" alt="Screenshot 2024-07-10 at 00 36 03" src="https://github.com/QuesmaOrg/quesma/assets/5407146/6218944c-67d5-4ea5-9ef0-e7c3c6e0cb7c">

Proof that it's indeed not a AND not b in Elastic: with one condition, we have >0 results, with 2 we have none, so it can't be OR like we used to have.
![Screenshot 2024-07-10 at 10 36 15](https://github.com/QuesmaOrg/quesma/assets/5407146/257004ab-1749-4ede-8509-9dcbe70b6c98)
![Screenshot 2024-07-10 at 10 36 23](https://github.com/QuesmaOrg/quesma/assets/5407146/38d19bae-ac94-465c-89a9-012420fe9a36)

