### PR TITLE
Pancake - quickfix `value_count` metric aggr

### DIFF
--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -127,7 +127,7 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 		query.SelectCommand.Columns = append(query.SelectCommand.Columns, model.NewCountFunc(model.NewDistinctExpr(getFirstExpression())))
 
 	case "value_count":
-		query.SelectCommand.Columns = append(query.SelectCommand.Columns, model.NewCountFunc())
+		query.SelectCommand.Columns = append(query.SelectCommand.Columns, model.NewCountFunc(getFirstExpression()))
 
 	case "stats":
 		expr := getFirstExpression()

--- a/quesma/queryparser/pancake_aggregation_parser_metrics.go
+++ b/quesma/queryparser/pancake_aggregation_parser_metrics.go
@@ -45,7 +45,7 @@ func generateMetricSelectedColumns(ctx context.Context, metricsAggr metricsAggre
 		result = []model.Expr{model.NewCountFunc(model.NewDistinctExpr(getFirstExpression()))}
 
 	case "value_count":
-		result = []model.Expr{model.NewCountFunc()}
+		result = []model.Expr{model.NewCountFunc(getFirstExpression())}
 
 	case "stats":
 		expr := getFirstExpression()

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -80,9 +80,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if multiTerms(test.TestName) {
 				t.Skip("Fix multi terms")
 			}
-			if valueCount(test.TestName) { // DON'T FIX, I already have it fixed in another PR
-				t.Skip("Fix value count")
-			}
 
 			fmt.Println("i:", i, "test:", test.TestName)
 
@@ -249,11 +246,6 @@ func multiTerms(testName string) bool {
 	t3 := testName == "Multi_terms with double-nested subaggregations. Visualize: Bar Vertical: Horizontal Axis: Top values (2 values), Vertical: Unique count, Breakdown: @timestamp"
 	t4 := testName == "Quite simple multi_terms, but with non-string keys. Visualize: Bar Vertical: Horizontal Axis: Date Histogram, Vertical Axis: Count of records, Breakdown: Top values (2 values)"
 	return t1 || t2 || t3 || t4
-}
-
-// TODO remove after fix
-func valueCount(testName string) bool {
-	return testName == "value_count + top_values: regression test"
 }
 
 func TestPancakeQueryGeneration_halfpancake(t *testing.T) {

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -144,7 +144,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if len(expectedMinusActual) != 0 {
 				pp.Println("EXPECTED diff", expectedMinusActual)
 			}
-			pp.Println("ACTUAL", pancakeJson)
+			//pp.Println("ACTUAL", pancakeJson)
 			//pp.Println("EXPECTED", expectedAggregationsPart)
 			assert.True(t, util.AlmostEmpty(actualMinusExpected, acceptableDifference))
 			assert.True(t, util.AlmostEmpty(expectedMinusActual, acceptableDifference))

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2570,12 +2570,14 @@ var AggregationTests = []AggregationTestCase{
 				  "aggr__sample__top_values__count", count() AS
 				  "aggr__sample__top_values__order_1", count(*) AS
 				  "aggr__sample__count_part"
-				FROM "logs-generic-default"
-				WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z')
-				  AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z'))
-				  AND "message" iLIKE '%user%')
+				FROM (
+				  SELECT "host.name"
+				  FROM "logs-generic-default"
+				  WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z')
+				    AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND "message" iLIKE '%user%')
+				  LIMIT 8000)
 				GROUP BY "host.name" AS "aggr__sample__top_values__key_0"))
-			WHERE "aggr__sample__top_values__order_1_rank"<=10
+			WHERE "aggr__sample__top_values__order_1_rank"<=11
 			ORDER BY "aggr__sample__top_values__order_1_rank" ASC`,
 	},
 	{ // [12], "old" test, also can be found in testdata/requests.go TestAsyncSearch[3]

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2564,8 +2564,9 @@ var AggregationTests = []AggregationTestCase{
 				"aggr__sample__top_values__order_1_rank"
 			  FROM (
 				SELECT sum("aggr__sample__count_part") OVER (PARTITION BY 1) AS
-				  "aggr__sample__count", count() AS "metric__sample__sample_count_col_0",
-				  "host.name" AS "aggr__sample__top_values__key_0", count(*) AS
+				  "aggr__sample__count", count("host.name") AS
+				  "metric__sample__sample_count_col_0", "host.name" AS
+				  "aggr__sample__top_values__key_0", count(*) AS
 				  "aggr__sample__top_values__count", count() AS
 				  "aggr__sample__top_values__order_1", count(*) AS
 				  "aggr__sample__count_part"


### PR DESCRIPTION
Basically, like in the example test, we had:
```
SELECT count() AS "metric__sample__sample_count_col_0"
```
But should have:
```
SELECT count("host.name") AS "metric__sample__sample_count_col_0"
```
and that's it. 99% sure it's fine now.