### PR TITLE
Display `OpaqueId` in the UI

### DIFF
--- a/quesma/logger/logger.go
+++ b/quesma/logger/logger.go
@@ -29,6 +29,7 @@ const (
 	Reason                           = "reason"     // Known error reason key for the logger
 	Path                             = "path"
 	AsyncId                          = "async_id"
+	OpaqueId                         = "opaque_id"
 	ReasonPrefixUnsupportedQueryType = "unsupported_search_query: " // Reason for Error messages for unsupported queries will start with this prefix
 )
 
@@ -173,6 +174,11 @@ func addKnownContextValues(event *zerolog.Event, ctx context.Context) *zerolog.E
 			event = event.Str(AsyncId, asyncId)
 		}
 	}
+
+	if requestId, ok := ctx.Value(tracing.OpaqueIdCtxKey).(string); ok {
+		event = event.Str(OpaqueId, requestId)
+	}
+
 	return event
 }
 

--- a/quesma/quesma/functionality/terms_enum/terms_enum.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum.go
@@ -97,11 +97,13 @@ func handleTermsEnumRequest(ctx context.Context, body types.JSON, qt *queryparse
 		}
 	}
 
+	ctxValues := tracing.ExtractValues(ctx)
+
 	reqBody, _ := body.Bytes()
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
-		Id:                     ctx.Value(tracing.RequestIdCtxKey).(string),
+		Id:                     ctxValues.RequestId,
 		Path:                   path,
-		OpaqueId:               ctx.Value(tracing.OpaqueIdCtxKey).(string),
+		OpaqueId:               ctxValues.OpaqueId,
 		IncomingQueryBody:      reqBody,
 		QueryBodyTranslated:    []types.TranslatedSQLQuery{{Query: []byte(selectQuery.SelectCommand.String())}},
 		QueryTranslatedResults: result,

--- a/quesma/quesma/functionality/terms_enum/terms_enum.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum.go
@@ -101,6 +101,7 @@ func handleTermsEnumRequest(ctx context.Context, body types.JSON, qt *queryparse
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     ctx.Value(tracing.RequestIdCtxKey).(string),
 		Path:                   path,
+		OpaqueId:               ctx.Value(tracing.OpaqueIdCtxKey).(string),
 		IncomingQueryBody:      reqBody,
 		QueryBodyTranslated:    []types.TranslatedSQLQuery{{Query: []byte(selectQuery.SelectCommand.String())}},
 		QueryTranslatedResults: result,

--- a/quesma/quesma/processors.go
+++ b/quesma/quesma/processors.go
@@ -34,6 +34,8 @@ func (t TraceIdPreprocessor) PreprocessRequest(ctx context.Context, req *mux.Req
 	req.Headers.Add(tracing.RequestIdCtxKey.AsString(), rid)
 	ctx = context.WithValue(ctx, tracing.RequestIdCtxKey, rid)
 	ctx = context.WithValue(ctx, tracing.RequestPath, req.Path)
+	ctx = context.WithValue(ctx, tracing.OpaqueIdCtxKey, req.Headers.Get(opaqueIdHeaderKey))
+
 	return ctx, req, nil
 }
 

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -243,7 +243,7 @@ func (q *QueryRunner) executeAlternativePlan(ctx context.Context, plan *model.Ex
 
 	contextValues := tracing.ExtractValues(ctx)
 	bodyAsBytes, _ := body.Bytes()
-	pushAlternativeInfo(q.quesmaManagementConsole, contextValues.RequestId, "", contextValues.RequestPath, bodyAsBytes, response.translatedQueryBody, responseBody, plan.StartTime)
+	pushAlternativeInfo(q.quesmaManagementConsole, contextValues.RequestId, "", contextValues.OpaqueId, contextValues.RequestPath, bodyAsBytes, response.translatedQueryBody, responseBody, plan.StartTime)
 
 	return responseBody, response.err
 
@@ -253,6 +253,7 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 	contextValues := tracing.ExtractValues(ctx)
 	id := contextValues.RequestId
 	path := contextValues.RequestPath
+	opaqueId := contextValues.OpaqueId
 
 	doneCh := make(chan AsyncSearchWithError, 1)
 
@@ -296,13 +297,13 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 			go func() { // Async search takes longer. Return partial results and wait for
 				recovery.LogPanicWithCtx(ctx)
 				res := <-doneCh
-				responseBody, err = q.storeAsyncSearch(q.quesmaManagementConsole, id, optAsync.asyncId, optAsync.startTime, path, body, res, true)
+				responseBody, err = q.storeAsyncSearch(q.quesmaManagementConsole, id, optAsync.asyncId, optAsync.startTime, path, body, res, true, opaqueId)
 				sendMainPlanResult(responseBody, err)
 			}()
 			return q.handlePartialAsyncSearch(ctx, optAsync.asyncId)
 		case res := <-doneCh:
 			responseBody, err = q.storeAsyncSearch(q.quesmaManagementConsole, id, optAsync.asyncId, optAsync.startTime, path, body, res,
-				optAsync.keepOnCompletion)
+				optAsync.keepOnCompletion, opaqueId)
 			sendMainPlanResult(responseBody, err)
 			return responseBody, err
 		}
