### PR TITLE
Fix license check when DB conn is flapping

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -334,6 +334,9 @@ func (lm *LogManager) CheckIfConnectedPaidService(service PaidServiceName) (retu
 		}
 		if isConnectedToPaidService {
 			return fmt.Errorf("detected %s-specific table engine, which is not allowed", service)
+		} else if err == nil { // no paid service detected, no conn errors
+			returnedErr = nil
+			break
 		}
 		if time.Since(start) > totalCheckTime {
 			break


### PR DESCRIPTION
This have slipped unnoticed. 

If only one out of few license check calls fails (e.g. db being temporarily unavailable), `returnedErr` was not reset and shadowed the passing check.

This PR updates this logic - a single passed check resets `returnedErr` and immediately returns, additionally cancelling further (unnecessary) executions. 