### PR TITLE
Fix parseTerm to resolve field name

### DIFF
--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -550,7 +550,8 @@ func (cw *ClickhouseQueryTranslator) parseTerm(queryMap QueryMap) model.SimpleQu
 				whereClause = model.NewInfixExpr(model.NewLiteral("0"), "=", model.NewLiteral("0 /* "+k+"="+sprint(v)+" */"))
 				return model.NewSimpleQuery(whereClause, true)
 			}
-			whereClause = model.NewInfixExpr(model.NewColumnRef(k), "=", model.NewLiteral(sprint(v)))
+			fieldName := cw.ResolveField(cw.Ctx, k)
+			whereClause = model.NewInfixExpr(model.NewColumnRef(fieldName), "=", model.NewLiteral(sprint(v)))
 			return model.NewSimpleQuery(whereClause, true)
 		}
 	}

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -109,7 +109,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 			logger.Error().Msgf("Schema for table %s not found, this should never happen here", fromTable)
 		}
 
-		field, found := dataScheme.ResolveField(lhsValue)
+		field, found := dataScheme.ResolveFieldByInternalName(lhsValue)
 		if !found {
 			logger.Error().Msgf("Field %s not found in schema for table %s, should never happen here", lhsValue, fromTable)
 		}
@@ -131,7 +131,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 				&model.FunctionExpr{
 					Name: CASTPrimitive,
 					Args: []model.Expr{
-						&model.LiteralExpr{Value: lhsValue},
+						lhs.(model.Expr),
 						&model.LiteralExpr{Value: StringLiteral},
 					},
 				},


### PR DESCRIPTION
In most other `parse*` functions in `query_parser.go`, the incoming field names are first resolved with schema - this takes care of changing `.` to `::`. However, `parseTerm` was missing that call to `ResolveField` and just used the field name as-is (with `.`).

This caused the following query to not work properly:
```
GET index/_search
{
  "query": {
    "term": {
      "nested.clientip": "0.0.0.0/0"
    }
  }
}
```

Upon fixing `parseTerm`, `applyIpTransformations` had to be fixed - now it receives the "internal name" (`::`), not the original name (`.`) and has to resolve the field accordingly. Additionally, fields with `::` have to be quoted - not wrapped in un-quoted `model.LiteralExpr`.