### PR TITLE
Resolve override in `removeNotExistingTables`

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -341,6 +341,10 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 func (q *QueryRunner) removeNotExistingTables(sourcesClickhouse []string) []string {
 	allKnownTables, _ := q.logManager.GetTableDefinitions()
 	return slices.DeleteFunc(sourcesClickhouse, func(s string) bool {
+		if len(q.cfg.IndexConfig[s].Override) > 0 {
+			s = q.cfg.IndexConfig[s].Override
+		}
+
 		_, exists := allKnownTables.Load(s)
 		return !exists
 	})


### PR DESCRIPTION
`removeNotExistingTables` is used in searches with wildcard index patterns to remove indexes which were enabled in a config but without a corresponding table in ClickHouse. However, the logic did not take into account the overrides. For example if index `A` was overridden to `B`, removeNotExistingTables would still search for ClickHouse table `A`, not `B` and wildcard search would return incomplete results.

A disadvantage of this solution is that we are doing Override resolution in yet another place, however I couldn't find a way to do that resolution earlier since later code still needs the original (pre-override) name.