### PR TITLE
Live view - show query time and transformations

### DIFF
--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -17,11 +17,16 @@ type QueryOptimizeHints struct {
 	OptimizationsPerformed []string
 }
 
+type TransformationHistory struct {
+	SchemaTransformers []string
+}
+
 type (
 	Query struct {
 		SelectCommand SelectCommand // The representation of SELECT query
 
-		OptimizeHints *QueryOptimizeHints // it can be optional
+		OptimizeHints         *QueryOptimizeHints   // it can be optional
+		TransformationHistory TransformationHistory // it can be optional
 
 		Type      QueryType
 		TableName string

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -19,6 +19,8 @@ type QueryOptimizeHints struct {
 
 type TransformationHistory struct {
 	SchemaTransformers []string
+	// we may keep AST for each transformation here
+	// or anything that will help to understand what was done
 }
 
 type (

--- a/quesma/quesma/functionality/terms_enum/terms_enum.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum.go
@@ -84,7 +84,7 @@ func handleTermsEnumRequest(ctx context.Context, body types.JSON, qt *queryparse
 	dbQueryCtx, cancel := context.WithCancel(ctx)
 	// TODO this will be used to cancel goroutine that is executing the query
 	_ = cancel
-	if rows, err2 := qt.ClickhouseLM.ProcessQuery(dbQueryCtx, qt.Table, selectQuery); err2 != nil {
+	if rows, _, err2 := qt.ClickhouseLM.ProcessQuery(dbQueryCtx, qt.Table, selectQuery); err2 != nil {
 		logger.Error().Msgf("terms enum failed - error processing SQL query [%s]", err2)
 		result, err = json.Marshal(emptyTermsEnumResponse())
 	} else {

--- a/quesma/quesma/functionality/terms_enum/terms_enum.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum.go
@@ -102,7 +102,7 @@ func handleTermsEnumRequest(ctx context.Context, body types.JSON, qt *queryparse
 		Id:                     ctx.Value(tracing.RequestIdCtxKey).(string),
 		Path:                   path,
 		IncomingQueryBody:      reqBody,
-		QueryBodyTranslated:    [][]byte{[]byte(selectQuery.SelectCommand.String())},
+		QueryBodyTranslated:    []types.TranslatedSQLQuery{{Query: []byte(selectQuery.SelectCommand.String())}},
 		QueryTranslatedResults: result,
 		SecondaryTook:          time.Since(startTime),
 	})

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -281,6 +281,9 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 			inputQuery := query.SelectCommand.String()
 			query, err = transformation.Transformation(query)
 			if query.SelectCommand.String() != inputQuery {
+
+				query.TransformationHistory.SchemaTransformers = append(query.TransformationHistory.SchemaTransformers, transformation.TransformationName)
+
 				logger.Info().Msgf(transformation.TransformationName+" triggered, input query: %s", inputQuery)
 				logger.Info().Msgf(transformation.TransformationName+" triggered, output query: %s", query.SelectCommand.String())
 			}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -135,7 +135,7 @@ func (q *QueryRunner) handleAsyncSearch(ctx context.Context, indexPattern string
 
 type AsyncSearchWithError struct {
 	response            *model.SearchResp
-	translatedQueryBody [][]byte
+	translatedQueryBody []types.TranslatedSQLQuery
 	err                 error
 }
 
@@ -278,10 +278,10 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			}()
 
 		} else {
-			queriesBody := make([][]byte, len(queries))
+			queriesBody := make([]types.TranslatedSQLQuery, len(queries))
 			queriesBodyConcat := ""
 			for i, query := range queries {
-				queriesBody[i] = []byte(query.SelectCommand.String())
+				queriesBody[i].Query = []byte(query.SelectCommand.String())
 				queriesBodyConcat += query.SelectCommand.String() + "\n"
 			}
 			responseBody = []byte(fmt.Sprintf("Invalid Queries: %s, err: %v", queriesBody, err))
@@ -557,9 +557,9 @@ func (q *QueryRunner) runQueryJobs(jobs []QueryJob) ([][]model.QueryResultRow, e
 func (q *QueryRunner) searchWorkerCommon(
 	ctx context.Context,
 	queries []*model.Query,
-	table *clickhouse.Table) (translatedQueryBody [][]byte, hits [][]model.QueryResultRow, err error) {
+	table *clickhouse.Table) (translatedQueryBody []types.TranslatedSQLQuery, hits [][]model.QueryResultRow, err error) {
 
-	translatedQueryBody = make([][]byte, len(queries))
+	translatedQueryBody = make([]types.TranslatedSQLQuery, len(queries))
 	hits = make([][]model.QueryResultRow, len(queries))
 
 	var jobs []QueryJob
@@ -573,15 +573,11 @@ func (q *QueryRunner) searchWorkerCommon(
 		}
 
 		sql := query.SelectCommand.String()
-		//  TODO we should return what optimizations were performed
-		//  TODO translatedQueryBody should be a struct (sql, optimizations, query time, etc)
-		//
-		//if query.OptimizeHints != nil {
-		//	sql = sql + "\n-- optimizations: " + strings.Join(query.OptimizeHints.OptimizationsPerformed, ", ") + "\n"
-		//}
-
 		logger.InfoWithCtx(ctx).Msgf("SQL: %s", sql)
-		translatedQueryBody[i] = []byte(sql)
+		translatedQueryBody[i].Query = []byte(sql)
+		if query.OptimizeHints != nil {
+			translatedQueryBody[i].AppliedOptimizations = query.OptimizeHints.OptimizationsPerformed
+		}
 
 		if q.isInternalKibanaQuery(query) {
 			hits[i] = make([]model.QueryResultRow, 0)
@@ -624,7 +620,7 @@ func (q *QueryRunner) searchWorker(ctx context.Context,
 	queries []*model.Query,
 	table *clickhouse.Table,
 	doneCh chan<- AsyncSearchWithError,
-	optAsync *AsyncQuery) (translatedQueryBody [][]byte, resultRows [][]model.QueryResultRow, err error) {
+	optAsync *AsyncQuery) (translatedQueryBody []types.TranslatedSQLQuery, resultRows [][]model.QueryResultRow, err error) {
 	if optAsync != nil {
 		if q.reachedQueriesLimit(ctx, optAsync.asyncId, doneCh) {
 			return
@@ -681,7 +677,7 @@ func (q *QueryRunner) postProcessResults(table *clickhouse.Table, results [][]mo
 	return geoIpTransformer.Transform(res)
 }
 
-func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string, IncomingQueryBody []byte, QueryBodyTranslated [][]byte, QueryTranslatedResults []byte, startTime time.Time) {
+func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string, IncomingQueryBody []byte, QueryBodyTranslated []types.TranslatedSQLQuery, QueryTranslatedResults []byte, startTime time.Time) {
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     Id,
 		AsyncId:                AsyncId,

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -465,26 +465,30 @@ func (q *QueryRunner) isInternalKibanaQuery(query *model.Query) bool {
 	return false
 }
 
-type QueryJob func(ctx context.Context) ([]model.QueryResultRow, error)
+type QueryJob func(ctx context.Context) ([]model.QueryResultRow, clickhouse.PerformanceResult, error)
 
-func (q *QueryRunner) runQueryJobsSequence(jobs []QueryJob) ([][]model.QueryResultRow, error) {
+func (q *QueryRunner) runQueryJobsSequence(jobs []QueryJob) ([][]model.QueryResultRow, []clickhouse.PerformanceResult, error) {
 	var results = make([][]model.QueryResultRow, 0)
+	var performance = make([]clickhouse.PerformanceResult, 0)
 	for _, job := range jobs {
-		rows, err := job(q.executionCtx)
+		rows, perf, err := job(q.executionCtx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+
 		results = append(results, rows)
+		performance = append(performance, perf)
 	}
-	return results, nil
+	return results, performance, nil
 }
 
-func (q *QueryRunner) runQueryJobsParallel(jobs []QueryJob) ([][]model.QueryResultRow, error) {
+func (q *QueryRunner) runQueryJobsParallel(jobs []QueryJob) ([][]model.QueryResultRow, []clickhouse.PerformanceResult, error) {
 
 	var results = make([][]model.QueryResultRow, len(jobs))
-
+	var performances = make([]clickhouse.PerformanceResult, len(jobs))
 	type result struct {
 		rows  []model.QueryResultRow
+		perf  clickhouse.PerformanceResult
 		err   error
 		jobId int
 	}
@@ -505,9 +509,9 @@ func (q *QueryRunner) runQueryJobsParallel(jobs []QueryJob) ([][]model.QueryResu
 				collector <- result{err: err, jobId: jobId}
 			})
 			start := time.Now()
-			rows, err := j(ctx)
+			rows, perf, err := j(ctx)
 			logger.DebugWithCtx(ctx).Msgf("parallel job %d finished in %v", jobId, time.Since(start))
-			collector <- result{rows: rows, err: err, jobId: jobId}
+			collector <- result{rows: rows, perf: perf, err: err, jobId: jobId}
 		}(ctx, n, job)
 	}
 
@@ -516,15 +520,16 @@ func (q *QueryRunner) runQueryJobsParallel(jobs []QueryJob) ([][]model.QueryResu
 		res := <-collector
 		if res.err == nil {
 			results[res.jobId] = res.rows
+			performances[res.jobId] = res.perf
 		} else {
-			return nil, res.err
+			return nil, nil, res.err
 		}
 	}
 
-	return results, nil
+	return results, performances, nil
 }
 
-func (q *QueryRunner) runQueryJobs(jobs []QueryJob) ([][]model.QueryResultRow, error) {
+func (q *QueryRunner) runQueryJobs(jobs []QueryJob) ([][]model.QueryResultRow, []clickhouse.PerformanceResult, error) {
 	const maxParallelQueries = 25 // this is arbitrary value
 
 	numberOfJobs := len(jobs)
@@ -576,35 +581,42 @@ func (q *QueryRunner) searchWorkerCommon(
 		logger.InfoWithCtx(ctx).Msgf("SQL: %s", sql)
 		translatedQueryBody[i].Query = []byte(sql)
 		if query.OptimizeHints != nil {
-			translatedQueryBody[i].AppliedOptimizations = query.OptimizeHints.OptimizationsPerformed
+			translatedQueryBody[i].PerformedOptimizations = query.OptimizeHints.OptimizationsPerformed
 		}
+
+		translatedQueryBody[i].QueryTransformations = query.TransformationHistory.SchemaTransformers
 
 		if q.isInternalKibanaQuery(query) {
 			hits[i] = make([]model.QueryResultRow, 0)
 			continue
 		}
 
-		job := func(ctx context.Context) ([]model.QueryResultRow, error) {
+		job := func(ctx context.Context) ([]model.QueryResultRow, clickhouse.PerformanceResult, error) {
 			var err error
-			rows, err := q.logManager.ProcessQuery(ctx, table, query)
+			rows, performance, err := q.logManager.ProcessQuery(ctx, table, query)
 
 			if err != nil {
 				logger.ErrorWithCtx(ctx).Msg(err.Error())
-				return nil, err
+				return nil, clickhouse.PerformanceResult{}, err
 			}
 
 			if query.Type != nil {
 				rows = query.Type.PostprocessResults(rows)
 			}
 
-			return rows, nil
+			return rows, performance, nil
 		}
 		jobs = append(jobs, job)
 		jobHitsPosition = append(jobHitsPosition, i)
 	}
-	dbHits, err := q.runQueryJobs(jobs)
+	dbHits, performance, err := q.runQueryJobs(jobs)
 	if err != nil {
 		return
+	}
+
+	for i, p := range performance {
+		translatedQueryBody[i].Duration = p.Duration
+		translatedQueryBody[i].ExplainPlan = p.ExplainPlan
 	}
 
 	// fill the hits array with the results in the order of the database queries

--- a/quesma/quesma/types/translated_sql.go
+++ b/quesma/quesma/types/translated_sql.go
@@ -1,7 +1,15 @@
 package types
 
+import "time"
+
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 type TranslatedSQLQuery struct {
 	Query []byte
 
-	AppliedOptimizations []string
+	PerformedOptimizations []string
+	QueryTransformations   []string
+
+	Duration    time.Duration
+	ExplainPlan string
 }

--- a/quesma/quesma/types/translated_sql.go
+++ b/quesma/quesma/types/translated_sql.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package types
 
 import "time"

--- a/quesma/quesma/types/translated_sql.go
+++ b/quesma/quesma/types/translated_sql.go
@@ -1,0 +1,7 @@
+package types
+
+type TranslatedSQLQuery struct {
+	Query []byte
+
+	AppliedOptimizations []string
+}

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -26,7 +26,7 @@ func TestHtmlPages(t *testing.T) {
 	qmc.PushSecondaryInfo(&QueryDebugSecondarySource{Id: id,
 		Path:                   xss,
 		IncomingQueryBody:      xssBytes,
-		QueryBodyTranslated:    [][]byte{xssBytes},
+		QueryBodyTranslated:    []types.TranslatedSQLQuery{{Query: xssBytes}},
 		QueryTranslatedResults: xssBytes,
 	})
 	log := fmt.Sprintf(`{"request_id": "%s", "message": "%s"}`, id, xss)

--- a/quesma/quesma/ui/live_tail.go
+++ b/quesma/quesma/ui/live_tail.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"quesma/buildinfo"
 	"quesma/quesma/config"
+	"quesma/quesma/types"
 	"quesma/quesma/ui/internal/builder"
 	"quesma/util"
 	"strings"
@@ -249,7 +250,9 @@ func (qmc *QuesmaManagementConsole) populateQueries(debugKeyValueSlice []queryDe
 		buffer.Html(`<pre Id="second_query`).Text(v.id).Html(`">`)
 		for _, q := range v.query.QueryBodyTranslated {
 			buffer.Text(util.SqlPrettyPrint(q.Query))
-			buffer.Text(fmt.Sprintf("\n-- optimization: %s\n", strings.Join(q.AppliedOptimizations, ", ")))
+			buffer.Text("\n")
+			printPerformanceResult(&buffer, q)
+			buffer.Text("\n")
 		}
 		buffer.Html("\n</pre>")
 		if withLinks {
@@ -294,4 +297,18 @@ func errorBanner(debugInfo queryDebugInfo) string {
 		result += fmt.Sprintf(` <span class="debug-warn-log">%d warnings</span>`, debugInfo.warnLogCount)
 	}
 	return result
+}
+
+func printPerformanceResult(buffer *builder.HtmlBuffer, q types.TranslatedSQLQuery) {
+	buffer.Text(fmt.Sprintf("\n-- time: %s\n", q.Duration))
+	if len(q.ExplainPlan) > 0 {
+		buffer.Text(fmt.Sprintf("--  Slow query has been detected. Check logs for explain plan.\n"))
+	}
+	if len(q.QueryTransformations) > 0 {
+		buffer.Text(fmt.Sprintf("-- transformations: %s\n", strings.Join(q.QueryTransformations, ", ")))
+	}
+	if len(q.PerformedOptimizations) > 0 {
+		buffer.Text(fmt.Sprintf("-- optimization: %s\n", strings.Join(q.PerformedOptimizations, ", ")))
+	}
+
 }

--- a/quesma/quesma/ui/live_tail.go
+++ b/quesma/quesma/ui/live_tail.go
@@ -302,7 +302,7 @@ func errorBanner(debugInfo queryDebugInfo) string {
 func printPerformanceResult(buffer *builder.HtmlBuffer, q types.TranslatedSQLQuery) {
 	buffer.Text(fmt.Sprintf("\n-- time: %s\n", q.Duration))
 	if len(q.ExplainPlan) > 0 {
-		buffer.Text(fmt.Sprintf("--  Slow query has been detected. Check logs for explain plan.\n"))
+		buffer.Text("--  Slow query has been detected. Check logs for explain plan.\n")
 	}
 	if len(q.QueryTransformations) > 0 {
 		buffer.Text(fmt.Sprintf("-- transformations: %s\n", strings.Join(q.QueryTransformations, ", ")))

--- a/quesma/quesma/ui/live_tail.go
+++ b/quesma/quesma/ui/live_tail.go
@@ -3,12 +3,12 @@
 package ui
 
 import (
-	"bytes"
 	"fmt"
 	"quesma/buildinfo"
 	"quesma/quesma/config"
 	"quesma/quesma/ui/internal/builder"
 	"quesma/util"
+	"strings"
 )
 
 func (qmc *QuesmaManagementConsole) generateLiveTail() []byte {
@@ -247,7 +247,10 @@ func (qmc *QuesmaManagementConsole) populateQueries(debugKeyValueSlice []queryDe
 		tookStr := fmt.Sprintf(" took %d ms", v.query.SecondaryTook.Milliseconds())
 		buffer.Html("<p>UUID:").Text(v.id).Text(tookStr).Html(errorBanner(v.query)).Html("</p>\n")
 		buffer.Html(`<pre Id="second_query`).Text(v.id).Html(`">`)
-		buffer.Text(util.SqlPrettyPrint(bytes.Join(v.query.QueryBodyTranslated, []byte{})))
+		for _, q := range v.query.QueryBodyTranslated {
+			buffer.Text(util.SqlPrettyPrint(q.Query))
+			buffer.Text(fmt.Sprintf("\n-- optimization: %s\n", strings.Join(q.AppliedOptimizations, ", ")))
+		}
 		buffer.Html("\n</pre>")
 		if withLinks {
 			buffer.Html("\n</a>")

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -59,7 +59,7 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 		buffer.Html(`<div class="query-body-translated">` + "\n")
 		buffer.Html("<p class=\"title\">Translated SQL:</p>\n")
 		for _, queryBody := range request.QueryBodyTranslated {
-			prettyQueryBody := util.SqlPrettyPrint(queryBody)
+			prettyQueryBody := util.SqlPrettyPrint(queryBody.Query)
 			if qmc.cfg.ClickHouse.AdminUrl != nil {
 				// ClickHouse web UI /play expects a base64-encoded query
 				// in the URL:

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -68,6 +68,8 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 			}
 			buffer.Html(`<pre>`)
 			buffer.Text(prettyQueryBody)
+			buffer.Text("\n")
+			printPerformanceResult(&buffer, queryBody)
 			buffer.Html("\n</pre>")
 			if qmc.cfg.ClickHouse.AdminUrl != nil {
 				buffer.Html(`</a>`)

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"github.com/rs/zerolog"
 	"quesma/elasticsearch"
+	"quesma/quesma/types"
 	"quesma/schema"
 	"quesma/telemetry"
 	"quesma/util"
@@ -49,7 +50,7 @@ type QueryDebugSecondarySource struct {
 	Path              string
 	IncomingQueryBody []byte
 
-	QueryBodyTranslated    [][]byte
+	QueryBodyTranslated    []types.TranslatedSQLQuery
 	QueryTranslatedResults []byte
 	SecondaryTook          time.Duration
 }
@@ -135,8 +136,15 @@ func (qmc *QuesmaManagementConsole) RecordRequest(typeName string, took time.Dur
 }
 
 func (qdi *queryDebugInfo) requestContains(queryStr string) bool {
+
+	var translatedQueries [][]byte
+	for _, translatedQuery := range qdi.QueryDebugSecondarySource.QueryBodyTranslated {
+		translatedQueries = append(translatedQueries, translatedQuery.Query)
+	}
+
 	potentialPlaces := [][]byte{qdi.QueryDebugSecondarySource.IncomingQueryBody,
-		bytes.Join(qdi.QueryDebugSecondarySource.QueryBodyTranslated, []byte{})}
+		bytes.Join(translatedQueries, []byte{})}
+
 	for _, potentialPlace := range potentialPlaces {
 		if potentialPlace != nil && strings.Contains(string(potentialPlace), queryStr) {
 			return true


### PR DESCRIPTION
In the "Live View" tab we display additional information for each executed SQL query: 
- duration time
- which schema transformation was applied
- which optimizations were performed 

<img width="705" alt="Screenshot 2024-07-17 at 12 02 47" src="https://github.com/user-attachments/assets/011df75f-3008-44e7-9e5f-d479a194cc60">

