### PR TITLE
Handle Nullable() columns in IP transformation

### DIFF
--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -74,6 +74,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 		const isIPAddressInRangePrimitive = "isIPAddressInRange"
 		const CASTPrimitive = "CAST"
 		const COALESCEPrimitive = "COALESCE"
+		const StringLiteral = "String"
 		var lhs, rhs interface{}
 		lhsValue := ""
 		rhsValue := ""
@@ -141,7 +142,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 									&model.LiteralExpr{Value: "'0.0.0.0'"},
 								},
 							},
-							Alias: "String",
+							Alias: StringLiteral,
 						},
 					},
 				},

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -73,7 +73,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 	visitor.OverrideVisitInfix = func(b *model.BaseExprVisitor, e model.InfixExpr) interface{} {
 		const isIPAddressInRangePrimitive = "isIPAddressInRange"
 		const CASTPrimitive = "CAST"
-		const StringLiteral = "'String'"
+		const COALESCEPrimitive = "COALESCE"
 		var lhs, rhs interface{}
 		lhsValue := ""
 		rhsValue := ""
@@ -135,7 +135,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 					Args: []model.Expr{
 						&model.AliasedExpr{
 							Expr: &model.FunctionExpr{
-								Name: "COALESCE",
+								Name: COALESCEPrimitive,
 								Args: []model.Expr{
 									lhs.(model.Expr),
 									&model.LiteralExpr{Value: "'0.0.0.0'"},

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -23,6 +23,7 @@ func (f fixedTableProvider) TableDefinitions() map[string]schema.Table {
 func Test_ipRangeTransform(t *testing.T) {
 	const isIPAddressInRangePrimitive = "isIPAddressInRange"
 	const CASTPrimitive = "CAST"
+	const COALESCEPrimitive = "COALESCE"
 	const StringLiteral = "'String'"
 	const IpFieldContent = "'111.42.223.209/16'"
 	IpFieldName := strconv.Quote("clientip")
@@ -80,8 +81,16 @@ func Test_ipRangeTransform(t *testing.T) {
 						&model.FunctionExpr{
 							Name: CASTPrimitive,
 							Args: []model.Expr{
-								&model.LiteralExpr{Value: IpFieldName},
-								&model.LiteralExpr{Value: StringLiteral},
+								&model.AliasedExpr{
+									Expr: &model.FunctionExpr{
+										Name: COALESCEPrimitive,
+										Args: []model.Expr{
+											&model.LiteralExpr{Value: IpFieldName},
+											&model.LiteralExpr{Value: "'0.0.0.0'"},
+										},
+									},
+									Alias: "String",
+								},
 							},
 						},
 						&model.LiteralExpr{Value: IpFieldContent},
@@ -100,8 +109,16 @@ func Test_ipRangeTransform(t *testing.T) {
 						&model.FunctionExpr{
 							Name: CASTPrimitive,
 							Args: []model.Expr{
-								&model.ColumnRef{ColumnName: "nested::clientip"},
-								&model.LiteralExpr{Value: StringLiteral},
+								&model.AliasedExpr{
+									Expr: &model.FunctionExpr{
+										Name: COALESCEPrimitive,
+										Args: []model.Expr{
+											&model.ColumnRef{ColumnName: "nested::clientip"},
+											&model.LiteralExpr{Value: "'0.0.0.0'"},
+										},
+									},
+									Alias: "String",
+								},
 							},
 						},
 						&model.LiteralExpr{Value: IpFieldContent},
@@ -120,8 +137,16 @@ func Test_ipRangeTransform(t *testing.T) {
 						&model.FunctionExpr{
 							Name: CASTPrimitive,
 							Args: []model.Expr{
-								&model.ColumnRef{ColumnName: IpFieldName},
-								&model.LiteralExpr{Value: StringLiteral},
+								&model.AliasedExpr{
+									Expr: &model.FunctionExpr{
+										Name: COALESCEPrimitive,
+										Args: []model.Expr{
+											&model.ColumnRef{ColumnName: IpFieldName},
+											&model.LiteralExpr{Value: "'0.0.0.0'"},
+										},
+									},
+									Alias: "String",
+								},
 							},
 						},
 						&model.LiteralExpr{Value: IpFieldContent},
@@ -152,8 +177,16 @@ func Test_ipRangeTransform(t *testing.T) {
 						&model.FunctionExpr{
 							Name: CASTPrimitive,
 							Args: []model.Expr{
-								&model.LiteralExpr{Value: IpFieldName},
-								&model.LiteralExpr{Value: StringLiteral},
+								&model.AliasedExpr{
+									Expr: &model.FunctionExpr{
+										Name: COALESCEPrimitive,
+										Args: []model.Expr{
+											&model.LiteralExpr{Value: IpFieldName},
+											&model.LiteralExpr{Value: "'0.0.0.0'"},
+										},
+									},
+									Alias: "String",
+								},
 							},
 						},
 						&model.LiteralExpr{Value: IpFieldContent},
@@ -189,14 +222,23 @@ func Test_ipRangeTransform(t *testing.T) {
 						},
 					},
 					Op: "AND",
+
 					Right: &model.FunctionExpr{
 						Name: isIPAddressInRangePrimitive,
 						Args: []model.Expr{
 							&model.FunctionExpr{
 								Name: CASTPrimitive,
 								Args: []model.Expr{
-									&model.LiteralExpr{Value: IpFieldName},
-									&model.LiteralExpr{Value: StringLiteral},
+									&model.AliasedExpr{
+										Expr: &model.FunctionExpr{
+											Name: COALESCEPrimitive,
+											Args: []model.Expr{
+												&model.LiteralExpr{Value: IpFieldName},
+												&model.LiteralExpr{Value: "'0.0.0.0'"},
+											},
+										},
+										Alias: "String",
+									},
 								},
 							},
 							&model.LiteralExpr{Value: IpFieldContent},

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -24,7 +24,7 @@ func Test_ipRangeTransform(t *testing.T) {
 	const isIPAddressInRangePrimitive = "isIPAddressInRange"
 	const CASTPrimitive = "CAST"
 	const COALESCEPrimitive = "COALESCE"
-	const StringLiteral = "'String'"
+	const StringLiteral = "String"
 	const IpFieldContent = "'111.42.223.209/16'"
 	IpFieldName := strconv.Quote("clientip")
 
@@ -89,7 +89,7 @@ func Test_ipRangeTransform(t *testing.T) {
 											&model.LiteralExpr{Value: "'0.0.0.0'"},
 										},
 									},
-									Alias: "String",
+									Alias: StringLiteral,
 								},
 							},
 						},
@@ -117,7 +117,7 @@ func Test_ipRangeTransform(t *testing.T) {
 											&model.LiteralExpr{Value: "'0.0.0.0'"},
 										},
 									},
-									Alias: "String",
+									Alias: StringLiteral,
 								},
 							},
 						},
@@ -145,7 +145,7 @@ func Test_ipRangeTransform(t *testing.T) {
 											&model.LiteralExpr{Value: "'0.0.0.0'"},
 										},
 									},
-									Alias: "String",
+									Alias: StringLiteral,
 								},
 							},
 						},
@@ -185,7 +185,7 @@ func Test_ipRangeTransform(t *testing.T) {
 											&model.LiteralExpr{Value: "'0.0.0.0'"},
 										},
 									},
-									Alias: "String",
+									Alias: StringLiteral,
 								},
 							},
 						},
@@ -237,7 +237,7 @@ func Test_ipRangeTransform(t *testing.T) {
 												&model.LiteralExpr{Value: "'0.0.0.0'"},
 											},
 										},
-										Alias: "String",
+										Alias: StringLiteral,
 									},
 								},
 							},


### PR DESCRIPTION
Before we used to throw errors when there was `NULL` in a column subject to IP transformation:
```
Cannot convert NULL value to non-Nullable type: while executing 'FUNCTION CAST(destination::ip : 0,
```

This PR addresses this issue by injecting a little `COALESCE` into query, so that in case of null value we fall back to sane default and `CAST` does not fail. Final condition looks like this:
```sql
SELECT *
FROM tablename
WHERE isIPAddressInRange(CAST(COALESCE(columnName, '0.0.0.0') AS "String"),'10.10.10.14/24') 
```

End result:
![image](https://github.com/user-attachments/assets/b5d181b4-ba4f-48e8-a0df-bf8d1a20ce25)
