### PR TITLE
POC N index -> 1 table mapping

### DIFF
--- a/quesma/quesma/config/index_mappings.go
+++ b/quesma/quesma/config/index_mappings.go
@@ -10,7 +10,7 @@ import (
 
 type IndexMappingsConfiguration struct {
 	Name     string   `koanf:"name"`
-	Mappings []string `koanf:"internalIndexes"`
+	Mappings []string `koanf:"sourceIndexes"`
 }
 
 func (imc IndexMappingsConfiguration) String() string {

--- a/quesma/quesma/config/index_mappings.go
+++ b/quesma/quesma/config/index_mappings.go
@@ -1,0 +1,24 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type IndexMappingsConfiguration struct {
+	Name     string   `koanf:"name"`
+	Mappings []string `koanf:"internalIndexes"`
+}
+
+func (imc IndexMappingsConfiguration) String() string {
+	var str = fmt.Sprintf("\n\t\t%s",
+		imc.Name,
+	)
+	if len(imc.Mappings) > 0 {
+		str = fmt.Sprintf("%s <- %s", str, strings.Join(imc.Mappings, ", "))
+	}
+	return str
+}

--- a/quesma/quesma/index-mapping-query-rewriter.go
+++ b/quesma/quesma/index-mapping-query-rewriter.go
@@ -5,9 +5,11 @@ package quesma
 
 import (
 	"quesma/model"
+	"quesma/quesma/config"
 )
 
 type IndexMappingRewriter struct {
+	indexMappings map[string]config.IndexMappingsConfiguration
 }
 
 func (IndexMappingRewriter) VisitFunction(e model.FunctionExpr) interface{}           { return e }
@@ -29,7 +31,7 @@ func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}       
 func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}           { return e }
 
 func (s *SchemaCheckPass) applyIndexMappingTransformations(query *model.Query) (*model.Query, error) {
-	indexMappingRewriter := &IndexMappingRewriter{}
+	indexMappingRewriter := &IndexMappingRewriter{indexMappings: s.indexMappings}
 	expr := query.SelectCommand.Accept(indexMappingRewriter)
 	if _, ok := expr.(*model.SelectCommand); ok {
 		query.SelectCommand = *expr.(*model.SelectCommand)

--- a/quesma/quesma/index-mapping-query-rewriter.go
+++ b/quesma/quesma/index-mapping-query-rewriter.go
@@ -1,0 +1,12 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package quesma
+
+import (
+	"quesma/model"
+)
+
+func (s *SchemaCheckPass) applyIndexMappingTransformations(query *model.Query) (*model.Query, error) {
+	return query, nil
+}

--- a/quesma/quesma/index-mapping-query-rewriter.go
+++ b/quesma/quesma/index-mapping-query-rewriter.go
@@ -7,6 +7,33 @@ import (
 	"quesma/model"
 )
 
+type IndexMappingRewriter struct {
+}
+
+func (IndexMappingRewriter) VisitFunction(e model.FunctionExpr) interface{}           { return e }
+func (IndexMappingRewriter) VisitMultiFunction(e model.MultiFunctionExpr) interface{} { return e }
+func (IndexMappingRewriter) VisitLiteral(l model.LiteralExpr) interface{}             { return l }
+func (IndexMappingRewriter) VisitString(e model.StringExpr) interface{}               { return e }
+func (IndexMappingRewriter) VisitInfix(e model.InfixExpr) interface{}                 { return e }
+func (IndexMappingRewriter) VisitColumnRef(e model.ColumnRef) interface{}             { return e }
+func (IndexMappingRewriter) VisitPrefixExpr(e model.PrefixExpr) interface{}           { return e }
+func (IndexMappingRewriter) VisitNestedProperty(e model.NestedProperty) interface{}   { return e }
+func (IndexMappingRewriter) VisitArrayAccess(e model.ArrayAccess) interface{}         { return e }
+func (IndexMappingRewriter) VisitOrderByExpr(e model.OrderByExpr) interface{}         { return e }
+func (IndexMappingRewriter) VisitDistinctExpr(e model.DistinctExpr) interface{}       { return e }
+func (IndexMappingRewriter) VisitTableRef(e model.TableRef) interface{}               { return e }
+func (IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{}         { return e }
+func (IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{}     { return e }
+func (IndexMappingRewriter) VisitWindowFunction(f model.WindowFunction) interface{}   { return f }
+func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}             { return e }
+func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}           { return e }
+
 func (s *SchemaCheckPass) applyIndexMappingTransformations(query *model.Query) (*model.Query, error) {
+	indexMappingRewriter := &IndexMappingRewriter{}
+	expr := query.SelectCommand.Accept(indexMappingRewriter)
+	if _, ok := expr.(*model.SelectCommand); ok {
+		query.SelectCommand = *expr.(*model.SelectCommand)
+	}
 	return query, nil
+
 }

--- a/quesma/quesma/index_mapping_query_rewriter.go
+++ b/quesma/quesma/index_mapping_query_rewriter.go
@@ -23,12 +23,14 @@ func (IndexMappingRewriter) VisitNestedProperty(e model.NestedProperty) interfac
 func (IndexMappingRewriter) VisitArrayAccess(e model.ArrayAccess) interface{}         { return e }
 func (IndexMappingRewriter) VisitOrderByExpr(e model.OrderByExpr) interface{}         { return e }
 func (IndexMappingRewriter) VisitDistinctExpr(e model.DistinctExpr) interface{}       { return e }
-func (IndexMappingRewriter) VisitTableRef(e model.TableRef) interface{}               { return e }
-func (IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{}         { return e }
-func (IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{}     { return e }
-func (IndexMappingRewriter) VisitWindowFunction(f model.WindowFunction) interface{}   { return f }
-func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}             { return e }
-func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}           { return e }
+func (IndexMappingRewriter) VisitTableRef(e model.TableRef) interface{} {
+	return e
+}
+func (IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{}       { return e }
+func (IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{}   { return e }
+func (IndexMappingRewriter) VisitWindowFunction(f model.WindowFunction) interface{} { return f }
+func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}           { return e }
+func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}         { return e }
 
 func NewIndexMappingRewriter(indexMappings map[string]config.IndexMappingsConfiguration) *IndexMappingRewriter {
 	rewriter := &IndexMappingRewriter{sourceToDestMapping: make(map[string]string)}

--- a/quesma/quesma/index_mapping_query_rewriter.go
+++ b/quesma/quesma/index_mapping_query_rewriter.go
@@ -5,51 +5,26 @@ package quesma
 
 import (
 	"quesma/model"
-	"quesma/quesma/config"
 )
 
-type IndexMappingRewriter struct {
-	sourceToDestMapping map[string]string
-}
-
-func (IndexMappingRewriter) VisitFunction(e model.FunctionExpr) interface{}           { return e }
-func (IndexMappingRewriter) VisitMultiFunction(e model.MultiFunctionExpr) interface{} { return e }
-func (IndexMappingRewriter) VisitLiteral(l model.LiteralExpr) interface{}             { return l }
-func (IndexMappingRewriter) VisitString(e model.StringExpr) interface{}               { return e }
-func (IndexMappingRewriter) VisitInfix(e model.InfixExpr) interface{}                 { return e }
-func (IndexMappingRewriter) VisitColumnRef(e model.ColumnRef) interface{}             { return e }
-func (IndexMappingRewriter) VisitPrefixExpr(e model.PrefixExpr) interface{}           { return e }
-func (IndexMappingRewriter) VisitNestedProperty(e model.NestedProperty) interface{}   { return e }
-func (IndexMappingRewriter) VisitArrayAccess(e model.ArrayAccess) interface{}         { return e }
-func (IndexMappingRewriter) VisitOrderByExpr(e model.OrderByExpr) interface{}         { return e }
-func (IndexMappingRewriter) VisitDistinctExpr(e model.DistinctExpr) interface{}       { return e }
-func (IndexMappingRewriter) VisitTableRef(e model.TableRef) interface{} {
-	return model.NewTableRef(e.Name)
-}
-func (v *IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{} { return e }
-func (v *IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{} {
-	fromClause := e.FromClause.Accept(v)
-	return model.NewSelectCommand(e.Columns, e.GroupBy, e.OrderBy,
-		fromClause.(model.Expr), e.WhereClause, e.LimitBy, e.Limit, e.SampleLimit, e.IsDistinct, e.CTEs)
-}
-func (IndexMappingRewriter) VisitWindowFunction(f model.WindowFunction) interface{} { return f }
-func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}           { return e }
-func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}         { return e }
-
-func NewIndexMappingRewriter(indexMappings map[string]config.IndexMappingsConfiguration) *IndexMappingRewriter {
-	rewriter := &IndexMappingRewriter{sourceToDestMapping: make(map[string]string)}
-	for _, indexMapping := range indexMappings {
+func (s *SchemaCheckPass) applyIndexMappingTransformations(query *model.Query) (*model.Query, error) {
+	s.sourceToDestMapping = make(map[string]string)
+	for _, indexMapping := range s.indexMappings {
 		for _, sourceIndex := range indexMapping.Mappings {
 			destIndex := indexMapping.Name
-			rewriter.sourceToDestMapping[sourceIndex] = destIndex
+			s.sourceToDestMapping[sourceIndex] = destIndex
 		}
 	}
-	return rewriter
-}
-
-func (s *SchemaCheckPass) applyIndexMappingTransformations(query *model.Query) (*model.Query, error) {
-	indexMappingRewriter := NewIndexMappingRewriter(s.indexMappings)
-	expr := query.SelectCommand.Accept(indexMappingRewriter)
+	visitor := model.NewBaseVisitor()
+	visitor.OverrideVisitSelectCommand = func(b *model.BaseExprVisitor, e model.SelectCommand) interface{} {
+		fromClause := e.FromClause.Accept(b)
+		return model.NewSelectCommand(e.Columns, e.GroupBy, e.OrderBy,
+			fromClause.(model.Expr), e.WhereClause, e.LimitBy, e.Limit, e.SampleLimit, e.IsDistinct, e.CTEs)
+	}
+	visitor.OverrideVisitTableRef = func(b *model.BaseExprVisitor, e model.TableRef) interface{} {
+		return model.NewTableRef(e.Name)
+	}
+	expr := query.SelectCommand.Accept(visitor)
 	if _, ok := expr.(*model.SelectCommand); ok {
 		query.SelectCommand = *expr.(*model.SelectCommand)
 	}

--- a/quesma/quesma/index_mapping_query_rewriter.go
+++ b/quesma/quesma/index_mapping_query_rewriter.go
@@ -24,10 +24,14 @@ func (IndexMappingRewriter) VisitArrayAccess(e model.ArrayAccess) interface{}   
 func (IndexMappingRewriter) VisitOrderByExpr(e model.OrderByExpr) interface{}         { return e }
 func (IndexMappingRewriter) VisitDistinctExpr(e model.DistinctExpr) interface{}       { return e }
 func (IndexMappingRewriter) VisitTableRef(e model.TableRef) interface{} {
-	return e
+	return model.NewTableRef(e.Name)
 }
-func (IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{}       { return e }
-func (IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{}   { return e }
+func (v *IndexMappingRewriter) VisitAliasedExpr(e model.AliasedExpr) interface{} { return e }
+func (v *IndexMappingRewriter) VisitSelectCommand(e model.SelectCommand) interface{} {
+	fromClause := e.FromClause.Accept(v)
+	return model.NewSelectCommand(e.Columns, e.GroupBy, e.OrderBy,
+		fromClause.(model.Expr), e.WhereClause, e.LimitBy, e.Limit, e.SampleLimit, e.IsDistinct, e.CTEs)
+}
 func (IndexMappingRewriter) VisitWindowFunction(f model.WindowFunction) interface{} { return f }
 func (IndexMappingRewriter) VisitParenExpr(e model.ParenExpr) interface{}           { return e }
 func (IndexMappingRewriter) VisitLambdaExpr(e model.LambdaExpr) interface{}         { return e }

--- a/quesma/quesma/index_mapping_query_rewriter_test.go
+++ b/quesma/quesma/index_mapping_query_rewriter_test.go
@@ -1,0 +1,60 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package quesma
+
+import (
+	"github.com/stretchr/testify/assert"
+	"quesma/clickhouse"
+	"quesma/model"
+	"quesma/quesma/config"
+	"quesma/schema"
+	"testing"
+)
+
+func Test_index_table_mapping(t *testing.T) {
+	expectedQueries := []*model.Query{
+		{
+			TableName: "kibana_sample_data_logs",
+			SelectCommand: model.SelectCommand{
+				FromClause: model.NewTableRef("kibana_sample_data_logs"),
+			},
+		},
+	}
+
+	queries := [][]*model.Query{
+		{
+			{
+				TableName: "kibana_sample_data_logs",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("kibana_sample_data_logs"),
+				}},
+		},
+	}
+
+	indexConfig := map[string]config.IndexConfiguration{
+		"kibana_sample_data_logs": {
+			Name:    "kibana_sample_data_logs",
+			Enabled: true,
+		},
+	}
+
+	cfg := config.QuesmaConfiguration{
+		IndexConfig: indexConfig,
+	}
+
+	tableDiscovery :=
+		fixedTableProvider{tables: map[string]schema.Table{
+			"kibana_sample_data_flights": {Columns: map[string]schema.Column{
+				"DestLocation": {Name: "DestLocation", Type: "geo_point"},
+				"clientip":     {Name: "clientip", Type: "ip"},
+			}},
+		}}
+	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{})
+	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s, logManager: clickhouse.NewLogManagerEmpty()}
+
+	for k := range queries {
+		resultQueries, err := transform.Transform(queries[k])
+		assert.NoError(t, err)
+		assert.Equal(t, expectedQueries[k].SelectCommand.String(), resultQueries[0].SelectCommand.String())
+	}
+}

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -273,6 +273,7 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 			Transformation     func(*model.Query) (*model.Query, error)
 		}{
 			{TransformationName: "BooleanLiteralTransformation", Transformation: s.applyBooleanLiteralLowering},
+			{TransformationName: "IndexMappingQueryRewriter", Transformation: s.applyIndexMappingTransformations},
 			{TransformationName: "IpTransformation", Transformation: s.applyIpTransformations},
 			{TransformationName: "GeoTransformation", Transformation: s.applyGeoTransformations},
 			{TransformationName: "ArrayTransformation", Transformation: s.applyArrayTransformations},

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -40,10 +40,11 @@ func (s *SchemaCheckPass) applyBooleanLiteralLowering(query *model.Query) (*mode
 }
 
 type SchemaCheckPass struct {
-	cfg            map[string]config.IndexConfiguration
-	schemaRegistry schema.Registry
-	logManager     *clickhouse.LogManager
-	indexMappings  map[string]config.IndexMappingsConfiguration
+	cfg                 map[string]config.IndexConfiguration
+	schemaRegistry      schema.Registry
+	logManager          *clickhouse.LogManager
+	indexMappings       map[string]config.IndexMappingsConfiguration
+	sourceToDestMapping map[string]string
 }
 
 // This functions trims the db name from the table name if exists

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -40,11 +40,10 @@ func (s *SchemaCheckPass) applyBooleanLiteralLowering(query *model.Query) (*mode
 }
 
 type SchemaCheckPass struct {
-	cfg                 map[string]config.IndexConfiguration
-	schemaRegistry      schema.Registry
-	logManager          *clickhouse.LogManager
-	indexMappings       map[string]config.IndexMappingsConfiguration
-	sourceToDestMapping map[string]string
+	cfg            map[string]config.IndexConfiguration
+	schemaRegistry schema.Registry
+	logManager     *clickhouse.LogManager
+	indexMappings  map[string]config.IndexMappingsConfiguration
 }
 
 // This functions trims the db name from the table name if exists
@@ -274,8 +273,8 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 			TransformationName string
 			Transformation     func(*model.Query) (*model.Query, error)
 		}{
-			{TransformationName: "BooleanLiteralTransformation", Transformation: s.applyBooleanLiteralLowering},
 			{TransformationName: "IndexMappingQueryRewriter", Transformation: s.applyIndexMappingTransformations},
+			{TransformationName: "BooleanLiteralTransformation", Transformation: s.applyBooleanLiteralLowering},
 			{TransformationName: "IpTransformation", Transformation: s.applyIpTransformations},
 			{TransformationName: "GeoTransformation", Transformation: s.applyGeoTransformations},
 			{TransformationName: "ArrayTransformation", Transformation: s.applyArrayTransformations},

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -43,6 +43,7 @@ type SchemaCheckPass struct {
 	cfg            map[string]config.IndexConfiguration
 	schemaRegistry schema.Registry
 	logManager     *clickhouse.LogManager
+	indexMappings  map[string]config.IndexMappingsConfiguration
 }
 
 // This functions trims the db name from the table name if exists

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -81,7 +81,7 @@ func NewQueryRunner(lm *clickhouse.LogManager, cfg config.QuesmaConfiguration, i
 		AsyncQueriesContexts: concurrent.NewMap[string, *AsyncQueryContext](),
 		transformationPipeline: TransformationPipeline{
 			transformers: []plugins.QueryTransformer{
-				&SchemaCheckPass{cfg: cfg.IndexConfig, schemaRegistry: schemaRegistry, logManager: lm}, // this can be a part of another plugin
+				&SchemaCheckPass{cfg: cfg.IndexConfig, schemaRegistry: schemaRegistry, logManager: lm, indexMappings: cfg.IndexSourceToInternalMappings}, // this can be a part of another plugin
 			},
 		}, schemaRegistry: schemaRegistry}
 }


### PR DESCRIPTION
This PR adds new configuration settings to map input/source indexes to internal database table (that's proposal, I'm open to suggestions)
```
indexMappings:
  big_kibana_common_table:
    sourceIndexes: ["kibana_sample_data_flights", "kibana_sample_data_logs"]
```
It then uses this information to rewrite all table references to specified common database table. Rewriting table references in from clause should be sufficient for our current needs