### PR TITLE
Add optimization pipeline

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -136,7 +136,6 @@ func executeQuery(ctx context.Context, lm *LogManager, query *model.Query, field
 	settings["allow_ddl"] = "0"
 
 	if query.OptimizeHints != nil {
-		fmt.Println("Applying performance settings", query.OptimizeHints.Settings)
 		for k, v := range query.OptimizeHints.Settings {
 			settings[k] = v
 		}

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -11,9 +11,17 @@ const (
 	noLimit             = 0
 )
 
+// QueryOptimizeHints contains hints for query execution, e.g. peformance settings, temparaty table usage
+type QueryOptimizeHints struct {
+	Settings               map[string]any
+	OptimizationsPerformed []string
+}
+
 type (
 	Query struct {
 		SelectCommand SelectCommand // The representation of SELECT query
+
+		OptimizeHints *QueryOptimizeHints // it can be optional
 
 		Type      QueryType
 		TableName string
@@ -43,6 +51,10 @@ type (
 		String() string
 	}
 )
+
+func NewQueryExecutionHints() *QueryOptimizeHints {
+	return &QueryOptimizeHints{Settings: make(map[string]any)}
+}
 
 func NewSortColumn(field string, direction OrderByDirection) OrderByExpr {
 	return NewOrderByExpr([]Expr{NewColumnRef(field)}, direction)

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -11,7 +11,7 @@ const (
 	noLimit             = 0
 )
 
-// QueryOptimizeHints contains hints for query execution, e.g. peformance settings, temparaty table usage
+// QueryOptimizeHints contains hints for query execution, e.g., performance settings, temporary table usage
 type QueryOptimizeHints struct {
 	Settings               map[string]any
 	OptimizationsPerformed []string

--- a/quesma/optimize/cache_group_by.go
+++ b/quesma/optimize/cache_group_by.go
@@ -1,0 +1,35 @@
+package optimize
+
+import "quesma/model"
+
+// cacheGroupByQueries - a transformer that suggests db to cache the query results
+//
+// It's done by adding settings to the query
+//
+// https://clickhouse.com/docs/en/operations/query-cache
+//
+// Cached queries can be examined with:
+//
+// select * from system.query_cache
+//
+// Cache can be dropped with
+//
+//  SYSTEM DROP QUERY CACHE
+//
+
+type cacheGroupByQueries struct {
+}
+
+func (s *cacheGroupByQueries) Transform(queries []*model.Query) ([]*model.Query, error) {
+
+	for _, query := range queries {
+
+		// TODO add better detection
+		// TODO add CTE here
+		if len(query.SelectCommand.GroupBy) > 0 {
+			query.OptimizeHints.Settings["use_query_cache"] = true
+			query.OptimizeHints.OptimizationsPerformed = append(query.OptimizeHints.OptimizationsPerformed, "cacheGroupByQueries")
+		}
+	}
+	return queries, nil
+}

--- a/quesma/optimize/cache_group_by.go
+++ b/quesma/optimize/cache_group_by.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package optimize
 
 import "quesma/model"

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -1,0 +1,45 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package optimize
+
+import (
+	"quesma/model"
+	"quesma/plugins"
+	"time"
+)
+
+// OptimizePipeline - a transformer that optimizes queries
+type OptimizePipeline struct {
+	optimizations []plugins.QueryTransformer
+}
+
+func NewOptimizePipeline() plugins.QueryTransformer {
+
+	return &OptimizePipeline{
+		optimizations: []plugins.QueryTransformer{
+			&truncateDate{truncateTo: 5 * time.Minute},
+			&cacheGroupByQueries{},
+		},
+	}
+}
+
+func (s *OptimizePipeline) Transform(queries []*model.Query) ([]*model.Query, error) {
+
+	// add  hints if not present
+	for _, query := range queries {
+		if query.OptimizeHints == nil {
+			query.OptimizeHints = model.NewQueryExecutionHints()
+		}
+	}
+
+	// run optimizations on queries
+	for _, optimization := range s.optimizations {
+		var err error
+		queries, err = optimization.Transform(queries)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return queries, nil
+}

--- a/quesma/optimize/pipeline_test.go
+++ b/quesma/optimize/pipeline_test.go
@@ -117,12 +117,12 @@ func Test_dateTrunc(t *testing.T) {
 			model.SelectCommand{
 				Columns:     []model.Expr{model.NewColumnRef("*")},
 				FromClause:  model.NewTableRef("foo"),
-				WhereClause: date("2024-06-04T13:05:00Z"),
+				WhereClause: date("2024-06-04T13:08:53.675Z"),
 			},
 		},
 
 		{
-			"select all where and between dates",
+			"select all where and between dates (>24h)",
 			model.SelectCommand{
 				Columns:     []model.Expr{model.NewColumnRef("*")},
 				FromClause:  model.NewTableRef("foo"),
@@ -131,7 +131,21 @@ func Test_dateTrunc(t *testing.T) {
 			model.SelectCommand{
 				Columns:     []model.Expr{model.NewColumnRef("*")},
 				FromClause:  model.NewTableRef("foo"),
-				WhereClause: and(gt(col("a"), date("2024-06-04T13:05:00Z")), lt(col("a"), date("2024-06-06T13:10:00Z"))),
+				WhereClause: and(gt(col("a"), date("2024-06-04T13:05:00Z")), lt(col("a"), date("2024-06-06T13:15:00Z"))),
+			},
+		},
+
+		{
+			"select all where and between dates (<24h)",
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: and(gt(col("a"), date("2024-06-06T10:08:53.675Z")), lt(col("a"), date("2024-06-06T13:10:53.675Z"))),
+			},
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: and(gt(col("a"), date("2024-06-06T10:08:53.675Z")), lt(col("a"), date("2024-06-06T13:10:53.675Z"))),
 			},
 		},
 

--- a/quesma/optimize/pipeline_test.go
+++ b/quesma/optimize/pipeline_test.go
@@ -1,0 +1,179 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package optimize
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"quesma/model"
+	"testing"
+)
+
+func Test_cacheGroupBy(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		shouldCache bool
+		query       model.SelectCommand
+	}{
+		{
+			"select all",
+			false,
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("*")},
+				FromClause: model.NewTableRef("foo"),
+			},
+		},
+
+		{
+			"select a, count() from foo  group by 1",
+			true,
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("a"), model.NewFunction("count", model.NewColumnRef("*"))},
+				FromClause: model.NewTableRef("foo"),
+				GroupBy:    []model.Expr{model.NewLiteral(1)},
+			},
+		},
+		// Add CTE here
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			queries := []*model.Query{
+				{
+					SelectCommand: tt.query,
+				},
+			}
+			pipeline := NewOptimizePipeline()
+			optimized, err := pipeline.Transform(queries)
+			if err != nil {
+				t.Fatalf("error optimizing query: %v", err)
+			}
+
+			if len(optimized) != 1 {
+				t.Fatalf("expected 1 query, got %d", len(optimized))
+			}
+
+			var enabled bool
+			if optimized[0].OptimizeHints.Settings["use_query_cache"] != nil {
+				enabled = optimized[0].OptimizeHints.Settings["use_query_cache"].(bool)
+			}
+
+			assert.Truef(t, enabled == tt.shouldCache, "expected use_query_cache to be %v, got %v", tt.shouldCache, enabled)
+
+		})
+
+	}
+}
+
+func Test_dateTrunc(t *testing.T) {
+
+	date := func(s string) model.Expr {
+		return model.NewFunction("parseDateTime64BestEffort", model.NewLiteral(fmt.Sprintf("'%s'", s)))
+	}
+
+	and := func(a, b model.Expr) model.Expr {
+		return model.NewInfixExpr(a, "and", b)
+	}
+
+	lt := func(a, b model.Expr) model.Expr {
+		return model.NewInfixExpr(a, "<", b)
+	}
+
+	gt := func(a, b model.Expr) model.Expr {
+		return model.NewInfixExpr(a, ">", b)
+	}
+
+	col := func(s string) model.Expr {
+		return model.NewColumnRef(s)
+	}
+
+	tests := []struct {
+		name     string
+		query    model.SelectCommand
+		expected model.SelectCommand
+	}{
+		{
+			"select all",
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("*")},
+				FromClause: model.NewTableRef("foo"),
+			},
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("*")},
+				FromClause: model.NewTableRef("foo"),
+			},
+		},
+
+		{
+			"select all where date ",
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: date("2024-06-04T13:08:53.675Z"),
+			},
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: date("2024-06-04T13:05:00Z"),
+			},
+		},
+
+		{
+			"select all where and between dates",
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: and(gt(col("a"), date("2024-06-04T13:08:53.675Z")), lt(col("a"), date("2024-06-06T13:10:53.675Z"))),
+			},
+			model.SelectCommand{
+				Columns:     []model.Expr{model.NewColumnRef("*")},
+				FromClause:  model.NewTableRef("foo"),
+				WhereClause: and(gt(col("a"), date("2024-06-04T13:05:00Z")), lt(col("a"), date("2024-06-06T13:10:00Z"))),
+			},
+		},
+
+		{
+			"select a, count() from foo  group by 1",
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("a"), model.NewFunction("count", model.NewColumnRef("*"))},
+				FromClause: model.NewTableRef("foo"),
+				GroupBy:    []model.Expr{model.NewLiteral(1)},
+			},
+			model.SelectCommand{
+				Columns:    []model.Expr{model.NewColumnRef("a"), model.NewFunction("count", model.NewColumnRef("*"))},
+				FromClause: model.NewTableRef("foo"),
+				GroupBy:    []model.Expr{model.NewLiteral(1)},
+			},
+		},
+		// Add CTE here
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			queries := []*model.Query{
+				{
+					SelectCommand: tt.query,
+				},
+			}
+			pipeline := NewOptimizePipeline()
+			optimized, err := pipeline.Transform(queries)
+
+			if err != nil {
+				t.Fatalf("error optimizing query: %v", err)
+			}
+
+			if len(optimized) != 1 {
+				t.Fatalf("expected 1 query, got %d", len(optimized))
+			}
+
+			assert.Equal(t, tt.expected, optimized[0].SelectCommand)
+
+		})
+
+	}
+}

