### PR TITLE
A/B Testing - elastic 

### DIFF
--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -12,12 +12,13 @@ import (
 )
 
 type ResponseMismatch struct {
+	IsOK bool `json:"is_ok"` // true if responses are the same
+
 	Mismatches string `json:"mismatches"` // JSON array of differences
-	// TODO maybe we should keep more human readable list of differences
-	IsOK            bool   `json:"is_ok"`
-	Count           int    `json:"count"`
-	TopMismatchType string `json:"top_mismatch_type"`
-	Message         string `json:"message"`
+	Message    string `json:"message"`    // human readable variant of the array above
+
+	Count           int    `json:"count"`             // number of differences
+	TopMismatchType string `json:"top_mismatch_type"` // most common difference type
 }
 
 type Collector interface {

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -14,7 +14,10 @@ import (
 type ResponseMismatch struct {
 	Mismatches string `json:"mismatches"` // JSON array of differences
 	// TODO maybe we should keep more human readable list of differences
-	IsMismatch bool `json:"is_mismatch"`
+	IsMismatch      bool   `json:"is_mismatch"`
+	Count           int    `json:"count"`
+	TopMismatchType string `json:"top_mismatch_type"`
+	Message         string `json:"message"`
 }
 
 type Collector interface {
@@ -65,6 +68,7 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 		cancelFunc:   cancel,
 		pipeline: []pipelineProcessor{
 			&probabilisticSampler{ratio: 1},
+			&deAsyncResponse{},
 			&diffTransformer{},
 			&ppPrintFanout{},
 			&mismatchedOnlyFilter{},

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -14,7 +14,7 @@ import (
 type ResponseMismatch struct {
 	Mismatches string `json:"mismatches"` // JSON array of differences
 	// TODO maybe we should keep more human readable list of differences
-	IsMismatch      bool   `json:"is_mismatch"`
+	IsOK            bool   `json:"is_ok"`
 	Count           int    `json:"count"`
 	TopMismatchType string `json:"top_mismatch_type"`
 	Message         string `json:"message"`

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -62,6 +62,10 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 
 	// TODO read config here
 
+	// avoid unused struct error
+	var _ = &ppPrintFanout{}
+	var _ = &mismatchedOnlyFilter{}
+
 	return &InMemoryCollector{
 		receiveQueue: make(chan ab_testing.Result, 1000),
 		ctx:          ctx,
@@ -70,8 +74,8 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 			&probabilisticSampler{ratio: 1},
 			&deAsyncResponse{},
 			&diffTransformer{},
-			&ppPrintFanout{},
-			&mismatchedOnlyFilter{},
+			//&ppPrintFanout{},
+			//&mismatchedOnlyFilter{},
 			&elasticSearchFanout{
 				url:       "http://localhost:8080",
 				indexName: "ab_testing_logs",

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -72,7 +72,7 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 		cancelFunc:   cancel,
 		pipeline: []pipelineProcessor{
 			&probabilisticSampler{ratio: 1},
-			&deAsyncResponse{},
+			&unifySyncAsyncResponse{},
 			&diffTransformer{},
 			//&ppPrintFanout{},
 			//&mismatchedOnlyFilter{},

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -64,7 +64,6 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 	// TODO read config here
 
 	// avoid unused struct error
-	var _ = &ppPrintFanout{}
 	var _ = &mismatchedOnlyFilter{}
 
 	return &InMemoryCollector{

--- a/quesma/ab_testing/collector/diff.go
+++ b/quesma/ab_testing/collector/diff.go
@@ -11,21 +11,21 @@ import (
 type diffTransformer struct {
 }
 
-func (t diffTransformer) stats(mismatches []jsondiff.JSONMismatch) (string, int) {
+func (t *diffTransformer) mostCommonMismatchType(mismatches []jsondiff.JSONMismatch) (string, int) {
 
-	max := 0
+	currentMax := 0
 	maxType := ""
 	m := make(map[string]int)
 
 	for _, mismatch := range mismatches {
 		m[mismatch.Type]++
-		if m[mismatch.Type] > max {
-			max = m[mismatch.Type]
+		if m[mismatch.Type] > currentMax {
+			currentMax = m[mismatch.Type]
 			maxType = mismatch.Type
 		}
 	}
 
-	return maxType, max
+	return maxType, currentMax
 
 }
 
@@ -64,7 +64,7 @@ func (t *diffTransformer) process(in EnrichedResults) (out EnrichedResults, drop
 		in.Mismatch.Count = len(mismatches)
 		in.Mismatch.Message = mismatches.String()
 
-		topMismatchType, _ := t.stats(mismatches)
+		topMismatchType, _ := t.mostCommonMismatchType(mismatches)
 		if topMismatchType != "" {
 			in.Mismatch.TopMismatchType = topMismatchType
 		}

--- a/quesma/ab_testing/collector/diff.go
+++ b/quesma/ab_testing/collector/diff.go
@@ -60,7 +60,7 @@ func (t *diffTransformer) process(in EnrichedResults) (out EnrichedResults, drop
 		}
 
 		in.Mismatch.Mismatches = string(b)
-		in.Mismatch.IsMismatch = true
+		in.Mismatch.IsOK = false
 		in.Mismatch.Count = len(mismatches)
 		in.Mismatch.Message = mismatches.String()
 
@@ -71,7 +71,7 @@ func (t *diffTransformer) process(in EnrichedResults) (out EnrichedResults, drop
 
 	} else {
 		in.Mismatch.Mismatches = "[]"
-		in.Mismatch.IsMismatch = false
+		in.Mismatch.IsOK = true
 	}
 
 	return in, false, nil

--- a/quesma/ab_testing/collector/fanout.go
+++ b/quesma/ab_testing/collector/fanout.go
@@ -6,18 +6,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/k0kubun/pp"
 	"net/http"
 	"quesma/logger"
 )
-
-type ppPrintFanout struct {
-}
-
-func (t *ppPrintFanout) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
-	pp.Println("A/B Testing FANOUT", in)
-	return in, false, nil
-}
 
 type elasticSearchFanout struct {
 	url        string

--- a/quesma/ab_testing/collector/fanout.go
+++ b/quesma/ab_testing/collector/fanout.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/k0kubun/pp"
 	"net/http"
 	"quesma/logger"
 )
@@ -14,7 +15,7 @@ type ppPrintFanout struct {
 }
 
 func (t *ppPrintFanout) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
-	//pp.Println("A/B Testing FANOUT", in)
+	pp.Println("A/B Testing FANOUT", in)
 	return in, false, nil
 }
 

--- a/quesma/ab_testing/collector/fanout.go
+++ b/quesma/ab_testing/collector/fanout.go
@@ -28,8 +28,6 @@ func (t *elasticSearchFanout) process(in EnrichedResults) (out EnrichedResults, 
 
 	// TODO collect and send in bulk every 10 seconds or 1000 records for example
 
-	fmt.Println("XXXXXX A/B ElasticSearch FANOUT", in)
-
 	logBytes := []byte{}
 
 	bulkJson := fmt.Sprintf("{\"index\":{\"_index\":\"%s\"}}\n", t.indexName)

--- a/quesma/ab_testing/collector/fanout.go
+++ b/quesma/ab_testing/collector/fanout.go
@@ -28,6 +28,8 @@ func (t *elasticSearchFanout) process(in EnrichedResults) (out EnrichedResults, 
 
 	// TODO collect and send in bulk every 10 seconds or 1000 records for example
 
+	fmt.Println("XXXXXX A/B ElasticSearch FANOUT", in)
+
 	logBytes := []byte{}
 
 	bulkJson := fmt.Sprintf("{\"index\":{\"_index\":\"%s\"}}\n", t.indexName)

--- a/quesma/ab_testing/collector/filters.go
+++ b/quesma/ab_testing/collector/filters.go
@@ -17,6 +17,7 @@ func (t *probabilisticSampler) process(in EnrichedResults) (out EnrichedResults,
 	return in, false, nil
 }
 
+// mismatchedOnlyFilter is a filter results that only allows mismatched results to pass
 type mismatchedOnlyFilter struct {
 }
 

--- a/quesma/ab_testing/collector/filters.go
+++ b/quesma/ab_testing/collector/filters.go
@@ -22,7 +22,7 @@ type mismatchedOnlyFilter struct {
 
 func (t *mismatchedOnlyFilter) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
 
-	if !in.Mismatch.IsMismatch {
+	if in.Mismatch.IsOK {
 		return in, true, nil
 	}
 

--- a/quesma/ab_testing/collector/processors.go
+++ b/quesma/ab_testing/collector/processors.go
@@ -1,0 +1,51 @@
+package collector
+
+import (
+	"encoding/json"
+	"quesma/quesma/types"
+)
+
+type deAsyncResponse struct {
+}
+
+func (t *deAsyncResponse) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
+
+	deAsync := func(elasticResponse string) (string, error) {
+
+		asJson, err := types.ParseJSON(elasticResponse)
+
+		if asJson == nil {
+			return "", err
+		}
+
+		if asJson["response"] == nil {
+			return elasticResponse, nil
+		}
+
+		res := asJson["response"]
+
+		b, err := json.Marshal(res)
+
+		if err != nil {
+			return "", nil
+		}
+
+		return string(b), nil
+
+	}
+
+	respA, err := deAsync(in.A.Body)
+	if err != nil {
+		return in, false, err
+	}
+
+	respB, err := deAsync(in.B.Body)
+	if err != nil {
+		return in, false, err
+	}
+
+	in.A.Body = respA
+	in.B.Body = respB
+
+	return in, false, nil
+}

--- a/quesma/ab_testing/collector/processors.go
+++ b/quesma/ab_testing/collector/processors.go
@@ -7,6 +7,7 @@ import (
 	"quesma/quesma/types"
 )
 
+// deAsyncResponse is a processor that processes that removes async "wrapper" from the response
 type deAsyncResponse struct {
 }
 

--- a/quesma/ab_testing/collector/processors.go
+++ b/quesma/ab_testing/collector/processors.go
@@ -17,23 +17,21 @@ func (t *deAsyncResponse) process(in EnrichedResults) (out EnrichedResults, drop
 
 		asJson, err := types.ParseJSON(elasticResponse)
 
-		if asJson == nil {
+		if err != nil {
 			return "", err
 		}
 
-		if asJson["response"] == nil {
-			return elasticResponse, nil
+		if res, ok := asJson["response"]; ok {
+			b, err := json.Marshal(res)
+
+			if err != nil {
+				return "", err
+			}
+
+			return string(b), nil
 		}
 
-		res := asJson["response"]
-
-		b, err := json.Marshal(res)
-
-		if err != nil {
-			return "", nil
-		}
-
-		return string(b), nil
+		return elasticResponse, nil
 	}
 
 	respA, err := deAsync(in.A.Body)

--- a/quesma/ab_testing/collector/processors.go
+++ b/quesma/ab_testing/collector/processors.go
@@ -7,11 +7,11 @@ import (
 	"quesma/quesma/types"
 )
 
-// deAsyncResponse is a processor that processes that removes async "wrapper" from the response
-type deAsyncResponse struct {
+// unifySyncAsyncResponse is a processor that processes that removes async "wrapper" from the response
+type unifySyncAsyncResponse struct {
 }
 
-func (t *deAsyncResponse) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
+func (t *unifySyncAsyncResponse) process(in EnrichedResults) (out EnrichedResults, drop bool, err error) {
 
 	deAsync := func(elasticResponse string) (string, error) {
 

--- a/quesma/ab_testing/collector/processors.go
+++ b/quesma/ab_testing/collector/processors.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package collector
 
 import (
@@ -31,7 +33,6 @@ func (t *deAsyncResponse) process(in EnrichedResults) (out EnrichedResults, drop
 		}
 
 		return string(b), nil
-
 	}
 
 	respA, err := deAsync(in.A.Body)

--- a/quesma/ab_testing/model.go
+++ b/quesma/ab_testing/model.go
@@ -3,8 +3,9 @@
 package ab_testing
 
 type Request struct {
-	Path string `json:"path"`
-	Body string `json:"body"`
+	Path      string `json:"path"`
+	IndexName string `json:"index_name"`
+	Body      string `json:"body"`
 }
 
 type Response struct {

--- a/quesma/ab_testing/model.go
+++ b/quesma/ab_testing/model.go
@@ -2,20 +2,16 @@
 // SPDX-License-Identifier: Elastic-2.0
 package ab_testing
 
-import (
-	"time"
-)
-
 type Request struct {
 	Path string `json:"path"`
 	Body string `json:"body"`
 }
 
 type Response struct {
-	Name  string        `json:"name"`
-	Body  string        `json:"body"`
-	Time  time.Duration `json:"time"`
-	Error string        `json:"error"`
+	Name  string  `json:"name"`
+	Body  string  `json:"body"`
+	Time  float64 `json:"time"`
+	Error string  `json:"error"`
 }
 
 type Result struct {

--- a/quesma/ab_testing/model.go
+++ b/quesma/ab_testing/model.go
@@ -12,9 +12,10 @@ type Request struct {
 }
 
 type Response struct {
-	Name string        `json:"name"`
-	Body string        `json:"body"`
-	Time time.Duration `json:"time"`
+	Name  string        `json:"name"`
+	Body  string        `json:"body"`
+	Time  time.Duration `json:"time"`
+	Error string        `json:"error"`
 }
 
 type Result struct {

--- a/quesma/ab_testing/sender/sender.go
+++ b/quesma/ab_testing/sender/sender.go
@@ -54,6 +54,8 @@ func (f *sender) Start() {
 
 				if f.collector != nil {
 					f.collector.Collect(result)
+				} else {
+					logger.WarnWithCtx(f.ctx).Msgf("Sender: No collector available. Dropping result: %s", result)
 				}
 
 			case <-f.ctx.Done():

--- a/quesma/ab_testing/sender/sender.go
+++ b/quesma/ab_testing/sender/sender.go
@@ -54,8 +54,6 @@ func (f *sender) Start() {
 
 				if f.collector != nil {
 					f.collector.Collect(result)
-				} else {
-					logger.WarnWithCtx(f.ctx).Msgf("Sender: No collector available. Dropping result: %s", result)
 				}
 
 			case <-f.ctx.Done():

--- a/quesma/jsondiff/elastic_response_diff.go
+++ b/quesma/jsondiff/elastic_response_diff.go
@@ -6,7 +6,7 @@ import "fmt"
 
 // NewElasticResponseJSONDiff creates a JSONDiff instance that is tailored to compare Elasticsearch response JSONs.
 func NewElasticResponseJSONDiff() (*JSONDiff, error) {
-	d, err := NewJSONDiff("^id$", ".*Quesma_key_.*")
+	d, err := NewJSONDiff("^id$", ".*Quesma_key_.*", "^took$")
 
 	if err != nil {
 		return nil, fmt.Errorf("could not create JSONDiff: %v", err)
@@ -14,11 +14,30 @@ func NewElasticResponseJSONDiff() (*JSONDiff, error) {
 
 	// here we enable comparing the buckets by the key field
 	// this will show higher level differences in the JSON (e.g. sorting differences)
+
+	anyToKey := func(element any) string {
+
+		switch val := element.(type) {
+
+		case float64:
+
+			if val == float64(int(val)) {
+				return fmt.Sprintf("%d", int(val))
+			}
+			return fmt.Sprintf("%f", val)
+
+		case string:
+			return val
+		default:
+			return fmt.Sprintf("%v", val)
+		}
+	}
+
 	err = d.AddKeyExtractor("buckets", func(element any) (string, error) {
 		switch v := element.(type) {
 		case map[string]interface{}:
 			if val, ok := v["key"]; ok {
-				return fmt.Sprintf("%v", val), nil
+				return anyToKey(val), nil
 			}
 		}
 		return "", fmt.Errorf("could not extract key from element: %v", element)

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -3,7 +3,6 @@
 package optimize
 
 import (
-	"fmt"
 	"quesma/model"
 	"quesma/quesma/config"
 	"strings"
@@ -65,9 +64,7 @@ func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries [
 
 	// first we check index specific settings
 	if indexCfg, ok := s.config.IndexConfig[indexName]; ok {
-		fmt.Println("Index specific settings found", indexName)
 		if optimizerCfg, ok := indexCfg.EnabledOptimizers[transformer.Name()]; ok {
-			fmt.Println("Optimizer specific settings found", transformer.Name(), optimizerCfg.Enabled)
 			return optimizerCfg.Enabled, optimizerCfg.Properties
 		}
 	}

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -199,7 +199,11 @@ func (r *router) reroute(ctx context.Context, w http.ResponseWriter, req *http.R
 				sendElkResponseToQuesmaConsole(ctx, elkRawResponse, r.quesmaManagementConsole)
 			}
 			if !(elkResponse.StatusCode >= 200 && elkResponse.StatusCode < 300) {
-				logger.WarnWithCtx(ctx).Msgf("Elasticsearch returned unexpected status code [%d] when calling [%s %s]", elkResponse.StatusCode, req.Method, req.URL.Path)
+
+				// elastic respond with 400 status code for our async search queries
+				if !(elkResponse.StatusCode == 400 && strings.HasPrefix(req.URL.Path, "/_async_search/quesma_async_")) {
+					logger.WarnWithCtx(ctx).Msgf("Elasticsearch returned unexpected status code [%d] when calling [%s %s]", elkResponse.StatusCode, req.Method, req.URL.Path)
+				}
 			}
 		}
 

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -3,14 +3,9 @@
 package quesma
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/k0kubun/pp"
-	"io"
-	"net/http"
 	"quesma/ab_testing"
 	"quesma/clickhouse"
 	"quesma/concurrent"
@@ -154,12 +149,6 @@ type AsyncQuery struct {
 	startTime        time.Time
 }
 
-type executionPlanResult struct {
-	isMain       bool
-	plan         *model.ExecutionPlan
-	err          error
-	responseBody []byte
-}
 
 func (q *QueryRunner) transformQueries(ctx context.Context, plan *model.ExecutionPlan, table *clickhouse.Table) {
 	var err error
@@ -213,48 +202,6 @@ func (q *QueryRunner) runExecutePlanAsync(ctx context.Context, plan *model.Execu
 
 		doneCh <- AsyncSearchWithError{response: searchResponse, translatedQueryBody: translatedQueryBody, err: err}
 	}()
-}
-
-func (q *QueryRunner) executeAlternativePlan(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, isAsync bool) (responseBody []byte, err error) {
-
-	doneCh := make(chan AsyncSearchWithError, 1)
-
-	q.transformQueries(ctx, plan, table)
-
-	if resp, err := q.checkProperties(ctx, plan, table, queryTranslator); err != nil {
-		return resp, err
-	}
-
-	q.runExecutePlanAsync(ctx, plan, queryTranslator, table, doneCh, nil)
-
-	response := <-doneCh
-
-	if response.err == nil {
-		if isAsync {
-			asyncResponse := queryparser.SearchToAsyncSearchResponse(response.response, "__quesma_alternative_plan", false, 200)
-			responseBody, err = asyncResponse.Marshal()
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			responseBody, err = response.response.Marshal()
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		// TODO better error handling
-		m := make(map[string]interface{})
-		m["error"] = fmt.Sprintf("%v", response.err.Error())
-		responseBody, _ = json.MarshalIndent(m, "", "  ")
-	}
-
-	bodyAsBytes, _ := body.Bytes()
-	contextValues := tracing.ExtractValues(ctx)
-	pushAlternativeInfo(q.quesmaManagementConsole, contextValues.RequestId, "", contextValues.OpaqueId, contextValues.RequestPath, bodyAsBytes, response.translatedQueryBody, responseBody, plan.StartTime)
-
-	return responseBody, response.err
-
 }
 
 func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, optAsync *AsyncQuery, optComparePlansCh chan<- executionPlanResult) (responseBody []byte, err error) {
@@ -318,91 +265,6 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 			return responseBody, err
 		}
 	}
-}
-
-type executionPlanExecutor func(ctx context.Context) ([]byte, error)
-
-// runAlternativePlanAndComparison runs the alternative plan and comparison method in the background. It returns a channel to collect the main plan results.
-func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan *model.ExecutionPlan, alternativePlanExecutor executionPlanExecutor, body types.JSON) chan<- executionPlanResult {
-
-	contextValues := tracing.ExtractValues(ctx)
-
-	numberOfExpectedResults := len([]string{model.MainExecutionPlan, model.AlternativeExecutionPlan})
-
-	optComparePlansCh := make(chan executionPlanResult, numberOfExpectedResults)
-
-	// run alternative plan in the background (generator)
-	go func(optComparePlansCh chan<- executionPlanResult) {
-		defer recovery.LogPanic()
-
-		// results are passed via channel
-		newCtx := tracing.NewContextWithRequest(ctx)
-		body, err := alternativePlanExecutor(newCtx)
-
-		optComparePlansCh <- executionPlanResult{
-			plan:         plan,
-			err:          err,
-			responseBody: body,
-		}
-
-	}(optComparePlansCh)
-
-	// collector
-	go func(optComparePlansCh <-chan executionPlanResult) {
-		defer recovery.LogPanic()
-		var alternative executionPlanResult
-		var main executionPlanResult
-
-		for range numberOfExpectedResults {
-			r := <-optComparePlansCh
-			logger.InfoWithCtx(ctx).Msgf("received results  %s", r.plan.Name)
-			if r.isMain {
-				main = r
-			} else {
-				alternative = r
-			}
-		}
-
-		bytes, err := body.Bytes()
-		if err != nil {
-			bytes = []byte("error converting body to bytes")
-		}
-
-		toError := func(err error) string {
-			if err != nil {
-				return err.Error()
-			}
-			return ""
-		}
-
-		abResult := ab_testing.Result{
-			Request: ab_testing.Request{
-				Path: contextValues.RequestPath,
-				Body: string(bytes),
-			},
-
-			A: ab_testing.Response{
-				Name:  main.plan.Name,
-				Body:  string(main.responseBody),
-				Time:  time.Since(main.plan.StartTime),
-				Error: toError(main.err),
-			},
-
-			B: ab_testing.Response{
-				Name:  alternative.plan.Name,
-				Body:  string(alternative.responseBody),
-				Time:  time.Since(alternative.plan.StartTime),
-				Error: toError(alternative.err),
-			},
-			RequestID: contextValues.RequestId,
-			OpaqueID:  contextValues.OpaqueId,
-		}
-		pp.Println("XXXXX Sending A/B Testing Result", abResult)
-		q.ABResultsSender.Send(abResult)
-
-	}(optComparePlansCh)
-
-	return optComparePlansCh
 }
 
 func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern string, body types.JSON, optAsync *AsyncQuery, queryLanguage QueryLanguage) ([]byte, error) {
@@ -518,105 +380,6 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 	}
 
 	return q.executePlan(ctx, plan, queryTranslator, table, body, optAsync, optComparePlansCh)
-}
-
-func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
-
-	//p := q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
-	p, e := q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
-	return p, e
-}
-
-func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
-
-	requestBody, err := body.Bytes()
-	if err != nil {
-		return nil, nil
-	}
-
-	alternativePlan := &model.ExecutionPlan{
-		IndexPattern:          plan.IndexPattern,
-		QueryRowsTransformers: []model.QueryRowsTransformer{},
-		Queries:               []*model.Query{},
-		StartTime:             plan.StartTime,
-		Name:                  "elastic",
-	}
-
-	url := "http://elasticsearch:9200/" + plan.IndexPattern + "/_search"
-
-	return alternativePlan, func(ctx context.Context) ([]byte, error) {
-
-		fmt.Println("XXXXXXXX calling elastic", url)
-
-		if resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody)); err != nil {
-			return nil, err
-		} else {
-			responseBody, err := io.ReadAll(resp.Body)
-
-			if err != nil {
-				return nil, err
-			}
-
-			if err := resp.Body.Close(); err != nil {
-				return nil, err
-			}
-
-			if resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
-			}
-			return responseBody, nil
-		}
-	}
-}
-
-func (q *QueryRunner) maybeCreatePancakeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) executionPlanExecutor {
-
-	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
-	if enabled && props["mode"] == "alternative" {
-
-		hasAggQuery := false
-		queriesWithoutAggr := make([]*model.Query, 0)
-		for _, query := range plan.Queries {
-			switch query.Type.AggregationType() {
-			case model.MetricsAggregation, model.BucketAggregation, model.PipelineAggregation:
-				hasAggQuery = true
-			default:
-				queriesWithoutAggr = append(queriesWithoutAggr, query)
-			}
-		}
-
-		if hasAggQuery {
-			if chQueryTranslator, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator); ok {
-
-				// TODO FIXME check if the original plan has count query
-				addCount := false
-
-				if pancakeQueries, err := chQueryTranslator.PancakeParseAggregationJson(body, addCount); err == nil {
-					logger.InfoWithCtx(ctx).Msgf("Running alternative pancake queries")
-					queries := append(queriesWithoutAggr, pancakeQueries...)
-					plan := &model.ExecutionPlan{
-						IndexPattern:          plan.IndexPattern,
-						QueryRowsTransformers: make([]model.QueryRowsTransformer, len(queries)),
-						Queries:               queries,
-						StartTime:             plan.StartTime,
-						Name:                  "pancake",
-					}
-
-					return func(ctx context.Context) ([]byte, error) {
-
-						return q.executeAlternativePlan(ctx, plan, queryTranslator, table, body, false)
-					}
-
-				} else {
-					// TODO: change to info
-					logger.ErrorWithCtx(ctx).Msgf("Error parsing pancake queries: %v", err)
-				}
-			} else {
-				logger.ErrorWithCtx(ctx).Msgf("Alternative plan is not supported for non-clickhouse query translators")
-			}
-		}
-	}
-	return nil
 }
 
 func (q *QueryRunner) removeNotExistingTables(sourcesClickhouse []string) []string {

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -149,7 +149,6 @@ type AsyncQuery struct {
 	startTime        time.Time
 }
 
-
 func (q *QueryRunner) transformQueries(ctx context.Context, plan *model.ExecutionPlan, table *clickhouse.Table) {
 	var err error
 	plan.Queries, err = q.transformationPipeline.Transform(plan.Queries)
@@ -215,11 +214,11 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 	sendMainPlanResult := func(responseBody []byte, err error) {
 		if optComparePlansCh != nil {
 			optComparePlansCh <- executionPlanResult{
-
+				isMain:       true,
 				plan:         plan,
 				err:          err,
-				isMain:       true,
 				responseBody: responseBody,
+				endTime:      time.Now(),
 			}
 		}
 	}

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package quesma
 
 import (

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -152,24 +152,25 @@ func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 
 		// TODO: add user/pass
 
-		if resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody)); err != nil {
+		resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody))
+
+		if err != nil {
 			return nil, err
-		} else {
-			responseBody, err := io.ReadAll(resp.Body)
-
-			if err != nil {
-				return nil, err
-			}
-
-			if err := resp.Body.Close(); err != nil {
-				return nil, err
-			}
-
-			if resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
-			}
-			return responseBody, nil
 		}
+		responseBody, err := io.ReadAll(resp.Body)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if err := resp.Body.Close(); err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
+		}
+		return responseBody, nil
 	}
 }
 

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -1,0 +1,254 @@
+package quesma
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/k0kubun/pp"
+	"io"
+	"net/http"
+	"quesma/ab_testing"
+	"quesma/clickhouse"
+	"quesma/logger"
+	"quesma/model"
+	"quesma/queryparser"
+	"quesma/quesma/recovery"
+	"quesma/quesma/types"
+	"quesma/tracing"
+	"time"
+)
+
+type executionPlanResult struct {
+	isMain       bool
+	plan         *model.ExecutionPlan
+	err          error
+	responseBody []byte
+}
+
+type executionPlanExecutor func(ctx context.Context) ([]byte, error)
+
+// runAlternativePlanAndComparison runs the alternative plan and comparison method in the background. It returns a channel to collect the main plan results.
+func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan *model.ExecutionPlan, alternativePlanExecutor executionPlanExecutor, body types.JSON) chan<- executionPlanResult {
+
+	contextValues := tracing.ExtractValues(ctx)
+
+	numberOfExpectedResults := len([]string{model.MainExecutionPlan, model.AlternativeExecutionPlan})
+
+	optComparePlansCh := make(chan executionPlanResult, numberOfExpectedResults)
+
+	// run alternative plan in the background (generator)
+	go func(optComparePlansCh chan<- executionPlanResult) {
+		defer recovery.LogPanic()
+
+		// results are passed via channel
+		newCtx := tracing.NewContextWithRequest(ctx)
+		body, err := alternativePlanExecutor(newCtx)
+
+		optComparePlansCh <- executionPlanResult{
+			plan:         plan,
+			err:          err,
+			responseBody: body,
+		}
+
+	}(optComparePlansCh)
+
+	// collector
+	go func(optComparePlansCh <-chan executionPlanResult) {
+		defer recovery.LogPanic()
+		var alternative executionPlanResult
+		var main executionPlanResult
+
+		for range numberOfExpectedResults {
+			r := <-optComparePlansCh
+			logger.InfoWithCtx(ctx).Msgf("received results  %s", r.plan.Name)
+			if r.isMain {
+				main = r
+			} else {
+				alternative = r
+			}
+		}
+
+		bytes, err := body.Bytes()
+		if err != nil {
+			bytes = []byte("error converting body to bytes")
+		}
+
+		toError := func(err error) string {
+			if err != nil {
+				return err.Error()
+			}
+			return ""
+		}
+
+		abResult := ab_testing.Result{
+			Request: ab_testing.Request{
+				Path: contextValues.RequestPath,
+				Body: string(bytes),
+			},
+
+			A: ab_testing.Response{
+				Name:  main.plan.Name,
+				Body:  string(main.responseBody),
+				Time:  time.Since(main.plan.StartTime),
+				Error: toError(main.err),
+			},
+
+			B: ab_testing.Response{
+				Name:  alternative.plan.Name,
+				Body:  string(alternative.responseBody),
+				Time:  time.Since(alternative.plan.StartTime),
+				Error: toError(alternative.err),
+			},
+			RequestID: contextValues.RequestId,
+			OpaqueID:  contextValues.OpaqueId,
+		}
+		pp.Println("XXXXX Sending A/B Testing Result", abResult)
+		q.ABResultsSender.Send(abResult)
+
+	}(optComparePlansCh)
+
+	return optComparePlansCh
+}
+
+func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
+
+	// TODO read config here
+	//p := q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
+	p, e := q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
+	return p, e
+}
+
+func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
+
+	requestBody, err := body.Bytes()
+	if err != nil {
+		return nil, nil
+	}
+
+	alternativePlan := &model.ExecutionPlan{
+		IndexPattern:          plan.IndexPattern,
+		QueryRowsTransformers: []model.QueryRowsTransformer{},
+		Queries:               []*model.Query{},
+		StartTime:             plan.StartTime,
+		Name:                  "elastic",
+	}
+
+	url := "http://elasticsearch:9200/" + plan.IndexPattern + "/_search"
+
+	return alternativePlan, func(ctx context.Context) ([]byte, error) {
+
+		fmt.Println("XXXXXXXX calling elastic", url)
+
+		if resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody)); err != nil {
+			return nil, err
+		} else {
+			responseBody, err := io.ReadAll(resp.Body)
+
+			if err != nil {
+				return nil, err
+			}
+
+			if err := resp.Body.Close(); err != nil {
+				return nil, err
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
+			}
+			return responseBody, nil
+		}
+	}
+}
+
+func (q *QueryRunner) maybeCreatePancakeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) executionPlanExecutor {
+
+	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
+	if enabled && props["mode"] == "alternative" {
+
+		hasAggQuery := false
+		queriesWithoutAggr := make([]*model.Query, 0)
+		for _, query := range plan.Queries {
+			switch query.Type.AggregationType() {
+			case model.MetricsAggregation, model.BucketAggregation, model.PipelineAggregation:
+				hasAggQuery = true
+			default:
+				queriesWithoutAggr = append(queriesWithoutAggr, query)
+			}
+		}
+
+		if hasAggQuery {
+			if chQueryTranslator, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator); ok {
+
+				// TODO FIXME check if the original plan has count query
+				addCount := false
+
+				if pancakeQueries, err := chQueryTranslator.PancakeParseAggregationJson(body, addCount); err == nil {
+					logger.InfoWithCtx(ctx).Msgf("Running alternative pancake queries")
+					queries := append(queriesWithoutAggr, pancakeQueries...)
+					plan := &model.ExecutionPlan{
+						IndexPattern:          plan.IndexPattern,
+						QueryRowsTransformers: make([]model.QueryRowsTransformer, len(queries)),
+						Queries:               queries,
+						StartTime:             plan.StartTime,
+						Name:                  "pancake",
+					}
+
+					return func(ctx context.Context) ([]byte, error) {
+
+						return q.executeAlternativePlan(ctx, plan, queryTranslator, table, body, false)
+					}
+
+				} else {
+					// TODO: change to info
+					logger.ErrorWithCtx(ctx).Msgf("Error parsing pancake queries: %v", err)
+				}
+			} else {
+				logger.ErrorWithCtx(ctx).Msgf("Alternative plan is not supported for non-clickhouse query translators")
+			}
+		}
+	}
+	return nil
+}
+
+func (q *QueryRunner) executeAlternativePlan(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, isAsync bool) (responseBody []byte, err error) {
+
+	doneCh := make(chan AsyncSearchWithError, 1)
+
+	q.transformQueries(ctx, plan, table)
+
+	if resp, err := q.checkProperties(ctx, plan, table, queryTranslator); err != nil {
+		return resp, err
+	}
+
+	q.runExecutePlanAsync(ctx, plan, queryTranslator, table, doneCh, nil)
+
+	response := <-doneCh
+
+	if response.err == nil {
+		if isAsync {
+			asyncResponse := queryparser.SearchToAsyncSearchResponse(response.response, "__quesma_alternative_plan", false, 200)
+			responseBody, err = asyncResponse.Marshal()
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			responseBody, err = response.response.Marshal()
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		// TODO better error handling
+		m := make(map[string]interface{})
+		m["error"] = fmt.Sprintf("%v", response.err.Error())
+		responseBody, _ = json.MarshalIndent(m, "", "  ")
+	}
+
+	bodyAsBytes, _ := body.Bytes()
+	contextValues := tracing.ExtractValues(ctx)
+	pushAlternativeInfo(q.quesmaManagementConsole, contextValues.RequestId, "", contextValues.OpaqueId, contextValues.RequestPath, bodyAsBytes, response.translatedQueryBody, responseBody, plan.StartTime)
+
+	return responseBody, response.err
+
+}

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -87,8 +87,9 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 
 		abResult := ab_testing.Result{
 			Request: ab_testing.Request{
-				Path: contextValues.RequestPath,
-				Body: string(bytes),
+				Path:      contextValues.RequestPath,
+				IndexName: plan.IndexPattern,
+				Body:      string(bytes),
 			},
 
 			A: ab_testing.Response{

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -169,7 +169,7 @@ func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
 		}
-		
+
 		return responseBody, nil
 	}
 }

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -124,7 +124,7 @@ func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, r
 		return q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
 	}
 
-	props, enabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
+	_, enabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
 	if enabled {
 		return q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
 	}

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -132,7 +132,7 @@ func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, r
 	return nil, nil
 }
 
-func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
+func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
 
 	requestBody, err := body.Bytes()
 	if err != nil {
@@ -147,8 +147,7 @@ func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 		Name:                  "elastic",
 	}
 
-	// TODO: read config here
-	url := "http://elasticsearch:9200/" + plan.IndexPattern + "/_search"
+	url := q.cfg.Elasticsearch.Url.JoinPath(plan.IndexPattern, "_search").String()
 
 	return alternativePlan, func(ctx context.Context) ([]byte, error) {
 

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/k0kubun/pp"
 	"io"
 	"net/http"
 	"quesma/ab_testing"
@@ -24,6 +23,7 @@ type executionPlanResult struct {
 	plan         *model.ExecutionPlan
 	err          error
 	responseBody []byte
+	endTime      time.Time
 }
 
 type executionPlanExecutor func(ctx context.Context) ([]byte, error)
@@ -46,9 +46,11 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 		body, err := alternativePlanExecutor(newCtx)
 
 		optComparePlansCh <- executionPlanResult{
+			isMain:       false,
 			plan:         plan,
 			err:          err,
 			responseBody: body,
+			endTime:      time.Now(),
 		}
 
 	}(optComparePlansCh)
@@ -90,20 +92,19 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 			A: ab_testing.Response{
 				Name:  main.plan.Name,
 				Body:  string(main.responseBody),
-				Time:  time.Since(main.plan.StartTime),
+				Time:  main.endTime.Sub(main.plan.StartTime).Seconds(),
 				Error: toError(main.err),
 			},
 
 			B: ab_testing.Response{
 				Name:  alternative.plan.Name,
 				Body:  string(alternative.responseBody),
-				Time:  time.Since(alternative.plan.StartTime),
+				Time:  alternative.endTime.Sub(alternative.plan.StartTime).Seconds(),
 				Error: toError(alternative.err),
 			},
 			RequestID: contextValues.RequestId,
 			OpaqueID:  contextValues.OpaqueId,
 		}
-		pp.Println("XXXXX Sending A/B Testing Result", abResult)
 		q.ABResultsSender.Send(abResult)
 
 	}(optComparePlansCh)
@@ -114,9 +115,19 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
 
 	// TODO read config here
-	//p := q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
-	p, e := q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
-	return p, e
+
+	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
+	if enabled && props["mode"] == "alternative" {
+
+		return q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
+	}
+
+	props, enabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
+	if enabled {
+		return q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
+	}
+
+	return nil, nil
 }
 
 func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
@@ -134,11 +145,12 @@ func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 		Name:                  "elastic",
 	}
 
