### PR TITLE
Ingest alter table with new columns

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -427,6 +427,7 @@ func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalid
 func promoteAttributesToColumns(attrsMap map[string][]interface{}) {
 	var keys []string
 	var values []string
+	var types []string
 	for k, v := range attrsMap {
 		if k == AttributesKeyColumn {
 			for _, val := range v {
@@ -438,10 +439,15 @@ func promoteAttributesToColumns(attrsMap map[string][]interface{}) {
 				values = append(values, fmt.Sprintf("'%s': %s", val, NewType(val).String()))
 			}
 		}
+		if k == AttributesValueType {
+			for _, val := range v {
+				types = append(types, fmt.Sprintf("'%s': %s", val, NewType(val).String()))
+			}
+		}
 	}
 
 	for i := 0; i < len(keys); i++ {
-		fmt.Println("@@@:", keys[i], values[i])
+		fmt.Println("@@@:", keys[i], values[i], types[i])
 	}
 }
 

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -424,30 +424,28 @@ func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalid
 	}
 }
 
-func (lm *LogManager) promoteAttributesToColumns(attrsMap map[string][]interface{}, tableName string) {
-	var keys []string
-	var values []string
-	var types []string
+func getAttributesByArrayName(arrayName string,
+	attrsMap map[string][]interface{}) []string {
+	var attributes []string
 	for k, v := range attrsMap {
-		if k == AttributesKeyColumn {
+		if k == arrayName {
 			for _, val := range v {
-				keys = append(keys, fmt.Sprintf("%s", val))
-			}
-		}
-		if k == AttributesValueColumn {
-			for _, val := range v {
-				values = append(values, fmt.Sprintf("%s", val))
-			}
-		}
-		if k == AttributesValueType {
-			for _, val := range v {
-				types = append(types, fmt.Sprintf("%s", val))
+				attributes = append(attributes, fmt.Sprintf("%s", val))
 			}
 		}
 	}
+	return attributes
+}
 
-	for i := 0; i < len(keys); i++ {
-		alterTable := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN IF NOT EXISTS \"%s\" %s", tableName, keys[i], types[i])
+func (lm *LogManager) promoteAttributesToColumns(
+	attrsMap map[string][]interface{},
+	tableName string) {
+	attrKeys := getAttributesByArrayName(AttributesKeyColumn, attrsMap)
+	attrValues := getAttributesByArrayName(AttributesValueColumn, attrsMap)
+	attrTypes := getAttributesByArrayName(AttributesValueType, attrsMap)
+	_ = attrValues
+	for i := 0; i < len(attrKeys); i++ {
+		alterTable := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN IF NOT EXISTS \"%s\" %s", tableName, attrKeys[i], attrTypes[i])
 		err := lm.execute(context.Background(), alterTable)
 		if err != nil {
 		}

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -644,6 +644,9 @@ func (lm *LogManager) Insert(ctx context.Context, tableName string, jsons []type
 		"date_time_input_format": "best_effort",
 	}))
 
+	insertValues := strings.Join(jsonsReadyForInsertion, ", ")
+	insert := fmt.Sprintf("INSERT INTO \"%s\" FORMAT JSONEachRow %s", tableName, insertValues)
+
 	for _, alter := range alterCmd {
 		err := lm.execute(ctx, alter)
 		if err != nil {
@@ -651,9 +654,6 @@ func (lm *LogManager) Insert(ctx context.Context, tableName string, jsons []type
 		}
 	}
 
-	insertValues := strings.Join(jsonsReadyForInsertion, ", ")
-
-	insert := fmt.Sprintf("INSERT INTO \"%s\" FORMAT JSONEachRow %s", tableName, insertValues)
 	err := lm.execute(ctx, insert)
 	if err != nil {
 		return end_user_errors.GuessClickhouseErrorType(err).InternalDetails("insert into table '%s' failed", tableName)

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -511,7 +511,6 @@ func (lm *LogManager) BuildInsertJson(tableName string, data types.JSON, inValid
 	// we only want to add fields that are not part of the schema e.g we don't
 	// have columns for them
 	alterCmd := lm.generateNewColumns(attrsMap, tableName)
-
 	// If there are some invalid fields, we need to add them to the attributes map
 	// to not lose them and be able to store them later by
 	// generating correct update query
@@ -535,7 +534,9 @@ func (lm *LogManager) BuildInsertJson(tableName string, data types.JSON, inValid
 		nonSchemaStr += fmt.Sprintf(`"%s":%s`, othersFieldName, others)
 	}
 	onlySchemaFields := RemoveNonSchemaFields(m, t)
+
 	schemaFieldsJson, err = json.Marshal(onlySchemaFields)
+
 	if err != nil {
 		return "", nil, err
 	}
@@ -590,7 +591,7 @@ func (lm *LogManager) processInsertQuery(ctx context.Context, tableName string,
 	if err != nil {
 		return nil, err
 	}
-	return lm.Insert(ctx, tableName, jsonData, tableConfig, transformer)
+	return lm.GenerateSqlStatements(ctx, tableName, jsonData, tableConfig, transformer)
 }
 
 func (lm *LogManager) ProcessInsertQuery(ctx context.Context, tableName string,
@@ -635,7 +636,7 @@ func (lm *LogManager) executeStatements(ctx context.Context, queries []string) e
 	return nil
 }
 
-func (lm *LogManager) Insert(ctx context.Context, tableName string, jsons []types.JSON,
+func (lm *LogManager) GenerateSqlStatements(ctx context.Context, tableName string, jsons []types.JSON,
 	config *ChTableConfig, transformer jsonprocessor.IngestTransformer) ([]string, error) {
 	var jsonsReadyForInsertion []string
 	var alterCmd []string

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -49,8 +49,9 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, config.QuesmaConfiguration{})
-		j, err := lm.BuildInsertJson("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		j, alter, err := lm.BuildInsertJson("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig)
 		assert.NoError(t, err)
+		assert.Equal(t, 0, len(alter))
 		m := make(SchemaMap)
 		err = json.Unmarshal([]byte(j), &m)
 		assert.NoError(t, err)
@@ -512,6 +513,7 @@ func TestRemovingNonSchemaFields(t *testing.T) {
 }
 
 func TestJsonFlatteningToStringAttr(t *testing.T) {
+	t.Skip("TODO")
 	config := &ChTableConfig{
 		hasTimestamp:         true,
 		timestampDefaultsNow: true,
@@ -549,6 +551,7 @@ func TestJsonFlatteningToStringAttr(t *testing.T) {
 }
 
 func TestJsonConvertingBoolToStringAttr(t *testing.T) {
+	t.Skip("TODO")
 	config := &ChTableConfig{
 		hasTimestamp:         true,
 		timestampDefaultsNow: true,

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -49,7 +49,7 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, config.QuesmaConfiguration{})
-		j, alter, err := lm.BuildInsertJson("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		j, alter, err := lm.BuildInsertJson("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig, false)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))
 		m := make(SchemaMap)

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -513,7 +513,6 @@ func TestRemovingNonSchemaFields(t *testing.T) {
 }
 
 func TestJsonFlatteningToStringAttr(t *testing.T) {
-	t.Skip("TODO")
 	config := &ChTableConfig{
 		hasTimestamp:         true,
 		timestampDefaultsNow: true,
@@ -544,14 +543,13 @@ func TestJsonFlatteningToStringAttr(t *testing.T) {
 	attrs, others, err := BuildAttrsMapAndOthers(m, config)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(others))
-	assert.Equal(t, 2, len(attrs))
+	assert.Equal(t, 3, len(attrs))
 	for k := range attrs {
 		assert.Contains(t, k, "string")
 	}
 }
 
 func TestJsonConvertingBoolToStringAttr(t *testing.T) {
-	t.Skip("TODO")
 	config := &ChTableConfig{
 		hasTimestamp:         true,
 		timestampDefaultsNow: true,
@@ -582,7 +580,7 @@ func TestJsonConvertingBoolToStringAttr(t *testing.T) {
 	attrs, others, err := BuildAttrsMapAndOthers(m, config)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(others))
-	assert.Equal(t, 2, len(attrs))
+	assert.Equal(t, 3, len(attrs))
 	for k := range attrs {
 		assert.Contains(t, k, "string")
 	}

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -108,10 +108,10 @@ var configs = []*ChTableConfig{
 }
 
 var expectedInserts = []string{
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","service::name":"frontend","severity":"debug","source":"rhel"}`,
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["service::name","severity","source"\],"attributes_string_value":\["frontend","debug","rhel"\],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`,
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":\["debug"\],"random2":"random-string","severity":"frontend"}`,
-	`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":\["random1","random2","severity"\],"attributes_string_value":\["\[debug\]","random-string","frontend"\],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`,
+	EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","service::name":"frontend","severity":"debug","source":"rhel"}`),
+	EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":["service::name","severity","source"],"attributes_string_type":["String","String","String"],"attributes_string_value":["frontend","debug","rhel"],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`),
+	EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
+	EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_string_key":["random1","random2","severity"],"attributes_string_type":["Array(String)","String","String"],"attributes_string_value":["[debug]","random-string","frontend"],"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed"}`),
 }
 
 type logManagerHelper struct {
@@ -211,7 +211,6 @@ func TestAutomaticTableCreationAtInsert(t *testing.T) {
 }
 
 func TestProcessInsertQuery(t *testing.T) {
-	t.Skip("Reimplement this test")
 	ctx := context.Background()
 	for index1, tt := range insertTests {
 		for index2, config := range configs {

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -211,6 +211,7 @@ func TestAutomaticTableCreationAtInsert(t *testing.T) {
 }
 
 func TestProcessInsertQuery(t *testing.T) {
+	t.Skip("Reimplement this test")
 	ctx := context.Background()
 	for index1, tt := range insertTests {
 		for index2, config := range configs {

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -299,6 +299,7 @@ func BuildAttrsMapAndOthers(m SchemaMap, config *ChTableConfig) (map[string][]in
 			if a.Type.canConvert(value) {
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
+				result[a.TypesArrayName] = append(result[a.TypesArrayName], NewType(value).String())
 				matched = true
 				break
 			}

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -300,6 +300,7 @@ func BuildAttrsMapAndOthers(m SchemaMap, config *ChTableConfig) (map[string][]in
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
 				result[a.TypesArrayName] = append(result[a.TypesArrayName], NewType(value).String())
+
 				matched = true
 				break
 			}

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -14,6 +14,7 @@ import (
 const (
 	AttributesKeyColumn   = "attributes_string_key"
 	AttributesValueColumn = "attributes_string_value"
+	AttributesValueType   = "attributes_string_type"
 	attributesColumnType  = "Array(String)"
 )
 
@@ -315,6 +316,7 @@ func NewDefaultStringAttribute() Attribute {
 	return Attribute{
 		KeysArrayName:   AttributesKeyColumn,
 		ValuesArrayName: AttributesValueColumn,
+		TypesArrayName:  AttributesValueType,
 		Type:            NewBaseType("String"),
 	}
 }
@@ -323,6 +325,7 @@ func NewDefaultInt64Attribute() Attribute {
 	return Attribute{
 		KeysArrayName:   "attributes_int64_key",
 		ValuesArrayName: "attributes_int64_value",
+		TypesArrayName:  "attributes_int64_type",
 		Type:            NewBaseType("Int64"),
 	}
 }
@@ -331,6 +334,7 @@ func NewDefaultFloat64Attribute() Attribute {
 	return Attribute{
 		KeysArrayName:   "attributes_float64_key",
 		ValuesArrayName: "attributes_float64_value",
+		TypesArrayName:  "attributes_float64_type",
 		Type:            NewBaseType("Float64"),
 	}
 }
@@ -339,6 +343,7 @@ func NewDefaultBoolAttribute() Attribute {
 	return Attribute{
 		KeysArrayName:   "attributes_bool_key",
 		ValuesArrayName: "attributes_bool_value",
+		TypesArrayName:  "attributes_bool_type",
 		Type:            NewBaseType("Bool"),
 	}
 }

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -250,7 +250,9 @@ func NewType(value any) Type {
 	case map[string]interface{}:
 		cols := make([]*Column, len(valueCasted))
 		for k, v := range valueCasted {
-			cols = append(cols, &Column{Name: k, Type: NewType(v), Codec: Codec{Name: ""}})
+			if v != nil {
+				cols = append(cols, &Column{Name: k, Type: NewType(v), Codec: Codec{Name: ""}})
+			}
 		}
 		return MultiValueType{Name: "Tuple", Cols: cols}
 	case []interface{}:


### PR DESCRIPTION
This PR adds functionality of creating new columns instead of putting them into attributes in the case when they will arrive after first insert. It is hidden under feature flag, which is just const for now.

Still, few things ahead:
- new columns addition heuristic
- some config?
- removing `others`
- `BuildInsertJson` cleanup
- more tests