### PR TITLE
Show the number of returned rows

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -138,10 +138,8 @@ func getQueryId(ctx context.Context) string {
 
 	if asyncId, ok := ctx.Value(tracing.AsyncIdCtxKey).(string); ok {
 		prefix = asyncId
-	} else {
-		if requestId, ok := ctx.Value(tracing.RequestIdCtxKey).(string); ok {
-			prefix = requestId
-		}
+	} else if requestId, ok := ctx.Value(tracing.RequestIdCtxKey).(string); ok {
+		prefix = requestId
 	}
 
 	return fmt.Sprintf("%s-%d", prefix, queryCounter.Add(1))

--- a/quesma/quesma/types/translated_sql.go
+++ b/quesma/quesma/types/translated_sql.go
@@ -12,6 +12,8 @@ type TranslatedSQLQuery struct {
 	PerformedOptimizations []string
 	QueryTransformations   []string
 
-	Duration    time.Duration
-	ExplainPlan string
+	Duration     time.Duration
+	RowsReturned int
+	QueryID      string
+	ExplainPlan  string
 }

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -68,12 +68,15 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 			}
 			buffer.Html(`<pre>`)
 			buffer.Text(prettyQueryBody)
-			buffer.Text("\n")
-			printPerformanceResult(&buffer, queryBody)
 			buffer.Html("\n</pre>")
 			if qmc.cfg.ClickHouse.AdminUrl != nil {
 				buffer.Html(`</a>`)
 			}
+			buffer.Html(`<pre>`)
+			buffer.Text("\n")
+			qmc.printPerformanceResult(&buffer, queryBody)
+			buffer.Html("\n</pre>")
+
 		}
 		buffer.Html(`</div>` + "\n")
 


### PR DESCRIPTION
This PR adds the number of returned rows for each query.  You'll be redirected to the Clickhouse console to inspect that query if you click that line.

<img width="720" alt="Screenshot 2024-07-24 at 16 28 43" src="https://github.com/user-attachments/assets/967a2691-7d71-473d-bf39-5baacf87f0e1">

<img width="1374" alt="Screenshot 2024-07-24 at 16 28 56" src="https://github.com/user-attachments/assets/9a53c806-d26d-4e93-978d-58373ad06881">



It contains minor fixes:
- proper context propagation 
- fixed performance results binding
- some code clean 
