### PR TITLE
Fix handling of gzip-compressed requests in transparent proxy case 

### DIFF
--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -363,7 +363,8 @@ func peekBody(r *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	switch r.Header.Get("Content-Encoding") {
+	contentEncoding := r.Header.Get("Content-Encoding")
+	switch contentEncoding {
 	case "":
 		// No compression, leaving reqBody as-is
 	case "gzip":
@@ -375,7 +376,7 @@ func peekBody(r *http.Request) ([]byte, error) {
 		}
 	default:
 		logger.ErrorWithCtxAndReason(r.Context(), "unsupported Content-Encoding type").
-			Msgf("Unsupported Content-Encoding type: %v", err)
+			Msgf("Unsupported Content-Encoding type: %s", contentEncoding)
 		return nil, errors.New("unsupported Content-Encoding type")
 	}
 

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -379,6 +379,7 @@ func peekBody(r *http.Request) ([]byte, error) {
 			Msgf("Unsupported Content-Encoding type: %s", contentEncoding)
 		return nil, errors.New("unsupported Content-Encoding type")
 	}
+	r.Header.Del("Content-Encoding") // In the transparent proxy case we will send an uncompressed body, so the header should be removed
 
 	r.Body = io.NopCloser(bytes.NewBuffer(reqBody))
 	return reqBody, nil


### PR DESCRIPTION
In commit 9b9be28602 `peekBody` was extended to handle compressed requests by decompressing them.

This worked well in case of Quesma handling the request on its own (sending to ClickHouse). However, if Quesma decides to route the query to ElasticSearch ("transparent proxy case") it will attempt to send the uncompressed body with the original headers, which includes `Content-Encoding: gzip` header. The receiver (Elastic) then errored out trying to decompress an uncompressed body.

Fix the problem by removing the `Content-Encoding` header after decompression.

I manually tested the code with Filebeat: compressed/uncompressed traffic to both Elastic via Quesma and to ClickHouse via Quesma. Previously the compressed traffic to Elastic via Quesma would error out, but this change solves it.

Additionally fix one copy-paste error in error string formatting.