### PR TITLE
Add "PUT /:index/_mapping" endpoint

### DIFF
--- a/quesma/elasticsearch/mappings.go
+++ b/quesma/elasticsearch/mappings.go
@@ -30,6 +30,9 @@ func ParseMappings(namespace string, mappings map[string]interface{}) map[string
 
 		if typeMapping := fieldMappingAsMap["type"]; typeMapping != nil {
 			parsedType, _ := parseElasticType(typeMapping.(string))
+			if parsedType.Name == schema.TypeUnknown.Name {
+				log.Warn().Msgf("unknown type '%v' of field %s", typeMapping, fieldName)
+			}
 			result[fieldName] = schema.Column{Name: fieldName, Type: parsedType.Name}
 		} else if fieldMappingAsMap["properties"] != nil {
 			// Nested field
@@ -52,7 +55,7 @@ func parseElasticType(t string) (schema.Type, bool) {
 		return schema.TypeLong, true
 	case elasticsearch_field_types.FieldTypeDate:
 		return schema.TypeTimestamp, true
-	case elasticsearch_field_types.FieldTypeFloat, elasticsearch_field_types.FieldTypeHalfFloat:
+	case elasticsearch_field_types.FieldTypeFloat, elasticsearch_field_types.FieldTypeHalfFloat, elasticsearch_field_types.FieldTypeDouble:
 		return schema.TypeFloat, true
 	case elasticsearch_field_types.FieldTypeBoolean:
 		return schema.TypeBoolean, true

--- a/quesma/quesma/routes/paths.go
+++ b/quesma/quesma/routes/paths.go
@@ -14,6 +14,7 @@ const (
 	IndexDocPath         = "/:index/_doc"
 	IndexRefreshPath     = "/:index/_refresh"
 	IndexBulkPath        = "/:index/_bulk"
+	IndexMappingPath     = "/:index/_mapping"
 	FieldCapsPath        = "/:index/_field_caps"
 	TermsEnumPath        = "/:index/_terms_enum"
 	EQLSearch            = "/:index/_eql/search"


### PR DESCRIPTION
Add a new `PUT /:index/_mapping` endpoint for static mappings. The implementation is similar to the existing `PUT /:index` endpoint, which can also contain a (static) mapping.

Additionally add a previously missing 'double' case to parseElasticType and add a warning message if the parsing failed.