### PR TITLE
Introducing semver + "check for updates"

### DIFF
--- a/quesma/buildinfo/build.go
+++ b/quesma/buildinfo/build.go
@@ -47,7 +47,7 @@ func isNewer(latest, current string) (bool, error) {
 func CheckForTheLatestVersion() (updateAvailable bool, messageBanner string) {
 	latestRelease, err := getLatestRelease()
 	if err != nil {
-		return updateAvailable, fmt.Sprintf("Failed obtaining latest Quesma version form GitHub: %v", err)
+		return updateAvailable, fmt.Sprintf("Failed obtaining latest Quesma version from GitHub: %v", err)
 	}
 	shouldUpgrade, err := latestRelease.IsNewerThanCurrentlyRunning()
 	if err != nil {

--- a/quesma/buildinfo/build.go
+++ b/quesma/buildinfo/build.go
@@ -44,19 +44,19 @@ func isNewer(latest, current string) (bool, error) {
 
 // CheckForTheLatestVersion obtains the latest release information from GitHub and compares it to the currently running version.
 // It returns a user-facing message indicating whether the latest version is newer, the same, or if there was an error.
-func CheckForTheLatestVersion() string {
+func CheckForTheLatestVersion() (updateAvailable bool, messageBanner string) {
 	latestRelease, err := getLatestRelease()
 	if err != nil {
-		return fmt.Sprintf("Failed obtaining latest Quesma version form GitHub: %v", err)
+		return updateAvailable, fmt.Sprintf("Failed obtaining latest Quesma version form GitHub: %v", err)
 	}
 	shouldUpgrade, err := latestRelease.IsNewerThanCurrentlyRunning()
 	if err != nil {
-		return fmt.Sprintf("Failed comparing Quesma versions: %v", err)
+		return updateAvailable, fmt.Sprintf("Failed comparing Quesma versions: %v", err)
 	}
 	if shouldUpgrade {
-		return fmt.Sprintf("A new version of Quesma is available: %s", latestRelease.Name)
+		return true, fmt.Sprintf("A new version of Quesma is available: %s", latestRelease.Name)
 	} else {
-		return fmt.Sprintf("You are running the latest version of Quesma: %s", Version)
+		return updateAvailable, fmt.Sprintf("You are running the latest version of Quesma: %s", Version)
 	}
 }
 

--- a/quesma/buildinfo/build.go
+++ b/quesma/buildinfo/build.go
@@ -2,6 +2,73 @@
 // SPDX-License-Identifier: Elastic-2.0
 package buildinfo
 
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/coreos/go-semver/semver"
+	"net/http"
+	"time"
+)
+
 var Version = "development"
 var BuildHash = ""
 var BuildDate = ""
+
+const GitHubLatestReleaseURL = "https://api.github.com/repos/quesma/quesma/releases/latest"
+
+type ReleaseInfo struct {
+	Name    string `json:"name"`
+	TagName string `json:"tag_name"`
+	// CreatedAt is the date of the commit used for the release, ref: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (r *ReleaseInfo) IsNewerThanCurrentlyRunning() (bool, error) {
+	// This is injected at build time, ignore IDE warning below
+	if Version == "development" {
+		return false, nil
+	}
+	return isNewer(r.Name, Version)
+}
+
+func isNewer(latest, current string) (bool, error) {
+	vCurrent, vLatest := new(semver.Version), new(semver.Version)
+	if err := vCurrent.Set(current); err != nil {
+		return false, fmt.Errorf("error parsing current version: %v", err)
+	}
+	if err := vLatest.Set(latest); err != nil {
+		return false, fmt.Errorf("error parsing latest version: %v", err)
+	}
+	return vCurrent.LessThan(*vLatest), nil
+}
+
+// CheckForTheLatestVersion obtains the latest release information from GitHub and compares it to the currently running version.
+// It returns a user-facing message indicating whether the latest version is newer, the same, or if there was an error.
+func CheckForTheLatestVersion() string {
+	latestRelease, err := getLatestRelease()
+	if err != nil {
+		return fmt.Sprintf("Failed obtaining latest Quesma version form GitHub: %v", err)
+	}
+	shouldUpgrade, err := latestRelease.IsNewerThanCurrentlyRunning()
+	if err != nil {
+		return fmt.Sprintf("Failed comparing Quesma versions: %v", err)
+	}
+	if shouldUpgrade {
+		return fmt.Sprintf("A new version of Quesma is available: %s", latestRelease.Name)
+	} else {
+		return fmt.Sprintf("You are running the latest version of Quesma: %s", Version)
+	}
+}
+
+func getLatestRelease() (*ReleaseInfo, error) {
+	resp, err := http.Get(GitHubLatestReleaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching latest release from GitHub: %v", err)
+	}
+	var releaseInfo ReleaseInfo
+	if err = json.NewDecoder(resp.Body).Decode(&releaseInfo); err != nil {
+		return nil, fmt.Errorf("error decoding JSON: %v", err)
+	}
+	defer resp.Body.Close()
+	return &releaseInfo, nil
+}

--- a/quesma/buildinfo/build.go
+++ b/quesma/buildinfo/build.go
@@ -47,16 +47,16 @@ func isNewer(latest, current string) (bool, error) {
 func CheckForTheLatestVersion() (updateAvailable bool, messageBanner string) {
 	latestRelease, err := getLatestRelease()
 	if err != nil {
-		return updateAvailable, fmt.Sprintf("Failed obtaining latest Quesma version from GitHub: %v", err)
+		return false, fmt.Sprintf("Failed obtaining latest Quesma version from GitHub: %v", err)
 	}
 	shouldUpgrade, err := latestRelease.IsNewerThanCurrentlyRunning()
 	if err != nil {
-		return updateAvailable, fmt.Sprintf("Failed comparing Quesma versions: %v", err)
+		return false, fmt.Sprintf("Failed comparing Quesma versions: %v", err)
 	}
 	if shouldUpgrade {
 		return true, fmt.Sprintf("A new version of Quesma is available: %s", latestRelease.Name)
 	} else {
-		return updateAvailable, fmt.Sprintf("You are running the latest version of Quesma: %s", Version)
+		return false, fmt.Sprintf("You are running the latest version of Quesma: %s", Version)
 	}
 }
 

--- a/quesma/go.mod
+++ b/quesma/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect

--- a/quesma/go.sum
+++ b/quesma/go.sum
@@ -12,6 +12,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -59,7 +59,9 @@ func main() {
 	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()
 	defer logger.ErrLogFile.Close()
-	logger.Info().Msg(buildinfo.CheckForTheLatestVersion())
+	if upgradeAvailable, message := buildinfo.CheckForTheLatestVersion(); upgradeAvailable {
+		logger.Warn().Msg(message)
+	}
 
 	if asyncQueryTraceLogger != nil {
 		asyncQueryTraceEvictor := quesma.AsyncQueryTraceLoggerEvictor{AsyncQueryTrace: asyncQueryTraceLogger.AsyncQueryTrace}

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -59,6 +59,7 @@ func main() {
 	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()
 	defer logger.ErrLogFile.Close()
+	logger.Info().Msg(buildinfo.CheckForTheLatestVersion())
 
 	if asyncQueryTraceLogger != nil {
 		asyncQueryTraceEvictor := quesma.AsyncQueryTraceLoggerEvictor{AsyncQueryTrace: asyncQueryTraceLogger.AsyncQueryTrace}

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -59,9 +59,11 @@ func main() {
 	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()
 	defer logger.ErrLogFile.Close()
-	if upgradeAvailable, message := buildinfo.CheckForTheLatestVersion(); upgradeAvailable {
-		logger.Warn().Msg(message)
-	}
+	go func() {
+		if upgradeAvailable, message := buildinfo.CheckForTheLatestVersion(); upgradeAvailable {
+			logger.Warn().Msg(message)
+		}
+	}()
 
 	if asyncQueryTraceLogger != nil {
 		asyncQueryTraceEvictor := quesma.AsyncQueryTraceLoggerEvictor{AsyncQueryTrace: asyncQueryTraceLogger.AsyncQueryTrace}

--- a/quesma/quesma/ui/dashboard.go
+++ b/quesma/quesma/ui/dashboard.go
@@ -182,6 +182,13 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 	buffer.Html(`<div id="dashboard-quesma" class="component">`)
 	buffer.Html(`<h3>Quesma</h3>`)
 
+	buffer.Html(`<div class="status">Version: `)
+	buffer.Text(buildinfo.Version)
+	buffer.Html("</div>")
+	buffer.Html(`<div class="status">[`)
+	buffer.Html(buildinfo.CheckForTheLatestVersion())
+	buffer.Html("]</div>")
+
 	cpuStr := ""
 	c0, err0 := cpu.Percent(0, false)
 
@@ -210,10 +217,6 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 	if h, errH := host.Info(); errH == nil {
 		buffer.Html(fmt.Sprintf(`<div class="status">Host uptime: %s</div>`, secondsToTerseString(h.Uptime)))
 	}
-
-	buffer.Html(`<div class="status">Version: `)
-	buffer.Text(buildinfo.Version)
-	buffer.Html("</div>")
 
 	buffer.Html(`</div>`)
 

--- a/quesma/quesma/ui/dashboard.go
+++ b/quesma/quesma/ui/dashboard.go
@@ -187,11 +187,10 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 		buffer.Html(`<div class="status" style="background-color: yellow; padding: 5px;">`)
 		buffer.Text(message)
 		buffer.Html("</div>")
-	} else {
-		buffer.Html(`<div class="status">Version: `)
-		buffer.Text(buildinfo.Version)
-		buffer.Html("</div>")
 	}
+	buffer.Html(`<div class="status">Version: `)
+	buffer.Text(buildinfo.Version)
+	buffer.Html("</div>")
 
 	cpuStr := ""
 	c0, err0 := cpu.Percent(0, false)

--- a/quesma/quesma/ui/dashboard.go
+++ b/quesma/quesma/ui/dashboard.go
@@ -182,12 +182,16 @@ func (qmc *QuesmaManagementConsole) generateDashboardPanel() []byte {
 	buffer.Html(`<div id="dashboard-quesma" class="component">`)
 	buffer.Html(`<h3>Quesma</h3>`)
 
-	buffer.Html(`<div class="status">Version: `)
-	buffer.Text(buildinfo.Version)
-	buffer.Html("</div>")
-	buffer.Html(`<div class="status">[`)
-	buffer.Html(buildinfo.CheckForTheLatestVersion())
-	buffer.Html("]</div>")
+	upgradeAvailable, message := buildinfo.CheckForTheLatestVersion()
+	if upgradeAvailable {
+		buffer.Html(`<div class="status" style="background-color: yellow; padding: 5px;">`)
+		buffer.Text(message)
+		buffer.Html("</div>")
+	} else {
+		buffer.Html(`<div class="status">Version: `)
+		buffer.Text(buildinfo.Version)
+		buffer.Html("</div>")
+	}
 
 	cpuStr := ""
 	c0, err0 := cpu.Percent(0, false)


### PR DESCRIPTION
This PR adds simple "check for updates" functionality. 

We take the latest release from GitHub release API and compare it to currently running version. If new version is available, we log a warning and display beautiful yellow banner in the UI:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/3b637cef-1590-491f-8a48-5a2e72fb8895">

(keeping my FE skills sharp 💪)