+	// TODO: read config here
 	url := "http://elasticsearch:9200/" + plan.IndexPattern + "/_search"
 
 	return alternativePlan, func(ctx context.Context) ([]byte, error) {
 
-		fmt.Println("XXXXXXXX calling elastic", url)
+		// TODO: add user/pass
 
 		if resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody)); err != nil {
 			return nil, err
@@ -161,54 +173,51 @@ func (t *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 	}
 }
 
-func (q *QueryRunner) maybeCreatePancakeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) executionPlanExecutor {
+func (q *QueryRunner) maybeCreatePancakeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
 
-	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
-	if enabled && props["mode"] == "alternative" {
-
-		hasAggQuery := false
-		queriesWithoutAggr := make([]*model.Query, 0)
-		for _, query := range plan.Queries {
-			switch query.Type.AggregationType() {
-			case model.MetricsAggregation, model.BucketAggregation, model.PipelineAggregation:
-				hasAggQuery = true
-			default:
-				queriesWithoutAggr = append(queriesWithoutAggr, query)
-			}
-		}
-
-		if hasAggQuery {
-			if chQueryTranslator, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator); ok {
-
-				// TODO FIXME check if the original plan has count query
-				addCount := false
-
-				if pancakeQueries, err := chQueryTranslator.PancakeParseAggregationJson(body, addCount); err == nil {
-					logger.InfoWithCtx(ctx).Msgf("Running alternative pancake queries")
-					queries := append(queriesWithoutAggr, pancakeQueries...)
-					plan := &model.ExecutionPlan{
-						IndexPattern:          plan.IndexPattern,
-						QueryRowsTransformers: make([]model.QueryRowsTransformer, len(queries)),
-						Queries:               queries,
-						StartTime:             plan.StartTime,
-						Name:                  "pancake",
-					}
-
-					return func(ctx context.Context) ([]byte, error) {
-
-						return q.executeAlternativePlan(ctx, plan, queryTranslator, table, body, false)
-					}
-
-				} else {
-					// TODO: change to info
-					logger.ErrorWithCtx(ctx).Msgf("Error parsing pancake queries: %v", err)
-				}
-			} else {
-				logger.ErrorWithCtx(ctx).Msgf("Alternative plan is not supported for non-clickhouse query translators")
-			}
+	hasAggQuery := false
+	queriesWithoutAggr := make([]*model.Query, 0)
+	for _, query := range plan.Queries {
+		switch query.Type.AggregationType() {
+		case model.MetricsAggregation, model.BucketAggregation, model.PipelineAggregation:
+			hasAggQuery = true
+		default:
+			queriesWithoutAggr = append(queriesWithoutAggr, query)
 		}
 	}
-	return nil
+
+	if hasAggQuery {
+		if chQueryTranslator, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator); ok {
+
+			// TODO FIXME check if the original plan has count query
+			addCount := false
+
+			if pancakeQueries, err := chQueryTranslator.PancakeParseAggregationJson(body, addCount); err == nil {
+				logger.InfoWithCtx(ctx).Msgf("Running alternative pancake queries")
+				queries := append(queriesWithoutAggr, pancakeQueries...)
+				alternativePlan := &model.ExecutionPlan{
+					IndexPattern:          plan.IndexPattern,
+					QueryRowsTransformers: make([]model.QueryRowsTransformer, len(queries)),
+					Queries:               queries,
+					StartTime:             plan.StartTime,
+					Name:                  "pancake",
+				}
+
+				return alternativePlan, func(ctx context.Context) ([]byte, error) {
+
+					return q.executeAlternativePlan(ctx, plan, queryTranslator, table, body, false)
+				}
+
+			} else {
+				// TODO: change to info
+				logger.ErrorWithCtx(ctx).Msgf("Error parsing pancake queries: %v", err)
+			}
+		} else {
+			logger.ErrorWithCtx(ctx).Msgf("Alternative plan is not supported for non-clickhouse query translators")
+		}
+	}
+
+	return nil, nil
 }
 
 func (q *QueryRunner) executeAlternativePlan(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, isAsync bool) (responseBody []byte, err error) {

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -153,12 +153,11 @@ func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 		// TODO: add user/pass
 
 		resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody))
