### PR TITLE
Pancake - quickfix `(date) histogram`

### DIFF
--- a/quesma/queryparser/pancake_model.go
+++ b/quesma/queryparser/pancake_model.go
@@ -21,7 +21,7 @@ type pancakeAggregationLevel struct {
 	// only for bucket aggregations
 	children                []*pancakeAggregationLevel
 	orderBy                 []model.OrderByExpr
-	limit                   int // 0 if none, only for bucket aggregation
+	limit                   int // pancakeBucketAggregationNoLimit if none, only for bucket aggregation
 	isKeyed                 bool
 	filterOutEmptyKeyBucket bool
 
@@ -45,7 +45,7 @@ type pancakeLayerBucketAggregation struct {
 
 	// only for bucket aggregations
 	orderBy []model.OrderByExpr
-	limit   int // 0 if none, only for bucket aggregation
+	limit   int // pancakeBucketAggregationNoLimit if none
 	isKeyed bool
 
 	metadata                model.JsonMap
@@ -81,6 +81,7 @@ type pancakeAggregation struct {
 }
 
 const PancakeTotalCountMetricName = "__quesma_total_count"
+const pancakeBucketAggregationNoLimit = 0
 
 // Not a real aggregation, but it is a pancake that has alternative JSON rendering
 type PancakeQueryType struct {

--- a/quesma/queryparser/pancake_query_generation.go
+++ b/quesma/queryparser/pancake_query_generation.go
@@ -194,8 +194,10 @@ func (p *pancakeQueryGenerator) generateSelectCommand(aggregation *pancakeAggreg
 					}
 				}
 
-				whereRank := model.NewInfixExpr(p.newQuotedLiteral(aliasedRank.Alias), "<=", model.NewLiteral(bucketAggregation.limit))
-				whereRanks = append(whereRanks, whereRank)
+				if bucketAggregation.limit != pancakeBucketAggregationNoLimit {
+					whereRank := model.NewInfixExpr(p.newQuotedLiteral(aliasedRank.Alias), "<=", model.NewLiteral(bucketAggregation.limit))
+					whereRanks = append(whereRanks, whereRank)
+				}
 
 				rankOrderBy := model.NewOrderByExpr([]model.Expr{p.newQuotedLiteral(aliasedRank.Alias)}, model.AscOrder)
 				rankOrderBys = append(rankOrderBys, rankOrderBy)

--- a/quesma/queryparser/pancake_query_generation_test.go
+++ b/quesma/queryparser/pancake_query_generation_test.go
@@ -41,13 +41,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 
 	for i, test := range allAggregationTestsWithoutPipeline() { // TODO fix pipeline
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {
-			// --------
-			// TODO FIXME
-			// Fix date_histogram always having WHERE "aggr__0__1__order_1_rank"<=0
-			// It's wrong and should be an easy fix.
-			// It's e.g. test with i == 2
-			// --------
-
 			if test.ExpectedPancakeSQL == "" || test.ExpectedPancakeResults == nil { // TODO remove this
 				t.Skip("Not updated answers for pancake.")
 			}

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -671,7 +671,7 @@ var AggregationTests = []AggregationTestCase{
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))
 				GROUP BY "FlightDelayType" AS "aggr__0__key_0",
 				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS "aggr__0__1__key_0"))
-			WHERE ("aggr__0__order_1_rank"<=10 AND "aggr__0__1__order_1_rank"<=0)
+			WHERE "aggr__0__order_1_rank"<=10
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [3]
@@ -2032,7 +2032,7 @@ var AggregationTests = []AggregationTestCase{
 				  parseDateTime64BestEffort('2024-02-09T16:36:49.940Z')))
 				GROUP BY "severity" AS "aggr__0__key_0", toInt64(toUnixTimestamp64Milli(
 				  "@timestamp") / 10800000) AS "aggr__0__1__key_0"))
-			WHERE ("aggr__0__order_1_rank"<=3 AND "aggr__0__1__order_1_rank"<=0)
+			WHERE "aggr__0__order_1_rank"<=3
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [10]
@@ -2860,7 +2860,7 @@ var AggregationTests = []AggregationTestCase{
 				GROUP BY COALESCE("event.dataset",'unknown') AS "aggr__stats__key_0",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
 				  "aggr__stats__series__key_0"))
-			WHERE ("aggr__stats__order_1_rank"<=4 AND "aggr__stats__series__order_1_rank"<=0)
+			WHERE "aggr__stats__order_1_rank"<=4
 			ORDER BY "aggr__stats__order_1_rank" ASC, "aggr__stats__series__order_1_rank" ASC`,
 	},
 	{ // [14], "old" test, also can be found in testdata/requests.go TestAsyncSearch[5]
@@ -7066,7 +7066,7 @@ var AggregationTests = []AggregationTestCase{
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0", "FlightDelayMin" AS
 				  "aggr__0__1__key_0"))
-			WHERE ("aggr__0__order_1_rank"<=8 AND "aggr__0__1__order_1_rank"<=0)
+			WHERE "aggr__0__order_1_rank"<=8
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [36]
@@ -7332,7 +7332,7 @@ var AggregationTests = []AggregationTestCase{
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0", "FlightDelayMin" AS
 				  "aggr__0__1__key_0"))
-			WHERE ("aggr__0__order_1_rank"<=10 AND "aggr__0__1__order_1_rank"<=0)
+			WHERE "aggr__0__order_1_rank"<=10
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [38]


### PR DESCRIPTION
We want all the buckets in `(date) histogram`, so there should be no limit