### PR TITLE
Simplify json rendering refactor

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -8,7 +8,6 @@ import (
 	"quesma/logger"
 	"quesma/model"
 	"quesma/model/bucket_aggregations"
-	"quesma/model/metrics_aggregations"
 	"quesma/model/typical_queries"
 	"quesma/queryparser/query_util"
 	"quesma/queryprocessor"
@@ -83,21 +82,12 @@ func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query *mod
 	// check if we finish
 	if aggregatorsLevel == len(query.Aggregators) {
 		result := query.Type.TranslateSqlResponseToJson(ResultSet, selectLevel)
-		if query.Type.IsBucketAggregation() {
-			if len(result) == 1 { // maybe I fix other bug
-				return result[0]
-			} else {
-				return model.JsonMap{
-					"buckets": result,
-				}
-			}
-		} else {
-			if _, isTopHits := query.Type.(metrics_aggregations.TopHits); isTopHits {
-				return model.JsonMap{
-					"hits": result[0],
-				}
-			}
+		if !query.Type.IsBucketAggregation() || len(result) == 1 {
 			return result[0]
+		} else {
+			return model.JsonMap{
+				"buckets": result,
+			}
 		}
 	}
 

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -96,22 +96,17 @@ func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query *mod
 	}
 
 	// either we finish
-	if query.Type.IsBucketAggregation() {
-		if aggregatorsLevel == len(query.Aggregators) {
+	if aggregatorsLevel == len(query.Aggregators) {
+		if query.Type.IsBucketAggregation() {
 			return query.Type.TranslateSqlResponseToJson(ResultSet, selectLevel)
-		}
-	} else {
-		if aggregatorsLevel == len(query.Aggregators)-1 {
+		} else {
 			result := query.Type.TranslateSqlResponseToJson(ResultSet, selectLevel)[0]
-			lastAggregator := query.Aggregators[len(query.Aggregators)-1].Name
 			if _, isTopHits := query.Type.(metrics_aggregations.TopHits); isTopHits {
 				result = model.JsonMap{
 					"hits": result,
 				}
 			}
-			return []model.JsonMap{{
-				lastAggregator: result,
-			}}
+			return []model.JsonMap{result}
 		}
 	}
 

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -129,10 +129,8 @@ func (cw *ClickhouseQueryTranslator) makeResponseAggregationRecursive(query *mod
 		buckets := qp.SplitResultSetIntoBuckets(ResultSet, selectLevel+weSplitOverHowManyFields)
 		for _, bucket := range buckets {
 			newBuckets := cw.makeResponseAggregationRecursive(query, bucket, aggregatorsLevel+1, selectLevel+weSplitOverHowManyFields)
-			if len(bucket) > 0 {
-				for _, newBucket := range newBuckets {
-					newBucket[model.KeyAddedByQuesma] = bucket[0].Cols[selectLevel].Value
-				}
+			for _, newBucket := range newBuckets {
+				newBucket[model.KeyAddedByQuesma] = bucket[0].Cols[selectLevel].Value
 			}
 			bucketsReturnMap = append(bucketsReturnMap, newBuckets...)
 		}

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -184,7 +184,7 @@ func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []*mo
 		}
 		aggregation := cw.makeResponseAggregationRecursive(query, ResultSets[i], 0, 0)
 		if len(aggregation) != 0 {
-			aggregations = util.MergeMaps(cw.Ctx, aggregations, aggregation, model.KeyAddedByQuesma) // result of root node is always a single map, thus [0]
+			aggregations = util.MergeMaps(cw.Ctx, aggregations, aggregation, model.KeyAddedByQuesma)
 		}
 	}
 	return aggregations


### PR DESCRIPTION
Another stepping stone toward unifying rendering json:
- Make JSON rendering step more consistent, stop at the same level
- the logic is much shorter
- do not pass array with one element

@trzysiek should review