### PR TITLE
Fix `UInt*` inferred type mapping

### DIFF
--- a/quesma/clickhouse/type_adapter.go
+++ b/quesma/clickhouse/type_adapter.go
@@ -26,7 +26,7 @@ func (c SchemaTypeAdapter) Convert(s string) (schema.Type, bool) {
 		return schema.TypeKeyword, true
 	case "Int", "Int8", "Int16", "Int32", "Int64":
 		return schema.TypeLong, true
-	case "Uint8", "Uint16", "Uint32", "Uint64", "Uint128", "Uint256":
+	case "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UInt256":
 		return schema.TypeUnsignedLong, true
 	case "Bool":
 		return schema.TypeBoolean, true

--- a/quesma/clickhouse/type_adapter.go
+++ b/quesma/clickhouse/type_adapter.go
@@ -27,7 +27,7 @@ func (c SchemaTypeAdapter) Convert(s string) (schema.Type, bool) {
 	case "Int", "Int8", "Int16", "Int32", "Int64":
 		return schema.TypeLong, true
 	case "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UInt256":
-		return schema.TypeUnsignedLong, true
+		return schema.TypeInteger, true
 	case "Bool":
 		return schema.TypeBoolean, true
 	case "Float32", "Float64":

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -142,8 +142,8 @@ func asElasticType(t schema.Type) string {
 		return elasticsearch_field_types.FieldTypeObject
 	case schema.TypePoint.Name:
 		return elasticsearch_field_types.FieldTypeGeoPoint
-	case schema.TypeUnsignedLong.Name:
-		return elasticsearch_field_types.FieldTypeUnsignedLong
+	case schema.TypeInteger.Name:
+		return elasticsearch_field_types.FieldTypeInteger
 	default:
 		return elasticsearch_field_types.FieldTypeText
 	}

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -142,6 +142,8 @@ func asElasticType(t schema.Type) string {
 		return elasticsearch_field_types.FieldTypeObject
 	case schema.TypePoint.Name:
 		return elasticsearch_field_types.FieldTypeGeoPoint
+	case schema.TypeUnsignedLong.Name:
+		return elasticsearch_field_types.FieldTypeUnsignedLong
 	default:
 		return elasticsearch_field_types.FieldTypeText
 	}

--- a/quesma/schema/types.go
+++ b/quesma/schema/types.go
@@ -8,6 +8,7 @@ var (
 	// TODO add more and review existing
 	TypeText         = Type{Name: "text", Properties: []TypeProperty{Searchable, FullText}}
 	TypeKeyword      = Type{Name: "keyword", Properties: []TypeProperty{Searchable, Aggregatable}}
+	TypeInteger      = Type{Name: "integer", Properties: []TypeProperty{Searchable, Aggregatable}}
 	TypeLong         = Type{Name: "long", Properties: []TypeProperty{Searchable, Aggregatable}}
 	TypeUnsignedLong = Type{Name: "unsigned_long", Properties: []TypeProperty{Searchable, Aggregatable}}
 	TypeTimestamp    = Type{Name: "timestamp", Properties: []TypeProperty{Searchable, Aggregatable}}


### PR DESCRIPTION
There's been a bug in case sensitivity - `UInt8` from ClickHouse has defaulted to `text` field in our case.



I'm letting unsigned integers being just integers in ES response for now. We could also make these `unsigned_long`s...

The inconsistency here is that we currently translate integers from CH to longs in ES.
**So perhaps we should translate unsigned integers from CH to unsigned longs in ES (and completely ditch the `integer` type)?** I'm open to your suggestions here.

