### PR TITLE
Fix responses of `_bulk` and `PUT /:index` (for Kafka Sink Connector)

### DIFF
--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -54,6 +54,7 @@ type (
 		Result      string             `json:"result,omitempty"`
 		Status      int                `json:"status"`
 		Error       any                `json:"error,omitempty"`
+		Type        string             `json:"_type"` // ES 7.x Java Client requires this field
 	}
 	BulkShardsResponse struct {
 		Failed     int `json:"failed"`
@@ -224,6 +225,7 @@ func sendToClickhouse(ctx context.Context, clickhouseDocumentsToInsert map[strin
 					Version: 0,
 					Result:  "created",
 					Status:  201,
+					Type:    "_doc",
 				}
 				if err != nil {
 					bulkSingleResponse.Result = ""


### PR DESCRIPTION
ElasticSearch Kafka Sink Connector uses the ElasticSearch Java Client v7.17.23 and it failed to deserialize some of the responses from our endpoints.

Firstly, a `_type` field has to be present in the `_bulk` response: https://github.com/elastic/elasticsearch/blob/61d76462eecaf09ada684d1b5d319b5ff6865a83/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java#L116

Secondly, we were missing a response body for `PUT /:index` requests.