### PR TITLE
Fix a nil pointer dereference in GetSourceNames()

### DIFF
--- a/quesma/elasticsearch/index_management.go
+++ b/quesma/elasticsearch/index_management.go
@@ -53,6 +53,7 @@ func (im *indexManagement) GetSources() Sources {
 	if s := im.sources.Load(); s != nil {
 		return *s
 	} else {
+		logger.Warn().Msg("Indices are not yet loaded, returning empty sources.")
 		return Sources{}
 	}
 }

--- a/quesma/elasticsearch/index_management.go
+++ b/quesma/elasticsearch/index_management.go
@@ -50,12 +50,16 @@ func (im *indexManagement) ReloadIndices() {
 }
 
 func (im *indexManagement) GetSources() Sources {
-	return *im.sources.Load()
+	if s := im.sources.Load(); s != nil {
+		return *s
+	} else {
+		return Sources{}
+	}
 }
 
 func (im *indexManagement) GetSourceNames() map[string]bool {
 	names := make(map[string]bool)
-	sources := *im.sources.Load()
+	sources := im.GetSources()
 	for _, stream := range sources.DataStreams {
 		names[stream.Name] = true
 	}


### PR DESCRIPTION
Fix a nil pointer dereference in `GetSourceNames()`, which happened quite often for me while developing Quesma - I often start Quesma before Elastic is fully up, therefore `im.sources` would be nil (failed to load from Elastic) and `GetSourceNames()` would panic.