--- a/quesma/optimize/trunc_date.go
+++ b/quesma/optimize/trunc_date.go
@@ -1,0 +1,197 @@
+package optimize
+
+import (
+	"fmt"
+	"quesma/logger"
+	"quesma/model"
+	"strings"
+	"time"
+)
+
+type truncateDateVisitor struct {
+	truncateTo time.Duration
+	truncated  bool
+}
+
+func (v *truncateDateVisitor) visitChildren(args []model.Expr) []model.Expr {
+	var newArgs []model.Expr
+	for _, arg := range args {
+		if arg != nil {
+			newArgs = append(newArgs, arg.Accept(v).(model.Expr))
+		}
+	}
+	return newArgs
+}
+
+func (v *truncateDateVisitor) VisitLiteral(e model.LiteralExpr) interface{} {
+
+	switch v := e.Value.(type) {
+
+	case string:
+		// "2024-06-04T13:08:53.675Z"
+		//
+		if strings.HasPrefix(v, "2024-") {
+			logger.Warn().Msgf("not handled date to truncate: '%s'. This can be a bug.", v)
+		}
+
+	default:
+		return e
+	}
+
+	return e
+}
+
+func (v *truncateDateVisitor) VisitInfix(e model.InfixExpr) interface{} {
+	left := e.Left.Accept(v).(model.Expr)
+	right := e.Right.Accept(v).(model.Expr)
+
+	return model.NewInfixExpr(left, e.Op, right)
+}
+
+func (v *truncateDateVisitor) VisitPrefixExpr(e model.PrefixExpr) interface{} {
+	args := v.visitChildren(e.Args)
+	return model.NewPrefixExpr(e.Op, args)
+
+}
+
+func (v *truncateDateVisitor) VisitFunction(e model.FunctionExpr) interface{} {
+
+	// TODO what other functions should we handle?
+	if e.Name == "parseDateTime64BestEffort" {
+
+		if len(e.Args) == 1 {
+
+			//"2024-06-04T13:08:53.675Z" -> "2024-06-04T13:08:00.000Z"
+
+			if date, ok := e.Args[0].(model.LiteralExpr); ok {
+				if dateStr, ok := date.Value.(string); ok {
+
+					dateStr = strings.Trim(dateStr, "'")
+
+					// Parse the date string into a time.Time object
+					d, err := time.Parse(time.RFC3339, dateStr)
+					if err != nil {
+						// can parse the date, return the original expression
+					} else {
+						truncatedDate := d.Truncate(v.truncateTo)
+						truncatedDateStr := truncatedDate.Format(time.RFC3339)
+						v.truncated = true
+
+						fmt.Println("DATE TRUNCATED: ", d, " -> ", truncatedDateStr)
+						return model.NewFunction(e.Name, model.NewLiteral(fmt.Sprintf("'%s'", truncatedDateStr)))
+					}
+				}
+			}
+		}
+	}
+
+	args := v.visitChildren(e.Args)
+	return model.NewFunction(e.Name, args...)
+}
+
+func (v *truncateDateVisitor) VisitColumnRef(e model.ColumnRef) interface{} {
+	return e
+}
+
+func (v *truncateDateVisitor) VisitNestedProperty(e model.NestedProperty) interface{} {
+	return model.NestedProperty{
+		ColumnRef:    e.ColumnRef.Accept(v).(model.ColumnRef),
+		PropertyName: e.PropertyName.Accept(v).(model.LiteralExpr),
+	}
+}
+
+func (v *truncateDateVisitor) VisitArrayAccess(e model.ArrayAccess) interface{} {
+	return model.ArrayAccess{
+		ColumnRef: e.ColumnRef.Accept(v).(model.ColumnRef),
+		Index:     e.Index.Accept(v).(model.Expr),
+	}
+}
+
+func (v *truncateDateVisitor) VisitMultiFunction(e model.MultiFunctionExpr) interface{} {
+	args := v.visitChildren(e.Args)
+	return model.MultiFunctionExpr{Name: e.Name, Args: args}
+}
+
+func (v *truncateDateVisitor) VisitString(e model.StringExpr) interface{} { return e }
+
+func (v *truncateDateVisitor) VisitOrderByExpr(e model.OrderByExpr) interface{} {
+	exprs := v.visitChildren(e.Exprs)
+	return model.NewOrderByExpr(exprs, e.Direction)
+
+}
+func (v *truncateDateVisitor) VisitDistinctExpr(e model.DistinctExpr) interface{} {
+	return model.NewDistinctExpr(e.Expr.Accept(v).(model.Expr))
+}
+func (v *truncateDateVisitor) VisitTableRef(e model.TableRef) interface{} {
+	return model.NewTableRef(e.Name)
+}
+func (v *truncateDateVisitor) VisitAliasedExpr(e model.AliasedExpr) interface{} {
+	return model.NewAliasedExpr(e.Expr.Accept(v).(model.Expr), e.Alias)
+}
+func (v *truncateDateVisitor) VisitWindowFunction(e model.WindowFunction) interface{} {
+	return model.NewWindowFunction(e.Name, v.visitChildren(e.Args), v.visitChildren(e.PartitionBy), e.OrderBy.Accept(v).(model.OrderByExpr))
+}
+
+func (v *truncateDateVisitor) VisitSelectCommand(e model.SelectCommand) interface{} {
+
+	// transformation
+
+	var groupBy []model.Expr
+
+	for _, expr := range e.GroupBy {
+		groupBy = append(groupBy, expr.Accept(v).(model.Expr))
+	}
+
+	var columns []model.Expr
+	for _, expr := range e.Columns {
+		columns = append(columns, expr.Accept(v).(model.Expr))
+	}
+
+	var fromClause model.Expr
+	if e.FromClause != nil {
+		fromClause = e.FromClause.Accept(v).(model.Expr)
+	}
+
+	var whereClause model.Expr
+	if e.WhereClause != nil {
+		whereClause = e.WhereClause.Accept(v).(model.Expr)
+	}
+
+	return model.NewSelectCommand(columns, groupBy, e.OrderBy,
+		fromClause, whereClause, e.Limit, e.SampleLimit, e.IsDistinct)
+
+}
+
+func (v *truncateDateVisitor) VisitParenExpr(p model.ParenExpr) interface{} {
+	var exprs []model.Expr
+	for _, expr := range p.Exprs {
+		exprs = append(exprs, expr.Accept(v).(model.Expr))
+	}
+	return model.NewParenExpr(exprs...)
+}
+
+func (v *truncateDateVisitor) VisitLambdaExpr(e model.LambdaExpr) interface{} {
+	return model.NewLambdaExpr(e.Args, e.Body.Accept(v).(model.Expr))
+}
+
+type truncateDate struct {
+	truncateTo time.Duration
+}
+
+func (s *truncateDate) Transform(queries []*model.Query) ([]*model.Query, error) {
+
+	for k, query := range queries {
+		visitor := &truncateDateVisitor{}
+
+		visitor.truncateTo = s.truncateTo
+
+		result := query.SelectCommand.Accept(visitor).(*model.SelectCommand)
+
+		// this is just in case if there was no truncation, we keep the original query
+		if visitor.truncated && result != nil {
+			queries[k].SelectCommand = *result
+			query.OptimizeHints.OptimizationsPerformed = append(query.OptimizeHints.OptimizationsPerformed, "truncateDate")
+		}
+	}
+	return queries, nil
+}

