### PR TITLE
Filter out Kibana APM/Fleet internal queries

### DIFF
--- a/quesma/feature/not_supported_test.go
+++ b/quesma/feature/not_supported_test.go
@@ -13,14 +13,18 @@ func TestNewUnsupportedFeature_index(t *testing.T) {
 
 	tests := []struct {
 		path     string
+		opaqueId string
 		isLogged bool
 	}{
-		{"/foo/_search", true},
-		{"/foo/_new_feature", true},
-		{"/bar/_search", false},
+		{"/foo/_search", "", true},
+		{"/foo/_new_feature", "", true},
+		{"/bar/_search", "", false},
 
-		{"/foo/_search/template", true},
-		{"/_scripts/foo", true},
+		{"/foo/_search/template", "", true},
+		{"/_scripts/foo", "", true},
+
+		{"/logs-elastic_agent-*/_search", "unknownId;kibana:task%20manager:run%20Fleet-Usage-Sender:Fleet-Usage-Sender-1.1.3", false},
+		{"/foo/_search", "unknownId;kibana:task%20manager:run%20Fleet-Usage-Sender:Fleet-Usage-Sender-1.1.3", false},
 	}
 
 	cfg := config.QuesmaConfiguration{}
@@ -43,7 +47,7 @@ func TestNewUnsupportedFeature_index(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.path, func(t *testing.T) {
-			given := AnalyzeUnsupportedCalls(ctx, "GET", tt.path, indexNameResolver)
+			given := AnalyzeUnsupportedCalls(ctx, "GET", tt.path, tt.opaqueId, indexNameResolver)
 			assert.Equal(t, tt.isLogged, given)
 		})
 	}

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -258,7 +258,7 @@ func (r *router) reroute(ctx context.Context, w http.ResponseWriter, req *http.R
 		}
 	} else {
 
-		feature.AnalyzeUnsupportedCalls(ctx, req.Method, req.URL.Path, logManager.ResolveIndexes)
+		feature.AnalyzeUnsupportedCalls(ctx, req.Method, req.URL.Path, req.Header.Get(opaqueIdHeaderKey), logManager.ResolveIndexes)
 
 		rawResponse := <-r.sendHttpRequestToElastic(ctx, req, reqBody, true)
 		response := rawResponse.response


### PR DESCRIPTION
Filter out internal queries made by Kibana APM and Kibana Fleet in `not_supported.go`. Previously the code would go into `checkIfOurIndex`, query the `indexResolver`, which would prevent Quesma from properly idling.

This code takes a new approach - instead of looking at the index name or parts of request, it now looks at `X-Opaque-Id` header and this seems to be a much cleaner, less hacky way to detect those internal Kibana queries.