### PR TITLE
Hotfix `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.module }}/.
+          # when called from the main branch, `github.event.inputs.VERSION` doesn't use default value and is just empty
           tags: | 
             europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.sha }}
-            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION }}
-            quesma/quesma:${{ github.event.inputs.VERSION }}
+            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION || 'latest' }}
+            quesma/quesma:${{ github.event.inputs.VERSION || 'latest' }}
             quesma/quesma:latest
           # Pushes to GCR only for `main` branch builds, unless set explicitly in the job input
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.PUSH }}


### PR DESCRIPTION
A tiny fix to `release.yml`. 
I've thought that default input values are going to be used, but apparently that's not the case and for jobs triggered by a push to branch `github.event.inputs` is empty 

Ref: https://github.com/orgs/community/discussions/26322