--- a/quesma/optimize/trunc_date.go
+++ b/quesma/optimize/trunc_date.go
@@ -9,6 +9,17 @@ import (
 	"time"
 )
 
+// truncateDateVisitor - a visitor that truncates dates in the query
+// It finds date comparisons like:
+//
+// column >= '2024-06-04T13:08:53.675Z' and column <= '2024-06-06T13:10:53.675Z'
+//
+// and truncates the dates to the nearest 5 minutes (or any other duration), resulting in:
+//
+// column >= '2024-06-04T13:05:00.000Z' and column <= '2024-06-06T13:15:00.000Z'
+//
+// Note: Truncation is done only if the difference between the dates is more than 24 hours.
+
 type truncateDateVisitor struct {
 	truncateTo time.Duration
 	truncated  bool

--- a/quesma/optimize/trunc_date.go
+++ b/quesma/optimize/trunc_date.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package optimize
 
 import (

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -352,6 +352,7 @@ func (cw *ClickhouseQueryTranslator) MakeSearchResponse(queries []*model.Query, 
 			Relation: "gte",
 		}
 	}
+
 	return response
 }
 

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -129,7 +129,8 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhous
 	// TODO this should be configurable somehow
 	//
 	// tests should not be run with optimization enabled by default
-	queryRunner.EnableQueryOptimization()
+        // TODO: Enable it in YAML
+	// queryRunner.EnableQueryOptimization()
 
 	router := configureRouter(config, schemaRegistry, logManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)
 	return &Quesma{

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -129,7 +129,7 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhous
 	// TODO this should be configurable somehow
 	//
 	// tests should not be run with optimization enabled by default
-        // TODO: Enable it in YAML
+	// TODO: Enable it in YAML
 	// queryRunner.EnableQueryOptimization()
 
 	router := configureRouter(config, schemaRegistry, logManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -126,6 +126,11 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhous
 
 	queryRunner.DateMathRenderer = queryparser.DateMathExpressionFormatLiteral
 
+	// TODO this should be configurable somehow
+	//
+	// tests should not be run with optimization enabled by default
+	queryRunner.EnableQueryOptimization()
+
 	router := configureRouter(config, schemaRegistry, logManager, quesmaManagementConsole, phoneHomeAgent, queryRunner)
 	return &Quesma{
 		telemetryAgent:          phoneHomeAgent,


### PR DESCRIPTION
Let's introduce the SQL query optimization pipeline.

Now there are only two optimizations supported: 
- truncate dates to 5 minutes, it  will limit how many distinct queries we perform
- cache aggregation queries ("GROUP BY"), these queries can be slow, and produce a low number of rows, 

Optimizations are disabled for tests. 
Currently,  performed optimizations are not visible in the "Live View" tab. I will add it in the next PR.
