### PR TITLE
Remove kibana_sample_data_logs from the official example configuration

### DIFF
--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -32,18 +32,6 @@ indexes:
     mappings:
       DestLocation: "geo_point"
       OriginLocation: "geo_point"
-  kibana_sample_data_logs:
-    enabled: true
-    mappings:
-      ip: "ip"
-      clientip: "ip"
-      geo.coordinates: "point"
-      extension: "text"
-      url: "text"
-    aliases:
-      timestamp:
-        source: "timestamp"
-        target: "@timestamp"
   logs-generic-default:
     enabled: true
     static-schema:


### PR DESCRIPTION
The official example doesn't showcase `kibana_sample_data_logs` so there's no need to clutter the configuration file with redundant entries