### PR TITLE
Fix panic in MergeMaps

### DIFF
--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -345,7 +345,7 @@ func MergeMaps(ctx context.Context, mActual, mExpected JsonMap, keyAddedByQuesma
 			return mergedArray
 
 		default:
-			if i1 != i2 {
+			if !reflect.DeepEqual(i1, i2) {
 				logger.WarnWithCtx(ctx).Msgf(
 					"mergeAny: i1 isn't neither JsonMap nor []JsonMap, i1 type: %T, i2 type: %T, i1: %v, i2: %v", i1, i2, i1, i2)
 			}


### PR DESCRIPTION
Before this change, `MergeMaps` would panic while loading one of the panels in the "Ecommerce" dashboard, because of being unable to compare `[]string` values:

```
panic: runtime error: comparing uncomparable type []string

goroutine 2867 [running]:
quesma/util.MergeMaps.func1({0x103405b60, 0x140069bc0d8}, {0x103405b60, 0x140069bc4e0})
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:348 +0x5a4
quesma/util.MergeMaps.func2(0x14004cc0cf0, 0x14004cc15c0)
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:361 +0x134
quesma/util.MergeMaps.func1({0x103406da0, 0x140069bda28}, {0x103406da0, 0x140069bdb48})
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:286 +0x1598
quesma/util.MergeMaps.func2(0x14004cc0f90, 0x14004cc1020)
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:361 +0x134
quesma/util.MergeMaps.func1({0x103436fc0, 0x14004cc0f90}, {0x103436fc0, 0x14004cc1020})
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:264 +0x14c
quesma/util.MergeMaps.func2(0x14004cc0ff0, 0x14004cf0db0)
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:361 +0x134
quesma/util.MergeMaps({0x1035115d0, 0x140041f7260}, 0x14004cc0ff0, 0x14004cf0db0, {0x10329e4cc, 0x1e})
        /Users/piotrgrabowski/quesma1/quesma/quesma/util/utils.go:374 +0x184
quesma/queryparser.(*ClickhouseQueryTranslator).MakeAggregationPartOfResponse(0x14005284740, {0x14002c24960, 0x2, 0x2}, {0x14004cc0c60, 0x2, 0x2})
        /Users/piotrgrabowski/quesma1/quesma/quesma/queryparser/query_translator.go:176 +0x1c0
quesma/queryparser.(*ClickhouseQueryTranslator).MakeSearchResponse(0x14005284740, {0x14002c24960, 0x2, 0x2}, {0x14004cc0c60, 0x2, 0x2})
        /Users/piotrgrabowski/quesma1/quesma/quesma/queryparser/query_translator.go:314 +0x1e8
quesma/quesma.(*QueryRunner).handleSearchCommon.func1()
        /Users/piotrgrabowski/quesma1/quesma/quesma/quesma/search.go:275 +0x54c
created by quesma/quesma.(*QueryRunner).handleSearchCommon in goroutine 2762
        /Users/piotrgrabowski/quesma1/quesma/quesma/quesma/search.go:253 +0x1e44
Exiting.
```

By using `reflect.DeepEqual` the code no longer panics in this function.