### PR TITLE
Optimizer - Rewrite query using a materialized view 

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -89,8 +89,8 @@ func (lm *LogManager) ProcessQuery(ctx context.Context, table *Table, query *mod
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-const slowQueryThreshold = 2 * time.Second
-const slowQuerySampleRate = 1
+const slowQueryThreshold = 30 * time.Second
+const slowQuerySampleRate = 0.1
 
 func (lm *LogManager) shouldExplainQuery(elapsed time.Duration) bool {
 	return elapsed > slowQueryThreshold && random.Float64() < slowQuerySampleRate

--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -89,8 +89,8 @@ func (lm *LogManager) ProcessQuery(ctx context.Context, table *Table, query *mod
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-const slowQueryThreshold = 30 * time.Second
-const slowQuerySampleRate = 0.1
+const slowQueryThreshold = 2 * time.Second
+const slowQuerySampleRate = 1
 
 func (lm *LogManager) shouldExplainQuery(elapsed time.Duration) bool {
 	return elapsed > slowQueryThreshold && random.Float64() < slowQuerySampleRate

--- a/quesma/optimize/cache_group_by.go
+++ b/quesma/optimize/cache_group_by.go
@@ -31,7 +31,7 @@ func (s *cacheGroupByQueries) IsEnabledByDefault() bool {
 	return false
 }
 
-func (s *cacheGroupByQueries) Transform(queries []*model.Query) ([]*model.Query, error) {
+func (s *cacheGroupByQueries) Transform(queries []*model.Query, properties map[string]string) ([]*model.Query, error) {
 
 	for _, query := range queries {
 

--- a/quesma/optimize/materialized_view_replace.go
+++ b/quesma/optimize/materialized_view_replace.go
@@ -38,7 +38,8 @@ func (s *materializedViewReplace) replaceInfix(where model.Expr, pattern string,
 
 	visitor.OverrideVisitInfix = func(b *model.BaseExprVisitor, e model.InfixExpr) interface{} {
 
-		if pattern == model.AsString(e) {
+		current := model.AsString(e)
+		if pattern == current {
 			replaced = true
 			return replacement
 		}

--- a/quesma/optimize/materialized_view_replace.go
+++ b/quesma/optimize/materialized_view_replace.go
@@ -1,0 +1,148 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package optimize
+
+import (
+	"quesma/logger"
+	"quesma/model"
+	"strings"
+)
+
+type materializedViewReplaceRule struct {
+	tableName        string // table name that we want to replace
+	condition        string // this is string representation of the condition that we want to replace
+	materializedView string // target
+}
+
+type materializedViewReplace struct {
+}
+
+func (s *materializedViewReplace) getTableName(tableName string) string {
+
+	res := strings.Replace(tableName, `"`, "", -1)
+	if strings.Contains(res, ".") {
+		parts := strings.Split(res, ".")
+		if len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return res
+}
+
+func (s *materializedViewReplace) replaceInfix(where model.Expr, pattern string, replacement model.Expr) (model.Expr, bool) {
+
+	var replaced bool
+	var res model.Expr
+
+	visitor := model.NewBaseVisitor()
+
+	visitor.OverrideVisitInfix = func(b *model.BaseExprVisitor, e model.InfixExpr) interface{} {
+
+		if pattern == model.AsString(e) {
+			replaced = true
+			return replacement
+		}
+		return model.NewInfixExpr(e.Left.Accept(b).(model.Expr), e.Op, e.Right.Accept(b).(model.Expr))
+	}
+
+	res = where.Accept(visitor).(model.Expr)
+
+	return res, replaced
+}
+
+func (s *materializedViewReplace) replace(rule materializedViewReplaceRule, query model.SelectCommand) (*model.SelectCommand, bool) {
+
+	visitor := model.NewBaseVisitor()
+	var replaced bool
+
+	visitor.OverrideVisitSelectCommand = func(v *model.BaseExprVisitor, query model.SelectCommand) interface{} {
+
+		var columns, groupBy []model.Expr
+		var orderBy []model.OrderByExpr
+		from := query.FromClause
+		where := query.WhereClause
+		columns = query.Columns
+		groupBy = query.GroupBy
+		orderBy = query.OrderBy
+
+		var ctes []*model.SelectCommand
+		if query.CTEs != nil {
+			ctes = make([]*model.SelectCommand, 0)
+			for _, cte := range query.CTEs {
+				ctes = append(ctes, cte.Accept(v).(*model.SelectCommand))
+			}
+		}
+
+		if query.FromClause != nil {
+			if table, ok := query.FromClause.(model.TableRef); ok {
+
+				tableName := s.getTableName(table.Name) // todo: get table name from data
+
+				// if we match the table name
+				if rule.tableName == tableName { // config param
+
+					// we try to replace the where clause
+					newWhere, whereReplaced := s.replaceInfix(query.WhereClause, rule.condition, model.NewLiteral("TRUE"))
+
+					// if we replaced the where clause, we replace the from clause
+					if whereReplaced {
+						replaced = true
+						from = model.NewTableRef(rule.materializedView) // config param
+						return model.NewSelectCommand(columns, groupBy, orderBy, from, newWhere, query.LimitBy, query.Limit, query.SampleLimit, query.IsDistinct, ctes)
+					}
+				}
+			} else {
+				from = query.FromClause.Accept(v).(model.Expr)
+			}
+		}
+
+		where = query.WhereClause.Accept(v).(model.Expr)
+
+		return model.NewSelectCommand(columns, groupBy, orderBy, from, where, query.LimitBy, query.Limit, query.SampleLimit, query.IsDistinct, ctes)
+
+	}
+
+	newSelect := query.Accept(visitor).(*model.SelectCommand)
+
+	return newSelect, replaced
+}
+
+func (s *materializedViewReplace) readRule(properties map[string]string) materializedViewReplaceRule {
+	rule := materializedViewReplaceRule{
+		tableName:        properties["table"],
+		condition:        properties["condition"],
+		materializedView: properties["view"],
+	}
+	return rule
+}
+
+func (s *materializedViewReplace) Name() string {
+	return "materialized_view_replace"
+}
+
+func (s *materializedViewReplace) IsEnabledByDefault() bool {
+	return false
+}
+
+func (s *materializedViewReplace) Transform(queries []*model.Query, properties map[string]string) ([]*model.Query, error) {
+
+	//
+	// TODO add list of rules maybe
+	//
+	rule := s.readRule(properties)
+
+	for k, query := range queries {
+
+		result, replaced := s.replace(rule, query.SelectCommand)
+
+		// this is just in case if there was no truncation, we keep the original query
+		if result != nil && replaced {
+			logger.Info().Msgf(s.Name()+" triggered, input query: %s", query.SelectCommand.String())
+			logger.Info().Msgf(s.Name()+" triggered, output query: %s", (*result).String())
+
+			queries[k].SelectCommand = *result
+			query.OptimizeHints.OptimizationsPerformed = append(query.OptimizeHints.OptimizationsPerformed, s.Name())
+		}
+	}
+	return queries, nil
+}

--- a/quesma/optimize/trunc_date.go
+++ b/quesma/optimize/trunc_date.go
@@ -166,10 +166,11 @@ func (s *truncateDate) IsEnabledByDefault() bool {
 	return false
 }
 
-func (s *truncateDate) Transform(queries []*model.Query) ([]*model.Query, error) {
+func (s *truncateDate) Transform(queries []*model.Query, properties map[string]string) ([]*model.Query, error) {
 
 	for k, query := range queries {
-		visitor, processor := newTruncDate(s.truncateTo)
+
+		visitor, processor := newTruncDate(s.truncateTo) // read from properties
 
 		result := query.SelectCommand.Accept(visitor).(*model.SelectCommand)
 

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -44,7 +44,6 @@ type QuesmaConfiguration struct {
 	PublicTcpPort              network.Port                  `koanf:"port"`
 	IngestStatistics           bool                          `koanf:"ingestStatistics"`
 	QuesmaInternalTelemetryUrl *Url                          `koanf:"internalTelemetryUrl"`
-	EnabledOptimizers          OptimizersConfiguration       `koanf:"optimizers"`
 }
 
 type LoggingConfiguration struct {
@@ -64,7 +63,10 @@ type RelationalDbConfiguration struct {
 	AdminUrl      *Url   `koanf:"adminUrl"`
 }
 
-type OptimizersConfiguration map[string]bool
+type OptimizerConfiguration struct {
+	Enabled    bool              `koanf:"enabled"`
+	Properties map[string]string `koanf:"properties"`
+}
 
 func (c *RelationalDbConfiguration) IsEmpty() bool {
 	return c != nil && c.Url == nil && c.User == "" && c.Password == "" && c.Database == ""
@@ -236,13 +238,16 @@ func (c *QuesmaConfiguration) WritesToElasticsearch() bool {
 	return c.Mode != ClickHouse
 }
 
-func (c *QuesmaConfiguration) optimizersConfigAsString(s string, cfg OptimizersConfiguration) string {
+func (c *QuesmaConfiguration) optimizersConfigAsString(s string, cfg map[string]OptimizerConfiguration) string {
 
 	var lines []string
 
 	lines = append(lines, fmt.Sprintf("        %s:", s))
 	for k, v := range cfg {
-		lines = append(lines, fmt.Sprintf("            %s: %v", k, v))
+		lines = append(lines, fmt.Sprintf("            %s: %v", k, v.Enabled))
+		if v.Properties != nil && len(v.Properties) > 0 {
+			lines = append(lines, fmt.Sprintf("                properties: %v", v.Properties))
+		}
 	}
 
 	return strings.Join(lines, "\n")
@@ -253,8 +258,6 @@ func (c *QuesmaConfiguration) OptimizersConfigAsString() string {
 	var lines []string
 
 	lines = append(lines, "\n")
-
-	lines = append(lines, c.optimizersConfigAsString("Global", c.EnabledOptimizers))
 
 	for indexName, indexConfig := range c.IndexConfig {
 		if indexConfig.EnabledOptimizers != nil && len(indexConfig.EnabledOptimizers) > 0 {

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -23,8 +23,8 @@ type IndexConfiguration struct {
 	TimestampField *string `koanf:"timestampField"`
 	// this is hidden from the user right now
 	// deprecated
-	SchemaConfiguration *SchemaConfiguration    `koanf:"static-schema"`
-	EnabledOptimizers   OptimizersConfiguration `koanf:"optimizers"`
+	SchemaConfiguration *SchemaConfiguration              `koanf:"static-schema"`
+	EnabledOptimizers   map[string]OptimizerConfiguration `koanf:"optimizers"`
 }
 
 func (c IndexConfiguration) HasFullTextField(fieldName string) bool {


### PR DESCRIPTION
This PR adds an optimizer that rewrites queries and replaces the original table with a materialized view.  The rewrite rule is taken from the configuration. 

Suppose we've got the following table:
```
CREATE some_index (
  `date` DateTime64(3),
   `type` String,
   ... 
)
ENGINE=MergeTree()
ORDER BY (`date`)
```

We've discovered our dashboard generates a lot of queries with common expressions:
```
(type ILIKE '%foo%')
```

We may create a materialized view and query it instead of the original table.
Notice that the materialized view is updated on INSERT, it must be created before ingest.
```
-- a table that holds materialized view data 
CREATE table some_index_foo_dest (
  `date` DateTime64(3),
   `type` String,
   ... 
)

-- an index 

CREATE MATERIALIZED VIEW some_index_foo_mv to some_index_foo_dest AS
SELECT  * 
FROM some_index 
WHERE 
type ILIKE '%foo%'
```

Now we can configure the optimizer itself.
```
-- part of config.yaml
 some_index:
    enabled: true
    optimizers:
      materialized_view_replace:
        enabled: true
        properties:
          table: "some_index"
          condition: "(type ILIKE '%foo%')"
          view: "some_index_foo_mv"
```

So every query like
```
select count(*) from some_index where ((type ILIKE '%foo%') AND (`date` <= ..... AND `date` >= .....))
```
Will be rewritten to:
```
select count(*) from some_index where (TRUE AND (`date` <= ..... AND `date` >= .....))
```


Limitations:
- we can have only one rewrite rule per index/table
- a condition in the configuration must be the same as  a `string` representation of the  replaced expression 
- setup and configuration are  complex