### PR TITLE
Fix handling of field names with `.` from incoming JSONs

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -436,13 +436,31 @@ func (lm *LogManager) BuildInsertJson(tableName string, data types.JSON, config 
 	}
 	js := string(jsonData)
 
-	if !config.hasOthers && len(config.attributes) == 0 {
-		return js, nil
-	}
 	// we find all non-schema fields
 	m, err := types.ParseJSON(js)
 	if err != nil {
 		return "", err
+	}
+
+	if !config.hasOthers && len(config.attributes) == 0 {
+		gotDots := false
+		for fieldName, v := range m {
+			withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
+			if fieldName != withoutDotsFieldName {
+				gotDots = true
+				m[withoutDotsFieldName] = v
+				delete(m, fieldName)
+				fieldName = withoutDotsFieldName
+			}
+		}
+		if gotDots {
+			jsonData, err = m.Bytes()
+			if err != nil {
+				return "", err
+			}
+			js = string(jsonData)
+		}
+		return js, nil
 	}
 
 	t := lm.FindTable(tableName)

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -442,23 +442,15 @@ func (lm *LogManager) BuildInsertJson(tableName string, data types.JSON, config 
 		return "", err
 	}
 
+	wasReplaced := replaceDotsWithSeparator(m)
+
 	if !config.hasOthers && len(config.attributes) == 0 {
-		gotDots := false
-		for fieldName, v := range m {
-			withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
-			if fieldName != withoutDotsFieldName {
-				gotDots = true
-				m[withoutDotsFieldName] = v
-				delete(m, fieldName)
-				fieldName = withoutDotsFieldName
-			}
-		}
-		if gotDots {
-			jsonData, err = m.Bytes()
+		if wasReplaced {
+			rawBytes, err := m.Bytes()
 			if err != nil {
 				return "", err
 			}
-			js = string(jsonData)
+			js = string(rawBytes)
 		}
 		return js, nil
 	}

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -38,12 +38,12 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	// TODO fix columns
 	fieldsMap := concurrent.NewMapWith("tableName", &Table{
 		Cols: map[string]*Column{
-			"host.name":    nil,
-			"message":      nil,
-			"service.name": nil,
-			"severity":     nil,
-			"timestamp":    nil,
-			"source":       nil,
+			"host::name":    nil,
+			"message":       nil,
+			"service::name": nil,
+			"severity":      nil,
+			"timestamp":     nil,
+			"source":        nil,
 		},
 	})
 

--- a/quesma/clickhouse/dots.go
+++ b/quesma/clickhouse/dots.go
@@ -1,0 +1,26 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package clickhouse
+
+import (
+	"quesma/quesma/types"
+	"strings"
+)
+
+func replaceDotsWithSeparator(jsonInsert types.JSON) bool {
+	gotDots := false
+	for fieldName, v := range jsonInsert {
+		withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
+		if fieldName != withoutDotsFieldName {
+			gotDots = true
+			jsonInsert[withoutDotsFieldName] = v
+			delete(jsonInsert, fieldName)
+			fieldName = withoutDotsFieldName
+		}
+		if nestedJson, isNested := v.(map[string]interface{}); isNested {
+			nestedGotDots := replaceDotsWithSeparator(nestedJson)
+			gotDots = gotDots || nestedGotDots
+		}
+	}
+	return gotDots
+}

--- a/quesma/clickhouse/dots_test.go
+++ b/quesma/clickhouse/dots_test.go
@@ -1,0 +1,29 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package clickhouse
+
+import (
+	"github.com/stretchr/testify/assert"
+	"quesma/quesma/types"
+	"testing"
+)
+
+func Test_removeDotsFromJsons(t *testing.T) {
+	hostNameStr := `{"host.name": "alpha"}`
+	hostNameJson, _ := types.ParseJSON(hostNameStr)
+	assert.True(t, replaceDotsWithSeparator(hostNameJson))
+	newBytes, _ := hostNameJson.Bytes()
+	assert.Equal(t, `{"host::name":"alpha"}`, string(newBytes))
+
+	nestedStr := `{"cloud": {"host.name":"alpha"}}`
+	nestedJson, _ := types.ParseJSON(nestedStr)
+	assert.True(t, replaceDotsWithSeparator(nestedJson))
+	newNested, _ := nestedJson.Bytes()
+	assert.Equal(t, `{"cloud":{"host::name":"alpha"}}`, string(newNested))
+
+	noChange := `{"host_name": "alpha"}`
+	noChangeJson, _ := types.ParseJSON(noChange)
+	assert.False(t, replaceDotsWithSeparator(noChangeJson))
+	newNoChange, _ := noChangeJson.Bytes()
+	assert.Equal(t, `{"host_name":"alpha"}`, string(newNoChange))
+}

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -42,9 +42,9 @@ var insertTests = []struct {
 			`(`,
 			`	`,
 			`	"@timestamp" DateTime64`,
-			`	"host.name" String`,
+			`	"host::name" String`,
 			`	"message" String`,
-			`	"service.name" String`,
+			`	"service::name" String`,
 			`	"severity" String`,
 			`	"source" String`,
 			`	INDEX severity_idx severity TYPE set(25) GRANULARITY 4`,
@@ -75,7 +75,7 @@ var insertTests = []struct {
 			`(`,
 			`	`,
 			`	"@timestamp" DateTime64`,
-			`	"host.name" String`,
+			`	"host::name" String`,
 			`	"message" String`,
 			`	"random1" Array(String)`,
 			`	"random2" string`,
@@ -108,10 +108,10 @@ var configs = []*ChTableConfig{
 }
 
 var expectedInserts = []string{
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow ` + insertTests[0].insertJson,
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["service.name","severity","source"\],"attributes_string_value":\["frontend","debug","rhel"\],"@timestamp":"2024-01-27T16:11:19.94Z","host.name":"hermes","message":"User password reset failed"}`,
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow ` + strings.Replace(strings.Replace(insertTests[1].insertJson, "[", `\[`, 1), "]", `\]`, 1),
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["random1","random2","severity"\],"attributes_string_value":\["\[debug\]","random-string","frontend"\],"@timestamp":"2024-01-27T16:11:19.94Z","host.name":"hermes","message":"User password reset failed"}`,
+	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","service::name":"frontend","severity":"debug","source":"rhel"}`,
+	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["service::name","severity","source"\],"attributes_string_value":\["frontend","debug","rhel"\],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`,
+	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":\["debug"\],"random2":"random-string","severity":"frontend"}`,
+	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["random1","random2","severity"\],"attributes_string_value":\["\[debug\]","random-string","frontend"\],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`,
 }
 
 type logManagerHelper struct {
@@ -127,7 +127,7 @@ func logManagersNonEmpty(cfg *ChTableConfig) []logManagerHelper {
 			Config: cfg,
 			Cols: map[string]*Column{
 				"@timestamp":       dateTime("@timestamp"),
-				"host.name":        genericString("host.name"),
+				"host::name":       genericString("host::name"),
 				"message":          lowCardinalityString("message"),
 				"non-insert-field": genericString("non-insert-field"),
 			},

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -266,13 +266,6 @@ func RemoveTypeMismatchSchemaFields(m SchemaMap, t *Table) SchemaMap {
 		}
 	}
 	for fieldName, v := range m {
-		withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
-		if fieldName != withoutDotsFieldName {
-			m[withoutDotsFieldName] = v
-			delete(m, fieldName)
-			fieldName = withoutDotsFieldName
-		}
-
 		col, ok := t.Cols[fieldName]
 		if ok && col != nil {
 			switch v := v.(type) {

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -86,7 +86,17 @@ func JsonToColumns(namespace string, m SchemaMap, indentLvl int, config *ChTable
 			if indentLvl == 1 && name == timestampFieldName && config.timestampDefaultsNow {
 				fType += " DEFAULT now64()"
 			}
-			resultColumns = append(resultColumns, CreateTableEntry{ClickHouseColumnName: nameFormatter.Format(namespace, name), ClickHouseType: fType})
+
+			// We still may have name like:
+			// "service.name": { "very.name": "value" }
+			// Before that code it would be transformed to:
+			// "service.name::very.name"
+			// So I convert it to:
+			// "service::name::very::name"
+			internalName := nameFormatter.Format(namespace, name)
+			// We should never have dots in the field names, see 4 ADR
+			internalName = strings.Replace(internalName, ".", "::", -1)
+			resultColumns = append(resultColumns, CreateTableEntry{ClickHouseColumnName: internalName, ClickHouseType: fType})
 		}
 	}
 	return resultColumns
@@ -102,7 +112,7 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter plugins.TableCo
 	for _, field := range schemaMapping.Fields {
 		var fType string
 
-		// FIXME: shouldn't InternalPropertyName already have "::"? (it currently doesn't)
+		// We should never have dots in the field names, see 4 ADR
 		internalPropertyName := strings.Replace(field.InternalPropertyName.AsString(), ".", "::", -1)
 
 		switch field.Type.Name {
@@ -256,6 +266,13 @@ func RemoveTypeMismatchSchemaFields(m SchemaMap, t *Table) SchemaMap {
 		}
 	}
 	for fieldName, v := range m {
+		withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
+		if fieldName != withoutDotsFieldName {
+			m[withoutDotsFieldName] = v
+			delete(m, fieldName)
+			fieldName = withoutDotsFieldName
+		}
+
 		col, ok := t.Cols[fieldName]
 		if ok && col != nil {
 			switch v := v.(type) {


### PR DESCRIPTION
This is quick fix, currently we double create columns:
![image](https://github.com/user-attachments/assets/b24cb564-15a0-426b-9660-641bb8266c75)
This removes original `host.name`.

I suggest next week we talk about properly addressing it.

