### PR TITLE
Minor UI fixes

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -60,10 +60,10 @@ func EmptyAsyncSearchResponse(id string, isPartial bool, completionStatus int) (
 	return asyncSearchResp.Marshal() // error should never ever happen here
 }
 
-func (cw *ClickhouseQueryTranslator) MakeAsyncSearchResponse(ResultSet []model.QueryResultRow, query *model.Query, asyncRequestIdStr string, isPartial bool) (*model.AsyncSearchEntireResp, error) {
+func (cw *ClickhouseQueryTranslator) MakeAsyncSearchResponse(ResultSet []model.QueryResultRow, query *model.Query, asyncId string, isPartial bool) (*model.AsyncSearchEntireResp, error) {
 	searchResponse := cw.MakeSearchResponse([]*model.Query{query}, [][]model.QueryResultRow{ResultSet})
 	id := new(string)
-	*id = asyncRequestIdStr
+	*id = asyncId
 	response := model.AsyncSearchEntireResp{
 		Response:  *searchResponse,
 		ID:        id,
@@ -366,9 +366,9 @@ func (cw *ClickhouseQueryTranslator) MakeSearchResponse(queries []*model.Query, 
 	return response
 }
 
-func SearchToAsyncSearchResponse(searchResponse *model.SearchResp, asyncRequestIdStr string, isPartial bool, completionStatus int) *model.AsyncSearchEntireResp {
+func SearchToAsyncSearchResponse(searchResponse *model.SearchResp, asyncId string, isPartial bool, completionStatus int) *model.AsyncSearchEntireResp {
 	id := new(string)
-	*id = asyncRequestIdStr
+	*id = asyncId
 	response := model.AsyncSearchEntireResp{
 		Response:  *searchResponse,
 		ID:        id,

--- a/quesma/quesma/matchers.go
+++ b/quesma/quesma/matchers.go
@@ -8,12 +8,13 @@ import (
 	"quesma/quesma/config"
 	"quesma/quesma/mux"
 	"quesma/quesma/types"
+	"quesma/tracing"
 	"strings"
 )
 
 func matchedAgainstAsyncId() mux.RequestMatcher {
 	return mux.RequestMatcherFunc(func(req *mux.Request) bool {
-		if !strings.HasPrefix(req.Params["id"], quesmaAsyncIdPrefix) {
+		if !strings.HasPrefix(req.Params["id"], tracing.AsyncIdPrefix) {
 			logger.Debug().Msgf("async query id %s is forwarded to Elasticsearch", req.Params["id"])
 			return false
 		}

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	httpOk              = 200
-	quesmaAsyncIdPrefix = "quesma_async_search_id_"
+	httpOk = 200
 )
 
 func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *clickhouse.LogManager, console *ui.QuesmaManagementConsole, phoneHomeAgent telemetry.PhoneHomeAgent, queryRunner *QueryRunner) *mux.PathRouter {

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -285,7 +285,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			responseBody = []byte(fmt.Sprintf("Invalid Queries: %s, err: %v", queriesBody, err))
 			logger.ErrorWithCtxAndReason(ctx, "Quesma generated invalid SQL query").Msg(queriesBodyConcat)
 			bodyAsBytes, _ := body.Bytes()
-			pushSecondaryInfo(q.quesmaManagementConsole, id, path, bodyAsBytes, queriesBody, responseBody, startTime)
+			pushSecondaryInfo(q.quesmaManagementConsole, id, "", path, bodyAsBytes, queriesBody, responseBody, startTime)
 			return responseBody, errors.New(string(responseBody))
 		}
 
@@ -302,7 +302,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			} else {
 				responseBody, err = response.response.Marshal()
 			}
-			pushSecondaryInfo(q.quesmaManagementConsole, id, path, bodyAsBytes, response.translatedQueryBody, responseBody, startTime)
+			pushSecondaryInfo(q.quesmaManagementConsole, id, "", path, bodyAsBytes, response.translatedQueryBody, responseBody, startTime)
 			return responseBody, err
 		} else {
 			select {
@@ -346,6 +346,7 @@ func (q *QueryRunner) storeAsyncSearch(qmc *ui.QuesmaManagementConsole, id, asyn
 		bodyAsBytes, _ := body.Bytes()
 		qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 			Id:                     id,
+			AsyncId:                asyncRequestIdStr,
 			Path:                   path,
 			IncomingQueryBody:      bodyAsBytes,
 			QueryBodyTranslated:    result.translatedQueryBody,
@@ -359,6 +360,7 @@ func (q *QueryRunner) storeAsyncSearch(qmc *ui.QuesmaManagementConsole, id, asyn
 	bodyAsBytes, _ := body.Bytes()
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     id,
+		AsyncId:                asyncRequestIdStr,
 		Path:                   path,
 		IncomingQueryBody:      bodyAsBytes,
 		QueryBodyTranslated:    result.translatedQueryBody,
@@ -670,9 +672,10 @@ func (q *QueryRunner) postProcessResults(table *clickhouse.Table, results [][]mo
 	return geoIpTransformer.Transform(res)
 }
 
-func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, Path string, IncomingQueryBody []byte, QueryBodyTranslated [][]byte, QueryTranslatedResults []byte, startTime time.Time) {
+func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string, IncomingQueryBody []byte, QueryBodyTranslated [][]byte, QueryTranslatedResults []byte, startTime time.Time) {
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     Id,
+		AsyncId:                AsyncId,
 		Path:                   Path,
 		IncomingQueryBody:      IncomingQueryBody,
 		QueryBodyTranslated:    QueryBodyTranslated,

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -35,8 +35,6 @@ const (
 	asyncQueriesLimitBytes = 1024 * 1024 * 500 // 500MB
 )
 
-var asyncRequestId atomic.Int64
-
 type AsyncRequestResult struct {
 	responseBody []byte
 	added        time.Time

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -25,7 +25,6 @@ import (
 	"quesma/tracing"
 	"quesma/util"
 	"slices"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -122,7 +121,7 @@ func (q *QueryRunner) handleEQLSearch(ctx context.Context, indexPattern string, 
 func (q *QueryRunner) handleAsyncSearch(ctx context.Context, indexPattern string, body types.JSON,
 	waitForResultsMs int, keepOnCompletion bool) ([]byte, error) {
 	async := AsyncQuery{
-		asyncRequestIdStr: generateAsyncRequestId(),
+		asyncRequestIdStr: tracing.GetAsyncId(),
 		waitForResultsMs:  waitForResultsMs,
 		keepOnCompletion:  keepOnCompletion,
 		startTime:         time.Now(),
@@ -388,10 +387,6 @@ func (q *QueryRunner) asyncQueriesCumulatedBodySize() int {
 		return true
 	})
 	return size
-}
-
-func generateAsyncRequestId() string {
-	return "quesma_async_search_id_" + strconv.FormatInt(asyncRequestId.Add(1), 10)
 }
 
 func (q *QueryRunner) handlePartialAsyncSearch(ctx context.Context, id string) ([]byte, error) {

--- a/quesma/quesma/ui/dashboard.go
+++ b/quesma/quesma/ui/dashboard.go
@@ -211,7 +211,7 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 		buffer.Html(fmt.Sprintf(`<div class="status">Host uptime: %s</div>`, secondsToTerseString(h.Uptime)))
 	}
 
-	buffer.Html("<div>Version: ")
+	buffer.Html(`<div class="status">Version: `)
 	buffer.Text(buildinfo.Version)
 	buffer.Html("</div>")
 

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -30,12 +30,12 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 	}
 	qmc.mutex.Unlock()
 
-	logMessages, optAsyncId := generateLogMessages(request.logMessages, []string{})
+	logMessages := generateLogMessages(request.logMessages, []string{})
 
 	buffer := newBufferWithHead()
 	if requestFound {
-		if optAsyncId != nil {
-			buffer.Write(generateSimpleTop("Report for request id " + requestId + " and async id " + *optAsyncId))
+		if len(request.AsyncId) > 0 {
+			buffer.Write(generateSimpleTop("Report for request id " + requestId + " and async id " + request.AsyncId))
 		} else {
 			buffer.Write(generateSimpleTop("Report for request id " + requestId))
 		}
@@ -125,8 +125,8 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 		buffer.Html("<ul>\n")
 		buffer.Html("<li>").Text("Request id: ").Text(requestId).Html("</li>\n")
 		buffer.Html("<li>").Text("Path: ").Text(request.Path).Html("</li>\n")
-		if optAsyncId != nil {
-			buffer.Html("<li>").Text("Async id: ").Text(*optAsyncId).Html("</li>\n")
+		if len(request.AsyncId) > 0 {
+			buffer.Html("<li>").Text("Async id: ").Text(request.AsyncId).Html("</li>\n")
 		}
 		if request.unsupported != nil {
 			buffer.Html("<li>").Text("Unsupported: ").Text(*request.unsupported).Html("</li>\n")
@@ -161,7 +161,7 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 
 // links might be empty, then table won't have any links within.
 // if i < len(logMessages) && i < len(links) then logMessages[i] will have link links[i]
-func generateLogMessages(logMessages []string, links []string) ([]byte, *string) {
+func generateLogMessages(logMessages []string, links []string) []byte {
 	// adds a link to the table row if there is a link for it
 	addOpeningLink := func(row, column int) string {
 		if row < len(links) {
@@ -191,8 +191,6 @@ func generateLogMessages(logMessages []string, links []string) ([]byte, *string)
 
 	buffer.Html("</thead>\n")
 	buffer.Html("<tbody>\n")
-
-	var asyncId *string
 
 	for i, logMessage := range logMessages {
 		buffer.Html("<tr>\n")
@@ -235,10 +233,7 @@ func generateLogMessages(logMessages []string, links []string) ([]byte, *string)
 
 		// get rid of request_id and async_id
 		delete(fields, "request_id")
-		if id, ok := fields["async_id"].(string); ok {
-			asyncId = &id
-			delete(fields, "async_id")
-		}
+		delete(fields, "async_id")
 
 		// message
 		buffer.Html(`<td class="message">` + addOpeningLink(i, 2))
@@ -258,7 +253,7 @@ func generateLogMessages(logMessages []string, links []string) ([]byte, *string)
 
 	buffer.Html("</tbody>\n")
 	buffer.Html("</table>\n")
-	return buffer.Bytes(), asyncId
+	return buffer.Bytes()
 }
 
 func (qmc *QuesmaManagementConsole) generateReportForRequestsWithStr(requestStr string) []byte {

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -8,13 +8,26 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v3"
 	"quesma/quesma/ui/internal/builder"
+	"quesma/tracing"
 	"quesma/util"
 	"strings"
 )
 
 func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string) []byte {
+	var request queryDebugInfo
+	var requestFound bool
 	qmc.mutex.Lock()
-	request, requestFound := qmc.debugInfoMessages[requestId]
+	if strings.HasPrefix(requestId, tracing.AsyncIdPrefix) {
+		for _, debugInfo := range qmc.debugInfoMessages {
+			if debugInfo.AsyncId == requestId {
+				request = debugInfo
+				requestFound = true
+				break
+			}
+		}
+	} else {
+		request, requestFound = qmc.debugInfoMessages[requestId]
+	}
 	qmc.mutex.Unlock()
 
 	logMessages, optAsyncId := generateLogMessages(request.logMessages, []string{})

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -76,8 +76,7 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 
 		buffer.Html(`<div class="quesma-response">` + "\n")
 		if len(request.QueryDebugSecondarySource.QueryTranslatedResults) > 0 {
-			tookStr := fmt.Sprintf(" took %d ms:", request.SecondaryTook.Milliseconds())
-			buffer.Html("<p class=\"title\">Quesma response").Text(tookStr).Html("</p>\n")
+			buffer.Html("<p class=\"title\">Quesma response").Html("</p>\n")
 			buffer.Html(`<pre>`)
 			buffer.Text(string(request.QueryDebugSecondarySource.QueryTranslatedResults))
 			buffer.Html("\n</pre>")
@@ -119,6 +118,8 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 		if request.unsupported != nil {
 			buffer.Html("<li>").Text("Unsupported: ").Text(*request.unsupported).Html("</li>\n")
 		}
+		tookStr := fmt.Sprintf("Took: %d ms", request.SecondaryTook.Milliseconds())
+		buffer.Html("<li>").Text(tookStr).Html("</li>")
 		buffer.Html("</ul>\n")
 	}
 

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -43,7 +43,8 @@ type QueryDebugPrimarySource struct {
 }
 
 type QueryDebugSecondarySource struct {
-	Id string
+	Id      string
+	AsyncId string
 
 	Path              string
 	IncomingQueryBody []byte
@@ -179,6 +180,7 @@ func (qmc *QuesmaManagementConsole) processChannelMessage() {
 		// fmt.Println(msg.IncomingQueryBody)
 		secondaryDebugInfo := QueryDebugSecondarySource{
 			msg.Id,
+			msg.AsyncId,
 			msg.Path,
 			[]byte(util.JsonPrettify(string(msg.IncomingQueryBody), true)),
 			msg.QueryBodyTranslated,

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -5302,7 +5302,7 @@ var AggregationTests = []AggregationTestCase{
 			"completion_status": 200,
 			"completion_time_in_millis": 0,
 			"expiration_time_in_millis": 0,
-			"id": "quesma_async_search_id_17",
+			"id": "quesma_async_17",
 			"is_partial": false,
 			"is_running": false,
 			"response": {

--- a/quesma/testdata/facets_requests.go
+++ b/quesma/testdata/facets_requests.go
@@ -79,7 +79,7 @@ var TestsNumericFacets = []struct {
 			"completion_status": 200,
 			"completion_time_in_millis": 0,
 			"expiration_time_in_millis": 0,
-			"id": "quesma_async_search_id_19",
+			"id": "quesma_async_19",
 			"is_partial": false,
 			"is_running": false,
 			"response": {
@@ -207,7 +207,7 @@ var TestsNumericFacets = []struct {
 			"completion_status": 200,
 			"completion_time_in_millis": 0,
 			"expiration_time_in_millis": 0,
-			"id": "quesma_async_search_id_19",
+			"id": "quesma_async_19",
 			"is_partial": false,
 			"is_running": false,
 			"response": {
@@ -338,7 +338,7 @@ var TestsNumericFacets = []struct {
 			"completion_status": 200,
 			"completion_time_in_millis": 0,
 			"expiration_time_in_millis": 0,
-			"id": "quesma_async_search_id_19",
+			"id": "quesma_async_19",
 			"is_partial": false,
 			"is_running": false,
 			"response": {
@@ -466,7 +466,7 @@ var TestsNumericFacets = []struct {
 			"completion_status": 200,
 			"completion_time_in_millis": 0,
 			"expiration_time_in_millis": 0,
-			"id": "quesma_async_search_id_19",
+			"id": "quesma_async_19",
 			"is_partial": false,
 			"is_running": false,
 			"response": {

--- a/quesma/tracing/async_trace_logger_test.go
+++ b/quesma/tracing/async_trace_logger_test.go
@@ -25,11 +25,11 @@ func initializeLogger(asyncQueryHook *AsyncTraceLogger) zerolog.Logger {
 func TestAsyncTraceLogger_OneTransactionWithError(t *testing.T) {
 	asyncQueryHook := AsyncTraceLogger{AsyncQueryTrace: concurrent.NewMap[string, TraceCtx]()}
 	logger := initializeLogger(&asyncQueryHook)
-	ctx := context.WithValue(context.Background(), AsyncIdCtxKey, "quesma_async_search_id_1")
+	ctx := context.WithValue(context.Background(), AsyncIdCtxKey, "quesma_async_1")
 	logger.Info().Ctx(ctx).Msg("Start async search")
 	logger.Info().Ctx(ctx).Msg("Continue async search")
 	assert.Equal(t, 1, asyncQueryHook.AsyncQueryTrace.Size())
-	if traceCtx, ok := asyncQueryHook.AsyncQueryTrace.Load("quesma_async_search_id_1"); ok {
+	if traceCtx, ok := asyncQueryHook.AsyncQueryTrace.Load("quesma_async_1"); ok {
 		assert.Equal(t, 2, len(traceCtx.Messages))
 	}
 	logger.Error().Ctx(ctx).Msg("Error in async search")
@@ -39,11 +39,11 @@ func TestAsyncTraceLogger_OneTransactionWithError(t *testing.T) {
 func TestAsyncTraceLogger_OneTransactionOk(t *testing.T) {
 	asyncQueryHook := AsyncTraceLogger{AsyncQueryTrace: concurrent.NewMap[string, TraceCtx]()}
 	logger := initializeLogger(&asyncQueryHook)
-	ctx := context.WithValue(context.Background(), AsyncIdCtxKey, "quesma_async_search_id_1")
+	ctx := context.WithValue(context.Background(), AsyncIdCtxKey, "quesma_async_1")
 	logger.Info().Ctx(ctx).Msg("Start async search")
 	logger.Info().Ctx(ctx).Msg("Continue async search")
 	assert.Equal(t, 1, asyncQueryHook.AsyncQueryTrace.Size())
-	if traceCtx, ok := asyncQueryHook.AsyncQueryTrace.Load("quesma_async_search_id_1"); ok {
+	if traceCtx, ok := asyncQueryHook.AsyncQueryTrace.Load("quesma_async_1"); ok {
 		assert.Equal(t, 2, len(traceCtx.Messages))
 	}
 	ctx = context.WithValue(ctx, TraceEndCtxKey, true)

--- a/quesma/tracing/context.go
+++ b/quesma/tracing/context.go
@@ -15,6 +15,8 @@ const (
 	RequestPath     ContextKey = "RequestPath"
 	AsyncIdCtxKey   ContextKey = "AsyncId"
 	TraceEndCtxKey  ContextKey = "TraceEnd"
+
+	AsyncIdPrefix = "quesma_async_"
 )
 
 func (c ContextKey) AsString() string {
@@ -35,5 +37,9 @@ func NewContextWithRequest(existingCtx context.Context) context.Context {
 }
 
 func GetRequestId() string {
-	return uuid.New().String()
+	return uuid.Must(uuid.NewV7()).String()
+}
+
+func GetAsyncId() string {
+	return AsyncIdPrefix + uuid.Must(uuid.NewV7()).String()
 }


### PR DESCRIPTION
@avelanarius requested change, be able to search by `quesma_async_...`. Now you can check the dashboard ID of the response and then find a matching one in Quesma.

While there, I added two minor styles, one in the dashboard and the other in total time.