### PR TITLE
Better sql pretty printer

### DIFF
--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -276,8 +276,8 @@ func TestPancakeQueryGeneration_halfpancake(t *testing.T) {
 
 `,
 			sql: `
-SELECT "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count", count() AS
-   "aggr__0__order_1"
+SELECT "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
+  count() AS "aggr__0__order_1"
 FROM "logs-generic-default"
 GROUP BY "host.name" AS "aggr__0__key_0"
 ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC
@@ -305,8 +305,9 @@ LIMIT 4`, // -- we added one more as filtering nulls happens during rendering
 }
 `,
 			`
-SELECT "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count", count() AS
-   "aggr__0__order_1", avgOrNull("bytes_gauge") AS "metric__0__2_col_0"
+SELECT "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
+  count() AS "aggr__0__order_1",
+  avgOrNull("bytes_gauge") AS "metric__0__2_col_0"
 FROM "logs-generic-default"
 GROUP BY "host.name" AS "aggr__0__key_0"
 ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC


### PR DESCRIPTION
The pretty SQL printer needs to be upgraded to pancake era:
- `ORDER BY` should not cause new line break in window functions
- `SELECT` stmts should break proactive on `,` if next one would not fit in same line


More complex logic, but way nicer, also in live tail.