### PR TITLE
Support sending bulk entries to both Elastic and ClickHouse

### DIFF
--- a/quesma/proxy/l4_proxy.go
+++ b/quesma/proxy/l4_proxy.go
@@ -106,17 +106,18 @@ func configureRouting() *http.ServeMux {
 			return
 		}
 
-		err := ndjson.BulkForEach(func(operation types.BulkOperation, document types.JSON) {
+		err := ndjson.BulkForEach(func(i int, operation types.BulkOperation, _, document types.JSON) error {
 
 			index := operation.GetIndex()
 			if index == "" {
 				logger.Error().Msg("No index in operation")
-				return
+				return nil
 			}
 
 			if !elasticsearch.IsInternalIndex(index) {
 				stats.GlobalStatistics.Process(configuration, index, document, clickhouse.NestedSeparator)
 			}
+			return nil
 		})
 
 		if err != nil {

--- a/quesma/proxy/l4_proxy.go
+++ b/quesma/proxy/l4_proxy.go
@@ -106,7 +106,7 @@ func configureRouting() *http.ServeMux {
 			return
 		}
 
-		err := ndjson.BulkForEach(func(i int, operation types.BulkOperation, _, document types.JSON) error {
+		err := ndjson.BulkForEach(func(entryNumber int, operation types.BulkOperation, _, document types.JSON) error {
 
 			index := operation.GetIndex()
 			if index == "" {

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -93,7 +93,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 	var elasticRequestBody []byte
 	var elasticBulkEntries []BulkRequestEntry
 
-	err := bulk.BulkForEach(func(i int, op types.BulkOperation, rawOp types.JSON, document types.JSON) error {
+	err := bulk.BulkForEach(func(entryNumber int, op types.BulkOperation, rawOp types.JSON, document types.JSON) error {
 		index := op.GetIndex()
 		operation := op.GetOperation()
 
@@ -101,7 +101,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 			operation: operation,
 			index:     index,
 			document:  document,
-			response:  &results[i],
+			response:  &results[entryNumber],
 		}
 
 		if index == "" {

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -3,110 +3,260 @@
 package bulk
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"quesma/clickhouse"
 	"quesma/logger"
 	"quesma/plugins/registry"
+	"quesma/queryparser"
 	"quesma/quesma/config"
 	"quesma/quesma/recovery"
 	"quesma/quesma/types"
 	"quesma/stats"
-	"quesma/stats/errorstats"
 	"quesma/telemetry"
 	"sync"
 )
 
 type (
-	WriteResult struct {
-		Operation string
-		Index     string
+	BulkRequestEntry struct {
+		operation string
+		index     string
+		document  types.JSON
+		response  *BulkItem
+	}
+
+	// Model of the response from Elastic's _bulk API
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-api-response-body
+	BulkResponse struct {
+		Errors bool       `json:"errors"`
+		Items  []BulkItem `json:"items"`
+		Took   int        `json:"took"`
+	}
+	// Create, Index, Update, Delete are of BulkSingleResponse type,
+	// but declaring them as 'any' to preserve any excess fields Elastic might send
+	BulkItem struct {
+		Create any `json:"create,omitempty"`
+		Index  any `json:"index,omitempty"`
+		Update any `json:"update,omitempty"`
+		Delete any `json:"delete,omitempty"`
+	}
+	BulkSingleResponse struct {
+		ID          string             `json:"_id"`
+		Index       string             `json:"_index"`
+		PrimaryTerm int                `json:"_primary_term"`
+		SeqNo       int                `json:"_seq_no"`
+		Shards      BulkShardsResponse `json:"_shards"`
+		Version     int                `json:"_version"`
+		Result      string             `json:"result,omitempty"`
+		Status      int                `json:"status"`
+		Error       any                `json:"error,omitempty"`
+	}
+	BulkShardsResponse struct {
+		Failed     int `json:"failed"`
+		Successful int `json:"successful"`
+		Total      int `json:"total"`
 	}
 )
 
 func Write(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *clickhouse.LogManager,
-	cfg config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []WriteResult) {
+	cfg config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []BulkItem, err error) {
 	defer recovery.LogPanic()
 
-	bulkSize := len(bulk)
-	maybeLogBatchSize(bulkSize / 2) // we divided payload by 2 so that we don't take into account the `action_and_meta_data` line, ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
-	indicesWithDocumentsToInsert := make(map[string][]types.JSON, bulkSize)
+	bulkSize := len(bulk) / 2 // we divided payload by 2 so that we don't take into account the `action_and_meta_data` line, ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+	maybeLogBatchSize(bulkSize)
 
-	err := bulk.BulkForEach(func(op types.BulkOperation, document types.JSON) {
+	results, clickhouseDocumentsToInsert, elasticRequestBody, elasticBulkEntries, err := splitBulk(ctx, defaultIndex, bulk, bulkSize, cfg)
+	if err != nil {
+		return []BulkItem{}, err
+	}
 
+	err = sendToElastic(elasticRequestBody, cfg, elasticBulkEntries)
+	if err != nil {
+		return []BulkItem{}, err
+	}
+
+	sendToClickhouse(ctx, clickhouseDocumentsToInsert, phoneHomeAgent, cfg, lm)
+
+	return results, nil
+}
+
+func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bulkSize int, cfg config.QuesmaConfiguration) ([]BulkItem, map[string][]BulkRequestEntry, []byte, []BulkRequestEntry, error) {
+	results := make([]BulkItem, bulkSize)
+
+	clickhouseDocumentsToInsert := make(map[string][]BulkRequestEntry, bulkSize)
+	var elasticRequestBody []byte
+	var elasticBulkEntries []BulkRequestEntry
+
+	err := bulk.BulkForEach(func(i int, op types.BulkOperation, rawOp types.JSON, document types.JSON) error {
 		index := op.GetIndex()
 		operation := op.GetOperation()
+
+		entryWithResponse := BulkRequestEntry{
+			operation: operation,
+			index:     index,
+			document:  document,
+			response:  &results[i],
+		}
 
 		if index == "" {
 			if defaultIndex != nil {
 				index = *defaultIndex
 			} else {
-				logger.ErrorWithCtxAndReason(ctx, "no index name in _bulk").
-					Msgf("Invalid index name in _bulk: %s", operation)
-				return
+				// Elastic also fails the entire bulk in such case
+				logger.ErrorWithCtxAndReason(ctx, "no index name in _bulk").Msgf("no index name in _bulk")
+				return fmt.Errorf("no index name in _bulk. Operation: %v, Document: %v", rawOp, document)
 			}
 		}
 
 		indexConfig, found := cfg.IndexConfig[index]
-		if !found {
-			logger.Debug().Msgf("index '%s' is not configured, skipping", index)
-			return
+		if !found || !indexConfig.Enabled {
+			// Bulk entry for Elastic - forward the request as-is
+			opBytes, err := rawOp.Bytes()
+			if err != nil {
+				return err
+			}
+			elasticRequestBody = append(elasticRequestBody, opBytes...)
+			elasticRequestBody = append(elasticRequestBody, '\n')
+
+			documentBytes, err := document.Bytes()
+			if err != nil {
+				return err
+			}
+			elasticRequestBody = append(elasticRequestBody, documentBytes...)
+			elasticRequestBody = append(elasticRequestBody, '\n')
+
+			elasticBulkEntries = append(elasticBulkEntries, entryWithResponse)
+		} else {
+			// Bulk entry for Clickhouse
+			if operation != "create" && operation != "index" {
+				// Elastic also fails the entire bulk in such case
+				logger.ErrorWithCtxAndReason(ctx, "unsupported bulk operation type").Msgf("unsupported bulk operation type: %s", operation)
+				return fmt.Errorf("unsupported bulk operation type: %s. Operation: %v, Document: %v", operation, rawOp, document)
+			}
+
+			clickhouseDocumentsToInsert[index] = append(clickhouseDocumentsToInsert[index], entryWithResponse)
 		}
-		if !indexConfig.Enabled {
-			logger.Debug().Msgf("index '%s' is disabled, ignoring", index)
-			return
-		}
-
-		switch operation {
-		case "create", "index":
-			results = append(results, WriteResult{operation, index})
-			indicesWithDocumentsToInsert[index] = append(indicesWithDocumentsToInsert[index], document)
-		case "update":
-
-			errorstats.GlobalErrorStatistics.RecordKnownError("_bulk update is not supported", nil,
-				"We do not support 'update' in _bulk")
-			logger.Debug().Msg("Not supporting 'update' _bulk.")
-
-		case "delete":
-			errorstats.GlobalErrorStatistics.RecordKnownError("_bulk delete is not supported", nil,
-				"We do not support 'delete' in _bulk")
-			logger.Debug().Msg("Not supporting 'delete' _bulk.")
-
-		default:
-			errorstats.GlobalErrorStatistics.RecordUnknownError(nil,
-				fmt.Sprintf("Unexpected operation in _bulk: %v", operation))
-			logger.Error().Msgf("Invalid JSON with operation definition in _bulk: %s", operation)
-		}
-
+		return nil
 	})
 
-	if err != nil {
-		logger.ErrorWithCtx(ctx).Msgf("Error processing _bulk: %v", err)
-		return
+	return results, clickhouseDocumentsToInsert, elasticRequestBody, elasticBulkEntries, err
+}
+
+func sendToElastic(elasticRequestBody []byte, cfg config.QuesmaConfiguration, elasticBulkEntries []BulkRequestEntry) error {
+	if len(elasticRequestBody) == 0 {
+		// Fast path - no need to contact Elastic!
+		return nil
 	}
 
-	for indexName, documents := range indicesWithDocumentsToInsert {
+	req, _ := http.NewRequest("POST", cfg.Elasticsearch.Url.String()+"/_bulk", bytes.NewBuffer(elasticRequestBody))
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	client := http.Client{} // FIXME
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("error sending bulk request (%v): %s", response.StatusCode, responseBody)
+	}
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	var elasticBulkResponse BulkResponse
+	err = json.Unmarshal(responseBody, &elasticBulkResponse)
+	if err != nil {
+		return err
+	}
+
+	// Copy Elastic's response entries to our response
+	for i, entry := range elasticBulkResponse.Items {
+		*elasticBulkEntries[i].response = entry
+	}
+	return nil
+}
+
+func sendToClickhouse(ctx context.Context, clickhouseDocumentsToInsert map[string][]BulkRequestEntry, phoneHomeAgent telemetry.PhoneHomeAgent, cfg config.QuesmaConfiguration, lm *clickhouse.LogManager) {
+	for indexName, documents := range clickhouseDocumentsToInsert {
 		phoneHomeAgent.IngestCounters().Add(indexName, int64(len(documents)))
 
 		config.RunConfigured(ctx, cfg, indexName, make(types.JSON), func() error {
 			for _, document := range documents {
-				stats.GlobalStatistics.Process(cfg, indexName, document, clickhouse.NestedSeparator)
+				stats.GlobalStatistics.Process(cfg, indexName, document.document, clickhouse.NestedSeparator)
 			}
 			// if the index is mapped to specified database table in the configuration, use that table
 			if len(cfg.IndexConfig[indexName].Override) > 0 {
 				indexName = cfg.IndexConfig[indexName].Override
 			}
-			nameFormatter, err := registry.TableColumNameFormatterFor(indexName, cfg, nil)
-			if err != nil {
-				logger.Error().Msgf("Error getting table column name formatter for index %s: %v", indexName, err)
-				return err
+
+			inserts := make([]types.JSON, len(documents))
+			for i, document := range documents {
+				inserts[i] = document.document
 			}
-			tableMap, _ := lm.GetTableDefinitions()
-			transformer := registry.IngestTransformerFor(indexName, cfg, nil, tableMap)
-			return lm.ProcessInsertQuery(ctx, indexName, documents, transformer, nameFormatter)
+
+			nameFormatter, err := registry.TableColumNameFormatterFor(indexName, cfg, nil)
+			if err == nil {
+				tableMap, _ := lm.GetTableDefinitions()
+				transformer := registry.IngestTransformerFor(indexName, cfg, nil, tableMap)
+				err = lm.ProcessInsertQuery(ctx, indexName, inserts, transformer, nameFormatter)
+			}
+
+			for _, document := range documents {
+				bulkSingleResponse := BulkSingleResponse{
+					ID:          "fakeId",
+					Index:       document.index,
+					PrimaryTerm: 1,
+					SeqNo:       0,
+					Shards: BulkShardsResponse{
+						Failed:     0,
+						Successful: 1,
+						Total:      1,
+					},
+					Version: 0,
+					Result:  "created",
+					Status:  201,
+				}
+				if err != nil {
+					bulkSingleResponse.Result = ""
+					bulkSingleResponse.Status = 400
+					bulkSingleResponse.Shards = BulkShardsResponse{
+						Failed:     1,
+						Successful: 0,
+						Total:      1,
+					}
+					bulkSingleResponse.Error = queryparser.Error{
+						RootCause: []queryparser.RootCause{
+							{
+								Type:   "quesma_error",
+								Reason: err.Error(),
+							},
+						},
+						Type:   "quesma_error",
+						Reason: err.Error(),
+					}
+				}
+
+				switch document.operation {
+				case "create":
+					document.response.Create = bulkSingleResponse
+
+				case "index":
+					document.response.Index = bulkSingleResponse
+
+				default:
+					return fmt.Errorf("unsupported bulk operation type: %s. Document: %v", document.operation, document.document)
+				}
+			}
+			return nil
 		})
 	}
-	return results
 }
 
 // Global set to keep track of logged batch sizes

--- a/quesma/quesma/functionality/bulk/bulk_test.go
+++ b/quesma/quesma/functionality/bulk/bulk_test.go
@@ -1,0 +1,45 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package bulk
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_unmarshalElasticResponse(t *testing.T) {
+	tests := []struct {
+		name                    string
+		bulkResponseFromElastic string
+	}{
+		{
+			name:                    "bulk response with no errors (1)",
+			bulkResponseFromElastic: `{"errors":false,"took":12,"items":[{"create":{"_index":"testcase15","_id":"XLkV5JABtqi1BREg-Ldw","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":7,"_primary_term":1,"status":201}}]}`,
+		},
+		{
+			name:                    "bulk response with no errors (2)",
+			bulkResponseFromElastic: `{"errors":false,"took":68,"items":[{"create":{"_index":"testcase15","_id":"XrkW5JABtqi1BREgWbeP","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":9,"_primary_term":1,"status":201}}]}`,
+		},
+		{
+			name:                    "bulk response with some error",
+			bulkResponseFromElastic: `{"errors":true,"took":28,"items":[{"create":{"_index":"testcase15","_id":"X7kW5JABtqi1BREgc7eg","status":400,"error":{"type":"document_parsing_exception","reason":"[1:14] failed to parse field [newcolumn] of type [long] in document with id 'X7kW5JABtqi1BREgc7eg'. Preview of field's value: 'invalid'","caused_by":{"type":"illegal_argument_exception","reason":"For input string: \"invalid\""}}}}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bulkResponse := &BulkResponse{}
+			if err := json.Unmarshal([]byte(tt.bulkResponseFromElastic), bulkResponse); err != nil {
+				t.Errorf("error while unmarshaling elastic response: %v", err)
+			}
+
+			marshaled, err := json.Marshal(bulkResponse)
+			if err != nil {
+				t.Errorf("error while marshaling elastic response: %v", err)
+			}
+
+			require.JSONEq(t, tt.bulkResponseFromElastic, string(marshaled), "unmarshaled and marshaled response should be the same")
+		})
+	}
+}

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -170,6 +170,12 @@ func Test_matchedAgainstBulkBody(t *testing.T) {
 			name:   "multiple indexes, some tables not present",
 			body:   `{"create":{"_index":"logs-generic-default"}}` + "\n{}\n" + `{"create":{"_index":"non-existent"}}`,
 			config: indexConfig("logs-generic-default", true),
+			want:   true,
+		},
+		{
+			name:   "multiple indexes, all tables not present",
+			body:   `{"create":{"_index":"not-there"}}` + "\n{}\n" + `{"create":{"_index":"non-existent"}}`,
+			config: indexConfig("logs-generic-default", true),
 			want:   false,
 		},
 	}

--- a/quesma/quesma/types/ndjson.go
+++ b/quesma/quesma/types/ndjson.go
@@ -63,7 +63,7 @@ func (op BulkOperation) GetOperation() string {
 	return ""
 }
 
-func (n NDJSON) BulkForEach(f func(operation BulkOperation, doc JSON)) error {
+func (n NDJSON) BulkForEach(f func(i int, operationParsed BulkOperation, operation JSON, doc JSON) error) error {
 
 	for i := 0; i+1 < len(n); i += 2 {
 		operation := n[i]  // {"create":{"_index":"kibana_sample_data_flights", "_id": 1}}
@@ -71,14 +71,12 @@ func (n NDJSON) BulkForEach(f func(operation BulkOperation, doc JSON)) error {
 
 		var operationParsed BulkOperation // operationName (create, index, update, delete) -> DocumentTarget
 
-		err := operation.Remarshal(&operationParsed)
+		_ = operation.Remarshal(&operationParsed) // ignore error, the callback must handle it (it will see an unknown operation)
+
+		err := f(i/2, operationParsed, operation, document)
 		if err != nil {
 			return err
 		}
-
-		f(operationParsed, document)
 	}
-
 	return nil
-
 }

--- a/quesma/quesma/types/ndjson.go
+++ b/quesma/quesma/types/ndjson.go
@@ -63,7 +63,7 @@ func (op BulkOperation) GetOperation() string {
 	return ""
 }
 
-func (n NDJSON) BulkForEach(f func(i int, operationParsed BulkOperation, operation JSON, doc JSON) error) error {
+func (n NDJSON) BulkForEach(f func(entryNumber int, operationParsed BulkOperation, operation JSON, doc JSON) error) error {
 
 	for i := 0; i+1 < len(n); i += 2 {
 		operation := n[i]  // {"create":{"_index":"kibana_sample_data_flights", "_id": 1}}


### PR DESCRIPTION
_bulk requests can write data to many indexes. In particular, a bulk request could contain writes to both enabled and disabled indexes, so some parts of it should be sent to Elastic and some parts to ClickHouse.

Previously the code supported only either sending the entire request to Elastic or sending the inserts to ClickHouse. After this change, the code splits the bulk request into a Elastic and ClickHouse portions and can send it to both endpoints.

The response from Elastic is parsed and "multiplexed" into the final Quesma response (alongside results from ClickHouse). This required some code refactoring and now the code has a proper support for setting response codes/status per each inserted entry.