### PR TITLE
Simple ClickHouse connection doctor impl

### DIFF
--- a/quesma/quesma/config/url.go
+++ b/quesma/quesma/config/url.go
@@ -24,6 +24,11 @@ func (u *Url) Hostname() string {
 	return urlValue.Hostname()
 }
 
+func (u *Url) Port() string {
+	urlValue := url.URL(*u)
+	return urlValue.Port()
+}
+
 func (u *Url) String() string {
 	urlValue := url.URL(*u)
 	return urlValue.String()


### PR DESCRIPTION
For now it's a very blunt and verbose function called only when DB conn pool creation failed completely. 
We might revisit the whole logic in the future, but for now these few simple log lines should make troubleshooting easier.