@@ -557,7 +558,7 @@ func (q *QueryRunner) removeNotExistingTables(sourcesClickhouse []string) []stri
 }
 
 func (q *QueryRunner) storeAsyncSearch(qmc *ui.QuesmaManagementConsole, id, asyncId string,
-	startTime time.Time, path string, body types.JSON, result AsyncSearchWithError, keep bool) (responseBody []byte, err error) {
+	startTime time.Time, path string, body types.JSON, result AsyncSearchWithError, keep bool, opaqueId string) (responseBody []byte, err error) {
 	took := time.Since(startTime)
 	if result.err != nil {
 		if keep {
@@ -570,6 +571,7 @@ func (q *QueryRunner) storeAsyncSearch(qmc *ui.QuesmaManagementConsole, id, asyn
 		qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 			Id:                     id,
 			AsyncId:                asyncId,
+			OpaqueId:               opaqueId,
 			Path:                   path,
 			IncomingQueryBody:      bodyAsBytes,
 			QueryBodyTranslated:    result.translatedQueryBody,
@@ -584,6 +586,7 @@ func (q *QueryRunner) storeAsyncSearch(qmc *ui.QuesmaManagementConsole, id, asyn
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     id,
 		AsyncId:                asyncId,
+		OpaqueId:               opaqueId,
 		Path:                   path,
 		IncomingQueryBody:      bodyAsBytes,
 		QueryBodyTranslated:    result.translatedQueryBody,
@@ -933,10 +936,11 @@ func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string
 		SecondaryTook:          time.Since(startTime)})
 }
 
-func pushAlternativeInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string, IncomingQueryBody []byte, QueryBodyTranslated []types.TranslatedSQLQuery, QueryTranslatedResults []byte, startTime time.Time) {
+func pushAlternativeInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, OpaqueId, Path string, IncomingQueryBody []byte, QueryBodyTranslated []types.TranslatedSQLQuery, QueryTranslatedResults []byte, startTime time.Time) {
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     Id,
 		AsyncId:                AsyncId,
+		OpaqueId:               OpaqueId,
 		Path:                   Path,
 		IncomingQueryBody:      IncomingQueryBody,
 		QueryBodyTranslated:    QueryBodyTranslated,

--- a/quesma/quesma/ui/live_tail.go
+++ b/quesma/quesma/ui/live_tail.go
@@ -199,7 +199,13 @@ func (qmc *QuesmaManagementConsole) populateQueries(debugKeyValueSlice []queryDe
 		if withLinks {
 			buffer.Html(`<a href="/request-id/`).Text(v.id).Html(`">`)
 		}
-		buffer.Html("<p>UUID:").Text(v.id).Html(" Path: ").Text(v.query.Path).Html("</p>\n")
+		buffer.Html("<p>UUID:").Text(v.id).Html(" Path: ")
+
+		if v.query.OpaqueId != "" {
+			buffer.Text("OpaqueId: ").Text(v.query.OpaqueId)
+		}
+
+		buffer.Text(v.query.Path).Html("</p>\n")
 		buffer.Html(`<pre Id="query`).Text(v.id).Html(`">`)
 		buffer.Text(string(v.query.IncomingQueryBody))
 		buffer.Html("\n</pre>")

--- a/quesma/quesma/ui/live_tail_drilldown.go
+++ b/quesma/quesma/ui/live_tail_drilldown.go
@@ -48,8 +48,8 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 
 	// Show Request and SQL
 	if requestFound {
-		buffer.Html(`<div>` + "\n")
 
+		buffer.Html(`<div>` + "\n")
 		buffer.Html(`<div class="query-body">` + "\n")
 		buffer.Html("<p class=\"title\">Original query:</p>\n")
 		buffer.Html(`<pre>`)
@@ -159,6 +159,10 @@ func (qmc *QuesmaManagementConsole) generateReportForRequestId(requestId string)
 		if len(request.AsyncId) > 0 {
 			buffer.Html("<li>").Text("Async id: ").Text(request.AsyncId).Html("</li>\n")
 		}
+		if request.OpaqueId != "" {
+			buffer.Html("<li>").Text("Opaque id: ").Text(request.OpaqueId).Html("</li>\n")
+		}
+
 		if request.unsupported != nil {
 			buffer.Html("<li>").Text("Unsupported: ").Text(*request.unsupported).Html("</li>\n")
 		}

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -44,8 +44,9 @@ type QueryDebugPrimarySource struct {
 }
 
 type QueryDebugSecondarySource struct {
-	Id      string
-	AsyncId string
+	Id       string
+	AsyncId  string
+	OpaqueId string
 
 	Path              string
 	IncomingQueryBody []byte
@@ -192,6 +193,7 @@ func (qmc *QuesmaManagementConsole) processChannelMessage() {
 		secondaryDebugInfo := QueryDebugSecondarySource{
 			msg.Id,
 			msg.AsyncId,
+			msg.OpaqueId,
 			msg.Path,
 			[]byte(util.JsonPrettify(string(msg.IncomingQueryBody), true)),
 			msg.QueryBodyTranslated,

--- a/quesma/tracing/context.go
+++ b/quesma/tracing/context.go
@@ -15,6 +15,7 @@ const (
 	RequestPath     ContextKey = "RequestPath"
 	AsyncIdCtxKey   ContextKey = "AsyncId"
 	TraceEndCtxKey  ContextKey = "TraceEnd"
+	OpaqueIdCtxKey  ContextKey = "OpaqueId"
 
 	AsyncIdPrefix = "quesma_async_"
 )
@@ -50,6 +51,7 @@ type ContextValues struct {
 	Reason      string
 	RequestPath string
 	TraceEnd    bool
+	OpaqueId    string
 }
 
 func ExtractValues(ctx context.Context) ContextValues {
@@ -68,5 +70,6 @@ func ExtractValues(ctx context.Context) ContextValues {
 		AsyncId:     str(AsyncIdCtxKey),
 		Reason:      str(ReasonCtxKey),
 		RequestPath: str(RequestPath),
+		OpaqueId:    str(OpaqueIdCtxKey),
 	}
 }


### PR DESCRIPTION
This PR adds the value of the `x-opaque-id` header to the context. `OpaqueId` is shown in the log files and live tab.


<img width="1540" alt="Screenshot 2024-08-07 at 17 03 13" src="https://github.com/user-attachments/assets/61d84e49-1893-4568-a19d-74e68ebbdf89">


<img width="451" alt="Screenshot 2024-08-07 at 17 11 55" src="https://github.com/user-attachments/assets/26f358e9-b222-4cda-9d31-81f048f8bc65">


I'm not sure if the `OpaqueId` is a good name. Suggestions welcomed.


