### PR TITLE
Add `_bulk` batch size logging

### DIFF
--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -26,7 +26,9 @@ func Write(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *cli
 	cfg config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []WriteResult) {
 	defer recovery.LogPanic()
 
-	indicesWithDocumentsToInsert := make(map[string][]types.JSON, len(bulk))
+	bulkSize := len(bulk)
+	logger.Info().Msgf("Processing %d documents in _bulk", bulkSize/2)
+	indicesWithDocumentsToInsert := make(map[string][]types.JSON, bulkSize)
 
 	err := bulk.BulkForEach(func(op types.BulkOperation, document types.JSON) {
 


### PR DESCRIPTION
As we've found out, the size of a bulk ingest payload is crucial to the ingest performance.

Hence, we should log this piece of information.