### PR TITLE
Allow disabling TLS explicitly

### DIFF
--- a/quesma/clickhouse/connection.go
+++ b/quesma/clickhouse/connection.go
@@ -24,8 +24,9 @@ func initDBConnection(c config.QuesmaConfiguration, tlsConfig *tls.Config) *sql.
 			Database: c.ClickHouse.Database,
 		}
 	}
-
-	options.TLS = tlsConfig
+	if !c.ClickHouse.DisableTLS {
+		options.TLS = tlsConfig
+	}
 
 	info := struct {
 		Name    string

--- a/quesma/config.yaml.template
+++ b/quesma/config.yaml.template
@@ -13,6 +13,7 @@ connectors:
     type: "clickhouse-os" # one of [clickhouse, clickhouse-os, hydrolix]
 #clickhouse:   # this config is going to be removed, but for now let's just comment out
 #  url: "clickhouse://localhost:9000"
+#  disableTLS: true  # required for plaintext connections
 ingestStatistics: true
 internalTelemetryUrl: "https://api.quesma.com/phone-home"
 logging:

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -63,6 +63,7 @@ type RelationalDbConfiguration struct {
 	Password      string `koanf:"password"`
 	Database      string `koanf:"database"`
 	AdminUrl      *Url   `koanf:"adminUrl"`
+	DisableTLS    bool   `koanf:"disableTLS"`
 }
 
 type OptimizersConfiguration map[string]bool


### PR DESCRIPTION
So we have this logic to ignore creating TLS-based connections when we get specific TLS-related errors (assuming that plaintext connection should be used).

However, when we start Quesma while ClickHouse is dead, aforementioned logic doesn't work and we don't fallback to non-TLS connection properly, as the error is just "connection refused":
![image (12)](https://github.com/user-attachments/assets/b043bda5-6e57-4895-bb63-5f051633ec4d)
So eventually when plaintext ClickHouse comes up, the pool will keep failing repeatedly with `tls: first record does not look like a TLS handshake`.

The proposed remediation is to just allow explicitly disabling TLS via configuration.

**Alternative approach** would be to derive this property by looking at port numbers: 
* 9000 -> no TLS
* 9440 -> TLS

of course being very verbose in logs about Quesma's choice.