### PR TITLE
Execution plan

### DIFF
--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -73,7 +73,7 @@ func (cw *ClickhouseEQLQueryTranslator) MakeSearchResponse(queries []*model.Quer
 	}
 }
 
-func (cw *ClickhouseEQLQueryTranslator) ParseQuery(body types.JSON) ([]*model.Query, bool, error) {
+func (cw *ClickhouseEQLQueryTranslator) ParseQuery(body types.JSON) (*model.ExecutionPlan, bool, error) {
 	simpleQuery, queryInfo, highlighter, err := cw.parseQuery(body)
 
 	if err != nil {
@@ -93,7 +93,8 @@ func (cw *ClickhouseEQLQueryTranslator) ParseQuery(body types.JSON) ([]*model.Qu
 		query.Highlighter = highlighter
 		query.SelectCommand.OrderBy = simpleQuery.OrderBy
 		queries = append(queries, query)
-		return queries, canParse, nil
+		return &model.ExecutionPlan{Queries: queries}, canParse, nil
+
 	}
 
 	return nil, false, err

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -59,6 +59,17 @@ type (
 	}
 )
 
+// QueryResultAdapter it adadpts the result of alternative query parsers to the standard query result
+// Interface is similar to plugins.ResultTransformer
+type QueryResultAdapter interface {
+	Transform(result [][]QueryResultRow) ([][]QueryResultRow, error)
+}
+
+type ExecutionPlan struct {
+	Queries       []*Query
+	ResultAdapter QueryResultAdapter
+}
+
 func NewQueryExecutionHints() *QueryOptimizeHints {
 	return &QueryOptimizeHints{Settings: make(map[string]any)}
 }

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -823,7 +823,8 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 			body, parseErr := types.ParseJSON(test.QueryRequestJson)
 			assert.NoError(t, parseErr)
 
-			queries, canParse, err := cw.ParseQuery(body)
+			plan, canParse, err := cw.ParseQuery(body)
+			queries := plan.Queries
 			assert.True(t, canParse)
 			assert.NoError(t, err)
 			assert.Len(t, test.ExpectedResults, len(queries))

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -73,7 +73,8 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 		t.Run(fmt.Sprintf("%s(%d)", tt.Name, i), func(t *testing.T) {
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)
-			queries, canParse, errQuery := cw.ParseQuery(body)
+			plan, canParse, errQuery := cw.ParseQuery(body)
+			queries := plan.Queries
 			assert.True(t, canParse, "can parse")
 			assert.NoError(t, errQuery, "no ParseQuery error")
 			assert.True(t, len(queries) > 0, "len queries > 0")
@@ -138,7 +139,8 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)
-			queries, canParse, errQuery := cw.ParseQuery(body)
+			plan, canParse, errQuery := cw.ParseQuery(body)
+			queries := plan.Queries
 			assert.NoError(t, errQuery, "no error in ParseQuery")
 			assert.True(t, canParse, "can parse")
 			assert.True(t, len(queries) > 0, "len queries > 0")
@@ -205,7 +207,8 @@ func TestQueryParserNoAttrsConfig(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)
-			queries, canParse, errQuery := cw.ParseQuery(body)
+			plan, canParse, errQuery := cw.ParseQuery(body)
+			queries := plan.Queries
 			assert.NoError(t, errQuery, "no error in ParseQuery")
 			assert.True(t, canParse, "can parse")
 			assert.True(t, len(queries) > 0, "len queries > 0")

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -4,6 +4,7 @@ package queryparser
 
 import (
 	"context"
+	"fmt"
 	"quesma/clickhouse"
 	"quesma/logger"
 	"quesma/model"
@@ -24,7 +25,8 @@ type ClickhouseQueryTranslator struct {
 	Table        *clickhouse.Table
 	Ctx          context.Context
 
-	DateMathRenderer  string // "clickhouse_interval" or "literal"  if not set, we use "clickhouse_interval"
+	DateMathRenderer string // "clickhouse_interval" or "literal"  if not set, we use "clickhouse_interval"
+
 	SchemaRegistry    schema.Registry
 	IncomingIndexName string
 }
@@ -169,6 +171,7 @@ func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []*mo
 	}
 	cw.postprocessPipelineAggregations(queries, ResultSets)
 	for i, query := range queries {
+		fmt.Printf("%d %s %v\n\n", i, model.AsString(query.SelectCommand), ResultSets[i])
 		if i >= len(ResultSets) || query_util.IsNonAggregationQuery(query) {
 			continue
 		}

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -4,7 +4,6 @@ package queryparser
 
 import (
 	"context"
-	"fmt"
 	"quesma/clickhouse"
 	"quesma/logger"
 	"quesma/model"
@@ -171,7 +170,6 @@ func (cw *ClickhouseQueryTranslator) MakeAggregationPartOfResponse(queries []*mo
 	}
 	cw.postprocessPipelineAggregations(queries, ResultSets)
 	for i, query := range queries {
-		fmt.Printf("%d %s %v\n\n", i, model.AsString(query.SelectCommand), ResultSets[i])
 		if i >= len(ResultSets) || query_util.IsNonAggregationQuery(query) {
 			continue
 		}

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -21,7 +21,7 @@ import (
 // 2. ClickhouseEQLQueryTranslator (implements only a subset of methods)
 
 type IQueryTranslator interface {
-	ParseQuery(body types.JSON) ([]*model.Query, bool, error)
+	ParseQuery(body types.JSON) (*model.ExecutionPlan, bool, error)
 	MakeSearchResponse(queries []*model.Query, ResultSets [][]model.QueryResultRow) *model.SearchResp
 }
 

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -64,7 +64,8 @@ func TestSearchOpensearch(t *testing.T) {
 
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)
-			queries, canParse, err := cw.ParseQuery(body)
+			plan, canParse, err := cw.ParseQuery(body)
+			queries := plan.Queries
 			assert.True(t, canParse, "can parse")
 			assert.NoError(t, err, "no ParseQuery error")
 			assert.True(t, len(queries) > 0, "len queries > 0")


### PR DESCRIPTION
We are introducing `ExecutionPlan`. The idea is to keep everything related to processing a single elastic query in a single place. 

We currently keep only a list of queries to execute. 

There is a `QueryResultAdapter` added also. It will be used to implement an alternative way of processing some aggregations. That adapter will adapt alternative results set to the canonical one. 