-
 		if err != nil {
 			return nil, err
 		}
-		responseBody, err := io.ReadAll(resp.Body)
 
+		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -170,6 +169,7 @@ func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
 		}
+		
 		return responseBody, nil
 	}
 }

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -117,14 +117,12 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 
 func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
 
-	// TODO read config here
-
 	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
 	if enabled && props["mode"] == "alternative" {
-
 		return q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
 	}
 
+	// TODO is should be enabled in a different way. it's not an optimizer
 	_, enabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
 	if enabled {
 		return q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -78,7 +78,7 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 			bytes = []byte("error converting body to bytes")
 		}
 
-		toError := func(err error) string {
+		errorToString := func(err error) string {
 			if err != nil {
 				return err.Error()
 			}
@@ -96,14 +96,14 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 				Name:  main.plan.Name,
 				Body:  string(main.responseBody),
 				Time:  main.endTime.Sub(main.plan.StartTime).Seconds(),
-				Error: toError(main.err),
+				Error: errorToString(main.err),
 			},
 
 			B: ab_testing.Response{
 				Name:  alternative.plan.Name,
 				Body:  string(alternative.responseBody),
 				Time:  alternative.endTime.Sub(alternative.plan.StartTime).Seconds(),
-				Error: toError(alternative.err),
+				Error: errorToString(alternative.err),
 			},
 			RequestID: contextValues.RequestId,
 			OpaqueID:  contextValues.OpaqueId,

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -315,7 +315,7 @@ func (qmc *QuesmaManagementConsole) comparePipelines() {
 					continue
 				}
 				if len(elasticSurplusFields) > 0 || len(ourSurplusFields) > 0 {
-					logger.Info().Str(logger.RID, queryDebugInfo.QueryDebugPrimarySource.Id).
+					logger.Debug().Str(logger.RID, queryDebugInfo.QueryDebugPrimarySource.Id).
 						Msgf("Response structure different, extra keys:\n"+
 							" Clickhouse response - Elastic response: %v\n"+
 							" Elastic response - Clickhouse response: %v",


### PR DESCRIPTION
This PR add:
- add support for comparison of  Elastic  vs Quesma responses
- add minor improvements related to storing the results 
- move alternative plan handling to a separate file 

Comparison with an Elastic or other external Quesma can be enabled by:
```
  some-index:
    enabled: true
    optimizers:
      elastic_ab_testing:
        enabled: true
        properties:
          mode: "alternative" 
```
Configuration will change in the future.



