### PR TITLE
Removing unused params

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -373,9 +373,10 @@ func findSchemaPointer(schemaRegistry schema.Registry, tableName string) *schema
 	return nil
 }
 
-func buildCreateTableQueryNoOurFields(ctx context.Context, tableName string, jsonData types.JSON, tableConfig *ChTableConfig, cfg config.QuesmaConfiguration, schemaRegistry schema.Registry, nameFormatter plugins.TableColumNameFormatter) (string, error) {
+func (lm *LogManager) buildCreateTableQueryNoOurFields(ctx context.Context, tableName string,
+	jsonData types.JSON, tableConfig *ChTableConfig, nameFormatter plugins.TableColumNameFormatter) (string, error) {
 
-	columns := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(schemaRegistry, tableName)) + Indexes(jsonData)
+	columns := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(lm.schemaRegistry, tableName)) + Indexes(jsonData)
 
 	createTableCmd := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s"
 (
@@ -407,7 +408,7 @@ func Indexes(m SchemaMap) string {
 func (lm *LogManager) CreateTableFromInsertQuery(ctx context.Context, name string, jsonData types.JSON, config *ChTableConfig, tableFormatter plugins.TableColumNameFormatter) error {
 	// TODO fix lm.AddTableIfDoesntExist(name, jsonData)
 
-	query, err := buildCreateTableQueryNoOurFields(ctx, name, jsonData, config, lm.cfg, lm.schemaRegistry, tableFormatter)
+	query, err := lm.buildCreateTableQueryNoOurFields(ctx, name, jsonData, config, tableFormatter)
 	if err != nil {
 		return err
 	}

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -133,8 +133,9 @@ func TestAddTimestamp(t *testing.T) {
 		preferCastingToOthers:                 false,
 	}
 	nameFormatter := &columNameFormatter{separator: "::"}
-
-	query, err := buildCreateTableQueryNoOurFields(context.Background(), "tableName", types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`), tableConfig, config.QuesmaConfiguration{}, schema.StaticRegistry{}, nameFormatter)
+	lm := NewLogManagerEmpty()
+	lm.schemaRegistry = schema.StaticRegistry{}
+	query, err := lm.buildCreateTableQueryNoOurFields(context.Background(), "tableName", types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`), tableConfig, nameFormatter)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(query, timestampFieldName))
 }

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -152,13 +152,12 @@ func logManagers(config *ChTableConfig) []logManagerHelper {
 }
 
 func TestAutomaticTableCreationAtInsert(t *testing.T) {
-	cfg := config.QuesmaConfiguration{}
 	for index1, tt := range insertTests {
 		for index2, tableConfig := range configs {
 			for index3, lm := range logManagers(tableConfig) {
 				t.Run("case insertTest["+strconv.Itoa(index1)+"], config["+strconv.Itoa(index2)+"], logManager["+strconv.Itoa(index3)+"]", func(t *testing.T) {
-
-					query, err := buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, cfg, schema.StaticRegistry{}, &columNameFormatter{separator: "::"})
+					lm.lm.schemaRegistry = schema.StaticRegistry{}
+					query, err := lm.lm.buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, &columNameFormatter{separator: "::"})
 					assert.NoError(t, err)
 					table, err := NewTable(query, tableConfig)
 					assert.NoError(t, err)


### PR DESCRIPTION
By adding receiver to `buildCreateTableQueryNoOurFields` we can remove `schemaRegistry` passed as arg + unused `config`