### PR TITLE
Refactor sqls

### DIFF
--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -289,17 +289,26 @@ func (v *renderer) VisitWindowFunction(f WindowFunction) interface{} {
 	for _, arg := range f.Args {
 		args = append(args, AsString(arg))
 	}
-	partitionBy := make([]string, 0)
-	for _, col := range f.PartitionBy {
-		partitionBy = append(partitionBy, AsString(col))
-	}
 
 	var sb strings.Builder
-	stmtWithoutOrderBy := fmt.Sprintf("%s(%s) OVER (PARTITION BY %s", f.Name, strings.Join(args, ", "), strings.Join(partitionBy, ", "))
+	stmtWithoutOrderBy := fmt.Sprintf("%s(%s) OVER (", f.Name, strings.Join(args, ", "))
 	sb.WriteString(stmtWithoutOrderBy)
 
+	if len(f.PartitionBy) > 0 {
+		sb.WriteString("PARTITION BY ")
+
+		partitionBy := make([]string, 0)
+		for _, col := range f.PartitionBy {
+			partitionBy = append(partitionBy, AsString(col))
+		}
+		sb.WriteString(strings.Join(partitionBy, ", "))
+	}
+
 	if len(f.OrderBy) > 0 && len(f.OrderBy[0].Exprs) > 0 {
-		sb.WriteString(" ORDER BY ")
+		if len(f.PartitionBy) > 0 {
+			sb.WriteString(" ")
+		}
+		sb.WriteString("ORDER BY ")
 		var orderByStr []string
 		for _, orderBy := range f.OrderBy {
 			orderByStr = append(orderByStr, AsString(orderBy))

--- a/quesma/queryparser/pancake_sql_query_generation.go
+++ b/quesma/queryparser/pancake_sql_query_generation.go
@@ -36,12 +36,8 @@ func (p *pancakeSqlQueryGenerator) aliasedExprArrayToLiteralExpr(aliasedExprs []
 
 func (p *pancakeSqlQueryGenerator) generatePartitionBy(groupByColumns []model.AliasedExpr) []model.Expr {
 	partitionBy := make([]model.Expr, 0)
-	if len(groupByColumns) == 0 {
-		partitionBy = []model.Expr{model.NewLiteral(1)}
-	} else {
-		for _, col := range groupByColumns {
-			partitionBy = append(partitionBy, p.newQuotedLiteral(col.Alias))
-		}
+	for _, col := range groupByColumns {
+		partitionBy = append(partitionBy, p.newQuotedLiteral(col.Alias))
 	}
 	return partitionBy
 }

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -264,7 +264,7 @@ func TestPancakeQueryGeneration_halfpancake(t *testing.T) {
 
 `,
 			sql: `
-SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
   "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
   count() AS "aggr__0__order_1"
 FROM "logs-generic-default"
@@ -294,7 +294,7 @@ LIMIT 4`, // -- we added one more as filtering nulls happens during rendering
 }
 `,
 			`
-SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
   "host.name" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
   count() AS "aggr__0__order_1",
   avgOrNull("bytes_gauge") AS "metric__0__2_col_0"

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -659,25 +659,27 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1", dense_rank() OVER (
-			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
-			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
+				"aggr__0__1__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
+				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "FlightDelayType" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
-				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1", toInt64(toUnixTimestamp64Milli("timestamp") / 10800000)
-				  AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS "aggr__0__1__order_1",
-				  count(*) AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  "FlightDelayType" AS "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
+				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS
+				  "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))
 				GROUP BY "FlightDelayType" AS "aggr__0__key_0",
-				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS "aggr__0__1__key_0"))
+				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS
+				  "aggr__0__1__key_0"))
 			WHERE "aggr__0__order_1_rank"<=11
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
@@ -2024,32 +2026,34 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 3`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-			  "aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1"
+			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+			  "aggr__0__1__order_1"
 			FROM (
-			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
-			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
+			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+				"aggr__0__1__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
+				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "severity" AS "aggr__0__key_0", sum("aggr__0__count_part")
-      			  OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1", toInt64(toUnixTimestamp64Milli("@timestamp") /
-				  10800000) AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  "severity" AS "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS
-				  "aggr__0__1__order_1", count(*) AS "aggr__0__count_part", count() AS
-				  "aggr__0__order_1_part"
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS
+				  "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("host.name" iLIKE '%prometheus%' AND ("@timestamp">=
 				  parseDateTime64BestEffort('2024-02-02T16:36:49.940Z') AND "@timestamp"<=
 				  parseDateTime64BestEffort('2024-02-09T16:36:49.940Z')))
 				GROUP BY "severity" AS "aggr__0__key_0",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS "aggr__0__1__key_0"))
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS
+				  "aggr__0__1__key_0"))
 			WHERE "aggr__0__order_1_rank"<=4
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
@@ -2587,24 +2591,22 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__sample__count", "metric__sample__sample_count_col_0",
 				"aggr__sample__top_values__parent_count", "aggr__sample__top_values__key_0",
 				"aggr__sample__top_values__count", "aggr__sample__top_values__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__sample__top_values__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__sample__top_values__order_1" DESC,
 				"aggr__sample__top_values__key_0" ASC) AS
 				"aggr__sample__top_values__order_1_rank"
 			  FROM (
-				SELECT sum("aggr__sample__count_part") OVER () AS
-				  "aggr__sample__count", count("host.name") AS
-				  "metric__sample__sample_count_col_0", sum(count(*)) OVER ()
-      			  AS "aggr__sample__top_values__parent_count", "host.name" AS
-				  "aggr__sample__top_values__key_0", count(*) AS
-				  "aggr__sample__top_values__count", count() AS
-				  "aggr__sample__top_values__order_1", count(*) AS
-				  "aggr__sample__count_part"
+				SELECT sum(count(*)) OVER () AS "aggr__sample__count",
+				  count("host.name") AS "metric__sample__sample_count_col_0",
+				  sum(count(*)) OVER () AS "aggr__sample__top_values__parent_count",
+				  "host.name" AS "aggr__sample__top_values__key_0",
+				  count(*) AS "aggr__sample__top_values__count",
+				  count() AS "aggr__sample__top_values__order_1"
 				FROM (
 				  SELECT "host.name"
 				  FROM "logs-generic-default"
-				  WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z')
-				    AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND "message" iLIKE '%user%')
+				  WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z'
+					) AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z'
+					)) AND "message" iLIKE '%user%')
 				  LIMIT 8000)
 				GROUP BY "host.name" AS "aggr__sample__top_values__key_0"))
 			WHERE "aggr__sample__top_values__order_1_rank"<=11
@@ -2964,36 +2966,37 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__stats__parent_count", "aggr__stats__key_0", "aggr__stats__count",
-			  "aggr__stats__order_1", "aggr__stats__series__key_0", "aggr__stats__series__count",
-			  "aggr__stats__series__order_1"
+			  "aggr__stats__order_1", "aggr__stats__series__key_0",
+			  "aggr__stats__series__count", "aggr__stats__series__order_1"
 			FROM (
-			  SELECT "aggr__stats__parent_count", "aggr__stats__key_0", "aggr__stats__count",
-			    "aggr__stats__order_1", "aggr__stats__series__key_0", "aggr__stats__series__count",
-				"aggr__stats__series__order_1", dense_rank() OVER (
-			  ORDER BY "aggr__stats__order_1" DESC, "aggr__stats__key_0" ASC) AS
-				"aggr__stats__order_1_rank", dense_rank() OVER (PARTITION BY
-				"aggr__stats__key_0"
-			  ORDER BY "aggr__stats__series__order_1", "aggr__stats__series__key_0" ASC) AS
+			  SELECT "aggr__stats__parent_count", "aggr__stats__key_0",
+				"aggr__stats__count", "aggr__stats__order_1", "aggr__stats__series__key_0",
+				"aggr__stats__series__count", "aggr__stats__series__order_1",
+				dense_rank() OVER (ORDER BY "aggr__stats__order_1" DESC,
+				"aggr__stats__key_0" ASC) AS "aggr__stats__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__stats__key_0" ORDER BY
+				"aggr__stats__series__order_1", "aggr__stats__series__key_0" ASC) AS
 				"aggr__stats__series__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__stats__parent_count",
-				  COALESCE("event.dataset",'unknown') AS "aggr__stats__key_0",
-				  sum("aggr__stats__count_part") OVER (PARTITION BY "aggr__stats__key_0") AS
-				  "aggr__stats__count", sum("aggr__stats__order_1_part") OVER (PARTITION BY
-				  "aggr__stats__key_0") AS "aggr__stats__order_1", toInt64(
-				  toUnixTimestamp64Milli("@timestamp") / 60000) AS
+				  COALESCE("event.dataset", 'unknown') AS "aggr__stats__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__stats__key_0") AS
+				  "aggr__stats__count",
+				  sum(count()) OVER (PARTITION BY "aggr__stats__key_0") AS
+				  "aggr__stats__order_1",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
 				  "aggr__stats__series__key_0", count(*) AS "aggr__stats__series__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
-				  "aggr__stats__series__order_1", count(*) AS "aggr__stats__count_part",
-				  count() AS "aggr__stats__order_1_part"
+				  "aggr__stats__series__order_1"
 				FROM "logs-generic-default"
 				WHERE ("@timestamp">parseDateTime64BestEffort('2024-01-25T14:53:59.033Z')
 				  AND "@timestamp"<=parseDateTime64BestEffort('2024-01-25T15:08:59.033Z'))
-				GROUP BY COALESCE("event.dataset",'unknown') AS "aggr__stats__key_0",
+				GROUP BY COALESCE("event.dataset", 'unknown') AS "aggr__stats__key_0",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
 				  "aggr__stats__series__key_0"))
 			WHERE "aggr__stats__order_1_rank"<=4
-			ORDER BY "aggr__stats__order_1_rank" ASC, "aggr__stats__series__order_1_rank" ASC`,
+			ORDER BY "aggr__stats__order_1_rank" ASC,
+			  "aggr__stats__series__order_1_rank" ASC`,
 	},
 	{ // [14], "old" test, also can be found in testdata/requests.go TestAsyncSearch[5]
 		// Copied it also here to be more sure we do not create some regression
@@ -4054,16 +4057,16 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__sampler__count", "aggr__sampler__eventRate__key_0",
 				"aggr__sampler__eventRate__count", "aggr__sampler__eventRate__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__sampler__eventRate__order_1",
+				dense_rank() OVER (ORDER BY "aggr__sampler__eventRate__order_1",
 				"aggr__sampler__eventRate__key_0" ASC) AS
 				"aggr__sampler__eventRate__order_1_rank"
 			  FROM (
-				SELECT sum("aggr__sampler__count_part") OVER () AS
-				  "aggr__sampler__count", toInt64(toUnixTimestamp64Milli("@timestamp") / 15000)
-				  AS "aggr__sampler__eventRate__key_0", count(*) AS
-				  "aggr__sampler__eventRate__count", toInt64(toUnixTimestamp64Milli("@timestamp") / 15000)
-				  AS "aggr__sampler__eventRate__order_1", count(*) AS "aggr__sampler__count_part"
+				SELECT sum(count(*)) OVER () AS "aggr__sampler__count",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 15000) AS
+				  "aggr__sampler__eventRate__key_0",
+				  count(*) AS "aggr__sampler__eventRate__count",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 15000) AS
+				  "aggr__sampler__eventRate__order_1"
 				FROM (
 				  SELECT "@timestamp"
 				  FROM "logs-generic-default"
@@ -5546,20 +5549,18 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__2__parent_count", "aggr__0__2__key_0", "aggr__0__2__count",
 				"aggr__0__2__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1",
-				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC) AS
+				"aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__2__order_1" DESC, "aggr__0__2__key_0" ASC) AS
 				"aggr__0__2__order_1_rank"
 			  FROM (
 				SELECT floor("rspContentLen"/2000.000000)*2000.000000 AS "aggr__0__key_0",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  floor("rspContentLen"/2000.000000)*2000.000000 AS "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__2__parent_count", "message" AS "aggr__0__2__key_0",
-				  count(*) AS "aggr__0__2__count", count() AS "aggr__0__2__order_1",
-				  count(*) AS "aggr__0__count_part"
+				  count(*) AS "aggr__0__2__count", count() AS "aggr__0__2__order_1"
 				FROM "logs-generic-default"
 				GROUP BY floor("rspContentLen"/2000.000000)*2000.000000 AS "aggr__0__key_0",
 				  "message" AS "aggr__0__2__key_0"))
@@ -6985,22 +6986,19 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
-				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__1__parent_count", "message" AS "aggr__0__1__key_0",
-				  count(*) AS "aggr__0__1__count", count() AS "aggr__0__1__order_1",
-				  count(*) AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  count(*) AS "aggr__0__1__count", count() AS "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0", "message" AS "aggr__0__1__key_0"))
@@ -7160,8 +7158,8 @@ var AggregationTests = []AggregationTestCase{
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1", "aggr__0__1__2__parent_count",
 				"aggr__0__1__2__key_0", "aggr__0__1__2__count", "aggr__0__1__2__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
-				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank",
@@ -7171,22 +7169,17 @@ var AggregationTests = []AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__1__parent_count", "message" AS "aggr__0__1__key_0",
-				  sum("aggr__0__1__count_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__1__key_0") AS "aggr__0__1__count",
-				  sum("aggr__0__1__order_1_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__1__key_0") AS "aggr__0__1__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__1__key_0") AS
+				  "aggr__0__1__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__1__key_0") AS
+				  "aggr__0__1__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__1__key_0") AS
 				  "aggr__0__1__2__parent_count", "message" AS "aggr__0__1__2__key_0",
-				  count(*) AS "aggr__0__1__2__count", count() AS "aggr__0__1__2__order_1",
-				  count(*) AS "aggr__0__count_part", count() AS "aggr__0__order_1_part",
-				  count(*) AS "aggr__0__1__count_part",
-				  count() AS "aggr__0__1__order_1_part"
+				  count(*) AS "aggr__0__1__2__count", count() AS "aggr__0__1__2__order_1"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0", "message" AS "aggr__0__1__key_0",
@@ -7303,23 +7296,23 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1", dense_rank() OVER (
-			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
-			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
+				"aggr__0__1__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
+				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
-				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1", "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS
-				  "aggr__0__1__count", "FlightDelayMin" AS "aggr__0__1__order_1", count(*)
-				  AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  "host.name" AS "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  "FlightDelayMin" AS "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
-				GROUP BY "host.name" AS "aggr__0__key_0", "FlightDelayMin" AS
-				  "aggr__0__1__key_0"))
+				GROUP BY "host.name" AS "aggr__0__key_0",
+				  "FlightDelayMin" AS "aggr__0__1__key_0"))
 			WHERE "aggr__0__order_1_rank"<=9
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
@@ -7440,27 +7433,29 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 10`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-			  "aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1"
+			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+			  "aggr__0__1__order_1"
 			FROM (
-			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
-			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
+			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+				"aggr__0__1__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
+				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
-				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1", "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS
-				  "aggr__0__1__count", "FlightDelayMin" AS "aggr__0__1__order_1", count(*)
-				  AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  "host.name" AS "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  "FlightDelayMin" AS "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
-				GROUP BY "host.name" AS "aggr__0__key_0", "FlightDelayMin" AS "aggr__0__1__key_0"))
+				GROUP BY "host.name" AS "aggr__0__key_0",
+				  "FlightDelayMin" AS "aggr__0__1__key_0"))
 			WHERE "aggr__0__order_1_rank"<=11
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
@@ -7568,28 +7563,29 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 10`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-			  "aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1"
+			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+			  "aggr__0__1__order_1"
 			FROM (
-			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
-			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
+			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
+				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
+				"aggr__0__1__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
+				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
-				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1", "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS
-				  "aggr__0__1__count", "FlightDelayMin" AS "aggr__0__1__order_1", count(*)
-				  AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  "host.name" AS "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
+				  "FlightDelayMin" AS "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
-				GROUP BY "host.name" AS "aggr__0__key_0", "FlightDelayMin" AS
-				  "aggr__0__1__key_0"))
+				GROUP BY "host.name" AS "aggr__0__key_0",
+				  "FlightDelayMin" AS "aggr__0__1__key_0"))
 			WHERE "aggr__0__order_1_rank"<=11
 			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
@@ -7933,22 +7929,19 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
-				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
+				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginAirportID" AS "aggr__0__key_0",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__count",
-				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__1__parent_count", "DestAirportID" AS "aggr__0__1__key_0",
-				  count(*) AS "aggr__0__1__count", count() AS "aggr__0__1__order_1",
-				  count(*) AS "aggr__0__count_part", count() AS "aggr__0__order_1_part"
+				  count(*) AS "aggr__0__1__count", count() AS "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "OriginAirportID" AS "aggr__0__key_0",
 				  "DestAirportID" AS "aggr__0__1__key_0"))

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -659,13 +659,13 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1", dense_rank() OVER (PARTITION BY 1
+				"aggr__0__1__order_1", dense_rank() OVER (
 			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
 				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
 			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "FlightDelayType" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
 				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
@@ -945,7 +945,7 @@ var AggregationTests = []AggregationTestCase{
 				`AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))`,
 		},
 		ExpectedPancakeSQL: `SELECT uniq("OriginCityName") AS "metric__unique_terms_col_0", ` +
-			`sum(count(*)) OVER (PARTITION BY 1) AS "aggr__suggestions__parent_count", ` +
+			`sum(count(*)) OVER () AS "aggr__suggestions__parent_count", ` +
 			`"OriginCityName" AS "aggr__suggestions__key_0", ` +
 			`count(*) AS "aggr__suggestions__count", ` +
 			`count() AS "aggr__suggestions__order_1" ` +
@@ -2029,13 +2029,13 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
 				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
 			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "severity" AS "aggr__0__key_0", sum("aggr__0__count_part")
       			  OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
@@ -2587,14 +2587,14 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__sample__count", "metric__sample__sample_count_col_0",
 				"aggr__sample__top_values__parent_count", "aggr__sample__top_values__key_0",
 				"aggr__sample__top_values__count", "aggr__sample__top_values__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__sample__top_values__order_1" DESC,
 				"aggr__sample__top_values__key_0" ASC) AS
 				"aggr__sample__top_values__order_1_rank"
 			  FROM (
-				SELECT sum("aggr__sample__count_part") OVER (PARTITION BY 1) AS
+				SELECT sum("aggr__sample__count_part") OVER () AS
 				  "aggr__sample__count", count("host.name") AS
-				  "metric__sample__sample_count_col_0", sum(count(*)) OVER (PARTITION BY 1)
+				  "metric__sample__sample_count_col_0", sum(count(*)) OVER ()
       			  AS "aggr__sample__top_values__parent_count", "host.name" AS
 				  "aggr__sample__top_values__key_0", count(*) AS
 				  "aggr__sample__top_values__count", count() AS
@@ -2969,14 +2969,14 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__stats__parent_count", "aggr__stats__key_0", "aggr__stats__count",
 			    "aggr__stats__order_1", "aggr__stats__series__key_0", "aggr__stats__series__count",
-				"aggr__stats__series__order_1", dense_rank() OVER (PARTITION BY 1
+				"aggr__stats__series__order_1", dense_rank() OVER (
 			  ORDER BY "aggr__stats__order_1" DESC, "aggr__stats__key_0" ASC) AS
 				"aggr__stats__order_1_rank", dense_rank() OVER (PARTITION BY
 				"aggr__stats__key_0"
 			  ORDER BY "aggr__stats__series__order_1", "aggr__stats__series__key_0" ASC) AS
 				"aggr__stats__series__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__stats__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__stats__parent_count",
 				  COALESCE("event.dataset",'unknown') AS "aggr__stats__key_0",
 				  sum("aggr__stats__count_part") OVER (PARTITION BY "aggr__stats__key_0") AS
 				  "aggr__stats__count", sum("aggr__stats__order_1_part") OVER (PARTITION BY
@@ -3417,7 +3417,7 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 3`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "message" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
 			  count() AS "aggr__0__order_1"
 			FROM "logs-generic-default"
@@ -4054,12 +4054,12 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__sampler__count", "aggr__sampler__eventRate__key_0",
 				"aggr__sampler__eventRate__count", "aggr__sampler__eventRate__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__sampler__eventRate__order_1",
 				"aggr__sampler__eventRate__key_0" ASC) AS
 				"aggr__sampler__eventRate__order_1_rank"
 			  FROM (
-				SELECT sum("aggr__sampler__count_part") OVER (PARTITION BY 1) AS
+				SELECT sum("aggr__sampler__count_part") OVER () AS
 				  "aggr__sampler__count", toInt64(toUnixTimestamp64Milli("@timestamp") / 15000)
 				  AS "aggr__sampler__eventRate__key_0", count(*) AS
 				  "aggr__sampler__eventRate__count", toInt64(toUnixTimestamp64Milli("@timestamp") / 15000)
@@ -4888,7 +4888,7 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 4`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "message" AS "aggr__2__key_0", 
 			  count(*) AS "aggr__2__count",
 			  count() AS "aggr__2__order_1"
@@ -5546,7 +5546,7 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__2__parent_count", "aggr__0__2__key_0", "aggr__0__2__count",
 				"aggr__0__2__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1",
 				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__2__order_1" DESC, "aggr__0__2__key_0" ASC) AS
@@ -6985,13 +6985,13 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
 				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__count",
@@ -7160,7 +7160,7 @@ var AggregationTests = []AggregationTestCase{
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1", "aggr__0__1__2__parent_count",
 				"aggr__0__1__2__key_0", "aggr__0__1__2__count", "aggr__0__1__2__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
 				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
@@ -7169,7 +7169,7 @@ var AggregationTests = []AggregationTestCase{
 				BY "aggr__0__1__2__order_1" DESC, "aggr__0__1__2__key_0" ASC) AS
 				"aggr__0__1__2__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__count",
@@ -7303,13 +7303,13 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1", dense_rank() OVER (PARTITION BY 1
+				"aggr__0__1__order_1", dense_rank() OVER (
 			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
 				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
 			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
 				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
@@ -7445,13 +7445,13 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
 				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
 			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
 				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
@@ -7573,13 +7573,13 @@ var AggregationTests = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC) AS
 				"aggr__0__order_1_rank", dense_rank() OVER (PARTITION BY "aggr__0__key_0"
 			  ORDER BY "aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0", sum("aggr__0__count_part") OVER
 				  (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum("aggr__0__order_1_part") OVER (PARTITION BY "aggr__0__key_0") AS
@@ -7834,7 +7834,7 @@ var AggregationTests = []AggregationTestCase{
 				`LIMIT 10`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "name" AS "aggr__2__key_0", 
 			  count(*) AS "aggr__2__count",
   			  sumOrNull("total") AS "aggr__2__order_1",
@@ -7933,13 +7933,13 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__parent_count", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC,
 				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginAirportID" AS "aggr__0__key_0",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__count",

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -645,7 +645,7 @@ var AggregationTests2 = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT
-			  sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			  sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "response" AS "aggr__2__key_0",
 			  count(*) AS "aggr__2__count",
 			  count() AS "aggr__2__order_1",
@@ -869,13 +869,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -1186,13 +1186,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -1415,13 +1415,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  COALESCE("surname", 'miss') AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -1677,13 +1677,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -1862,7 +1862,7 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
 			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
@@ -2055,7 +2055,7 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
 			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
@@ -2268,7 +2268,7 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (PARTITION BY 1
+				dense_rank() OVER (
 			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
 			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
@@ -2537,13 +2537,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__count", "aggr__2__8__5__parent_count",
 				"aggr__2__8__5__key_0", "aggr__2__8__5__count", "aggr__2__8__5__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__5__order_1" DESC, "aggr__2__8__5__key_0" ASC) AS
 				"aggr__2__8__5__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -2817,13 +2817,13 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__count", "aggr__2__8__5__parent_count",
 				"aggr__2__8__5__key_0", "aggr__2__8__5__count", "aggr__2__8__5__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__5__order_1" DESC, "aggr__2__8__5__key_0" ASC) AS
 				"aggr__2__8__5__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -869,23 +869,20 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part"
+				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0"))
@@ -1186,22 +1183,19 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count", "limbName" AS "aggr__2__8__key_0",
-				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part"
+				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0", "limbName" AS "aggr__2__8__key_0"))
 			WHERE ("aggr__2__order_1_rank"<=201 AND "aggr__2__8__order_1_rank"<=21)
@@ -1415,23 +1409,20 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  COALESCE("surname", 'miss') AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part"
+				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1"
 				FROM "logs-generic-default"
 				GROUP BY COALESCE("surname", 'miss') AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0"))
@@ -1677,22 +1668,19 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count", "limbName" AS "aggr__2__8__key_0",
-				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part"
+				  count(*) AS "aggr__2__8__count", count() AS "aggr__2__8__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0", "limbName" AS "aggr__2__8__key_0"))
 			WHERE ("aggr__2__order_1_rank"<=201 AND "aggr__2__8__order_1_rank"<=21)
@@ -1862,24 +1850,26 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
-				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
-			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
+				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
+				"aggr__2__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
+				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
 				"aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__2__key_0", sum("aggr__2__count_part") OVER (PARTITION BY
-				  "aggr__2__key_0") AS "aggr__2__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS "aggr__2__order_1",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS "aggr__2__3__key_0",
-				  count(*) AS "aggr__2__3__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS "aggr__2__3__order_1",
-				  count(*) AS "aggr__2__count_part"
+				  "aggr__2__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
+				  "aggr__2__order_1",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
+				  "aggr__2__3__key_0", count(*) AS "aggr__2__3__count",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
+				  "aggr__2__3__order_1"
 				FROM "logs-generic-default"
 				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__2__key_0", toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
-				   "aggr__2__3__key_0"))
+				  "aggr__2__key_0",
+				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
+				  "aggr__2__3__key_0"))
 			ORDER BY "aggr__2__order_1_rank" ASC, "aggr__2__3__order_1_rank" ASC`,
 	},
 	{ // [49] TODO should null be in the response? Maybe try to replicate and see if it's fine as is.
@@ -2055,24 +2045,23 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
-				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
-			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
+				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
+				"aggr__2__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
+				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
 				"aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count", floor("bytes"/100.000000)*100.000000 AS
-				  "aggr__2__order_1", floor("bytes2"/5.000000)*5.000000 AS
-				  "aggr__2__3__key_0", count(*) AS "aggr__2__3__count",
-				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1", count(*) AS
-				  "aggr__2__count_part"
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  floor("bytes"/100.000000)*100.000000 AS "aggr__2__order_1",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0",
+				  count(*) AS "aggr__2__3__count",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T13:47:56.077Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:02:56.077Z'))
-				GROUP BY floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0", floor(
-				  "bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0"))
+				GROUP BY floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0"))
 			ORDER BY "aggr__2__order_1_rank" ASC, "aggr__2__3__order_1_rank" ASC`,
 	},
 	{ // [50] TODO: what about nulls in histogram? Maybe they should be treated like in terms?
@@ -2268,24 +2257,23 @@ var AggregationTests2 = []AggregationTestCase{
 			FROM (
 			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
 				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (
-			  ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
-				 dense_rank() OVER (PARTITION BY "aggr__2__key_0"
-			  ORDER BY "aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
+				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
+				"aggr__2__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
+				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
 				"aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count", floor("bytes"/100.000000)*100.000000 AS
-				  "aggr__2__order_1", floor("bytes2"/5.000000)*5.000000 AS
-				  "aggr__2__3__key_0", count(*) AS "aggr__2__3__count",
-				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1", count(*) AS
-				  "aggr__2__count_part"
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  floor("bytes"/100.000000)*100.000000 AS "aggr__2__order_1",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0",
+				  count(*) AS "aggr__2__3__count",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T13:47:56.077Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:02:56.077Z'))
-				GROUP BY floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0", floor(
-				  "bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0"))
+				GROUP BY floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
+				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0"))
 			ORDER BY "aggr__2__order_1_rank" ASC, "aggr__2__3__order_1_rank" ASC`,
 	},
 	{ // [51]
@@ -2537,26 +2525,21 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__count", "aggr__2__8__5__parent_count",
 				"aggr__2__8__5__key_0", "aggr__2__8__5__count", "aggr__2__8__5__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__5__order_1" DESC, "aggr__2__8__5__key_0" ASC) AS
 				"aggr__2__8__5__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__8__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__8__count",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__5__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__5__key_0",
-				  count(*) AS "aggr__2__8__5__count", count() AS "aggr__2__8__5__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part",
-				  count(*) AS "aggr__2__8__count_part"
+				  count(*) AS "aggr__2__8__5__count", count() AS "aggr__2__8__5__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__5__key_0"))
@@ -2817,26 +2800,21 @@ var AggregationTests2 = []AggregationTestCase{
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "aggr__2__8__count", "aggr__2__8__5__parent_count",
 				"aggr__2__8__5__key_0", "aggr__2__8__5__count", "aggr__2__8__5__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__5__order_1" DESC, "aggr__2__8__5__key_0" ASC) AS
 				"aggr__2__8__5__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__8__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__8__count",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__5__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__5__key_0",
-				  count(*) AS "aggr__2__8__5__count", count() AS "aggr__2__8__5__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part",
-				  count(*) AS "aggr__2__8__count_part"
+				  count(*) AS "aggr__2__8__5__count", count() AS "aggr__2__8__5__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__5__key_0"))

--- a/quesma/testdata/clients/ophelia.go
+++ b/quesma/testdata/clients/ophelia.go
@@ -354,8 +354,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
@@ -365,23 +365,18 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__count",
-				  sum("aggr__2__8__order_1_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
-				  count(*) AS "aggr__2__8__4__count", count() AS "aggr__2__8__4__order_1",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part",
-				  count(*) AS "aggr__2__8__count_part",
-				  count() AS "aggr__2__8__order_1_part"
+				  count(*) AS "aggr__2__8__4__count", count() AS "aggr__2__8__4__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -998,8 +993,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"metric__2__8__4__1_col_0", "metric__2__8__4__5_col_0",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
@@ -1009,31 +1004,24 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sum("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__order_1",
-				  sumOrNull("metric__2__1_col_0_part") OVER (PARTITION BY "aggr__2__key_0")
-				  AS "metric__2__1_col_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__order_1",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0") AS
+				  "metric__2__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__count",
-				  sum("aggr__2__8__order_1_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
-				  sumOrNull("metric__2__8__1_col_0_part") OVER (PARTITION BY
-				  "aggr__2__key_0", "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__count",
+				  sum(count()) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__order_1",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
+				  "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
 				  count(*) AS "aggr__2__8__4__count", count() AS "aggr__2__8__4__order_1",
 				  sumOrNull("total") AS "metric__2__8__4__1_col_0",
-				  sumOrNull("some") AS "metric__2__8__4__5_col_0",
-				  count(*) AS "aggr__2__count_part", count() AS "aggr__2__order_1_part",
-				  sumOrNull("total") AS "metric__2__1_col_0_part",
-				  count(*) AS "aggr__2__8__count_part",
-				  count() AS "aggr__2__8__order_1_part",
-				  sumOrNull("total") AS "metric__2__8__1_col_0_part"
+				  sumOrNull("some") AS "metric__2__8__4__5_col_0"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -2116,8 +2104,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__8__key_0", "aggr__2__8__count", "aggr__2__8__order_1",
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
@@ -2127,29 +2115,23 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  avgOrNullMerge("aggr__2__order_1_part") OVER (PARTITION BY
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  avgOrNullMerge(avgOrNullState("total")) OVER (PARTITION BY
 				  "aggr__2__key_0") AS "aggr__2__order_1",
-				  avgOrNullMerge("metric__2__1_col_0_part") OVER (PARTITION BY
+				  avgOrNullMerge(avgOrNullState("total")) OVER (PARTITION BY
 				  "aggr__2__key_0") AS "metric__2__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__count",
-				  sumOrNull("aggr__2__8__order_1_part") OVER (PARTITION BY "aggr__2__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__count",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
 				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
 				  sumOrNull("total") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
 				  count(*) AS "aggr__2__8__4__count",
-				  "organName" AS "aggr__2__8__4__order_1",
-				  count(*) AS "aggr__2__count_part",
-				  avgOrNullState("total") AS "aggr__2__order_1_part",
-				  avgOrNullState("total") AS "metric__2__1_col_0_part",
-				  count(*) AS "aggr__2__8__count_part",
-				  sumOrNull("total") AS "aggr__2__8__order_1_part"
+				  "organName" AS "aggr__2__8__4__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -2706,8 +2688,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"aggr__2__8__4__5__parent_count", "aggr__2__8__4__5__key_0",
 				"aggr__2__8__4__5__count", "aggr__2__8__4__5__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
@@ -2720,31 +2702,27 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count", "surname" AS "aggr__2__order_1",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  "surname" AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__count",
-				  sumOrNull("aggr__2__8__order_1_part") OVER (PARTITION BY "aggr__2__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__count",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
 				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
-				  sumOrNull("metric__2__8__1_col_0_part") OVER (PARTITION BY
-				  "aggr__2__key_0", "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
+				  "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
-				  sum("aggr__2__8__4__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0", "aggr__2__8__4__key_0") AS "aggr__2__8__4__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0",
+				  "aggr__2__8__4__key_0") AS "aggr__2__8__4__count",
 				  "organName" AS "aggr__2__8__4__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0",
 				  "aggr__2__8__4__key_0") AS "aggr__2__8__4__5__parent_count",
 				  "organName" AS "aggr__2__8__4__5__key_0",
 				  count(*) AS "aggr__2__8__4__5__count",
-				  count() AS "aggr__2__8__4__5__order_1", count(*) AS "aggr__2__count_part",
-				  count(*) AS "aggr__2__8__count_part",
-				  sumOrNull("total") AS "aggr__2__8__order_1_part",
-				  sumOrNull("total") AS "metric__2__8__1_col_0_part",
-				  count(*) AS "aggr__2__8__4__count_part"
+				  count() AS "aggr__2__8__4__5__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -3352,8 +3330,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"metric__2__8__4__1_col_0", "metric__2__8__4__5_col_0",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
-				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
+				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
@@ -3363,33 +3341,26 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
-				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
-				  "aggr__2__count",
-				  sumOrNull("aggr__2__order_1_part") OVER (PARTITION BY "aggr__2__key_0") AS
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__order_1",
-				  sumOrNull("metric__2__1_col_0_part") OVER (PARTITION BY "aggr__2__key_0")
-				  AS "metric__2__1_col_0",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0") AS
+				  "metric__2__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
-				  sum("aggr__2__8__count_part") OVER (PARTITION BY "aggr__2__key_0",
-				  "aggr__2__8__key_0") AS "aggr__2__8__count",
-				  sumOrNull("aggr__2__8__order_1_part") OVER (PARTITION BY "aggr__2__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
+				  "aggr__2__8__count",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
 				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
-				  sumOrNull("metric__2__8__1_col_0_part") OVER (PARTITION BY
-				  "aggr__2__key_0", "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
+				  "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
 				  count(*) AS "aggr__2__8__4__count",
 				  sumOrNull("total") AS "aggr__2__8__4__order_1",
 				  sumOrNull("total") AS "metric__2__8__4__1_col_0",
-				  sumOrNull("some") AS "metric__2__8__4__5_col_0",
-				  count(*) AS "aggr__2__count_part",
-				  sumOrNull("total") AS "aggr__2__order_1_part",
-				  sumOrNull("total") AS "metric__2__1_col_0_part",
-				  count(*) AS "aggr__2__8__count_part",
-				  sumOrNull("total") AS "aggr__2__8__order_1_part",
-				  sumOrNull("total") AS "metric__2__8__1_col_0_part"
+				  sumOrNull("some") AS "metric__2__8__4__5_col_0"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",

--- a/quesma/testdata/clients/ophelia.go
+++ b/quesma/testdata/clients/ophelia.go
@@ -354,7 +354,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
 				"aggr__2__8__count", "aggr__2__8__order_1", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
@@ -363,7 +363,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
 				"aggr__2__8__4__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -998,7 +998,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"metric__2__8__4__1_col_0", "metric__2__8__4__5_col_0",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
@@ -1007,7 +1007,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
 				"aggr__2__8__4__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -2116,7 +2116,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__8__key_0", "aggr__2__8__count", "aggr__2__8__order_1",
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
@@ -2125,7 +2125,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
 				"aggr__2__8__4__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",
@@ -2706,7 +2706,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"aggr__2__8__4__5__parent_count", "aggr__2__8__4__5__key_0",
 				"aggr__2__8__4__5__count", "aggr__2__8__4__5__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
@@ -2718,7 +2718,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"aggr__2__8__4__key_0" ORDER BY "aggr__2__8__4__5__order_1" DESC,
 				"aggr__2__8__4__5__key_0" ASC) AS "aggr__2__8__4__5__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count", "surname" AS "aggr__2__order_1",
@@ -3352,7 +3352,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
 				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
 				"metric__2__8__4__1_col_0", "metric__2__8__4__5_col_0",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__2__order_1" DESC,
+				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC,
 				"aggr__2__key_0" ASC) AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" DESC, "aggr__2__8__key_0" ASC) AS
@@ -3361,7 +3361,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
 				"aggr__2__8__4__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum("aggr__2__count_part") OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__count",

--- a/quesma/testdata/kibana-visualize/aggregation_requests.go
+++ b/quesma/testdata/kibana-visualize/aggregation_requests.go
@@ -299,7 +299,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__1__parent_count", "aggr__0__1__key_0", "aggr__0__1__key_1",
 				"aggr__0__1__count", "aggr__0__1__order_2",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1",
 				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_2" DESC, "aggr__0__1__key_0" ASC, "aggr__0__1__key_1" ASC
@@ -528,13 +528,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_2" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
 				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "message" AS "aggr__0__key_0", "host.name" AS "aggr__0__key_1",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
 				  "aggr__0__key_1") AS "aggr__0__count",
@@ -848,13 +848,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 				"aggr__0__count", "aggr__0__order_2", "metric__0__2_col_0",
 				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
 				"metric__0__1__2_col_0",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_2" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
 				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "severity" AS "aggr__0__key_0", "source" AS "aggr__0__key_1",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
 				  "aggr__0__key_1") AS "aggr__0__count",
@@ -1110,13 +1110,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (PARTITION BY 1 ORDER BY "aggr__0__order_2" DESC,
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
 				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
-				SELECT sum(count(*)) OVER (PARTITION BY 1) AS "aggr__0__parent_count",
+				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "Cancelled" AS "aggr__0__key_0", "AvgTicketPrice" AS "aggr__0__key_1",
 				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
 				  "aggr__0__key_1") AS "aggr__0__count",

--- a/quesma/testdata/kibana-visualize/aggregation_requests.go
+++ b/quesma/testdata/kibana-visualize/aggregation_requests.go
@@ -299,22 +299,21 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
 				"aggr__0__1__parent_count", "aggr__0__1__key_0", "aggr__0__1__key_1",
 				"aggr__0__1__count", "aggr__0__1__order_2",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1",
-				"aggr__0__key_0" ASC) AS "aggr__0__order_1_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC) AS
+				"aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_2" DESC, "aggr__0__1__key_0" ASC, "aggr__0__1__key_1" ASC
 				) AS "aggr__0__1__order_2_rank"
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__key_0",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0") AS
-				  "aggr__0__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__1__parent_count", "severity" AS "aggr__0__1__key_0",
 				  "source" AS "aggr__0__1__key_1", count(*) AS "aggr__0__1__count",
-				  count() AS "aggr__0__1__order_2", count(*) AS "aggr__0__count_part"
+				  count() AS "aggr__0__1__order_2"
 				FROM "logs-generic-default"
 				WHERE ("@timestamp">=parseDateTime64BestEffort('2024-05-27T11:59:56.627Z')
 				  AND "@timestamp"<=parseDateTime64BestEffort('2024-05-27T12:14:56.627Z'))
@@ -528,23 +527,22 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
-				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
+				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "message" AS "aggr__0__key_0", "host.name" AS "aggr__0__key_1",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__key_1") AS "aggr__0__count",
-				  sum("aggr__0__order_2_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__key_1") AS "aggr__0__order_2",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
+				  "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
+				  "aggr__0__order_2",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1", count(*) AS "aggr__0__count_part",
-				  count() AS "aggr__0__order_2_part"
+				  "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "message" AS "aggr__0__key_0", "host.name" AS "aggr__0__key_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
@@ -848,27 +846,24 @@ var AggregationTests = []testdata.AggregationTestCase{
 				"aggr__0__count", "aggr__0__order_2", "metric__0__2_col_0",
 				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
 				"metric__0__1__2_col_0",
-				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
-				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
+				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "severity" AS "aggr__0__key_0", "source" AS "aggr__0__key_1",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__key_1") AS "aggr__0__count",
-				  uniqMerge("aggr__0__order_2_part") OVER (PARTITION BY "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
+				  "aggr__0__count",
+				  uniqMerge(uniqState("severity")) OVER (PARTITION BY "aggr__0__key_0",
 				  "aggr__0__key_1") AS "aggr__0__order_2",
-				  uniqMerge("metric__0__2_col_0_part") OVER (PARTITION BY "aggr__0__key_0",
+				  uniqMerge(uniqState("severity")) OVER (PARTITION BY "aggr__0__key_0",
 				  "aggr__0__key_1") AS "metric__0__2_col_0",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1", uniq("severity") AS "metric__0__1__2_col_0",
-				  count(*) AS "aggr__0__count_part",
-				  uniqState("severity") AS "aggr__0__order_2_part",
-				  uniqState("severity") AS "metric__0__2_col_0_part"
+				  "aggr__0__1__order_1", uniq("severity") AS "metric__0__1__2_col_0"
 				FROM "logs-generic-default"
 				GROUP BY "severity" AS "aggr__0__key_0", "source" AS "aggr__0__key_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
@@ -1110,23 +1105,22 @@ var AggregationTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
 				"aggr__0__1__count", "aggr__0__1__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC,
-				"aggr__0__key_0" ASC, "aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
+				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
 				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "Cancelled" AS "aggr__0__key_0", "AvgTicketPrice" AS "aggr__0__key_1",
-				  sum("aggr__0__count_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__key_1") AS "aggr__0__count",
-				  sum("aggr__0__order_2_part") OVER (PARTITION BY "aggr__0__key_0",
-				  "aggr__0__key_1") AS "aggr__0__order_2",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
+				  "aggr__0__count",
+				  sum(count()) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
+				  "aggr__0__order_2",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1", count(*) AS "aggr__0__count_part",
-				  count() AS "aggr__0__order_2_part"
+				  "aggr__0__1__order_1"
 				FROM "logs-generic-default"
 				GROUP BY "Cancelled" AS "aggr__0__key_0",
 				  "AvgTicketPrice" AS "aggr__0__key_1",

--- a/quesma/testdata/opensearch-visualize/aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/aggregation_requests.go
@@ -829,7 +829,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT
-			  sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			  sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "response" AS "aggr__2__key_0",
 			  count(*) AS "aggr__2__count",
 			  count() AS "aggr__2__order_1",
@@ -1032,7 +1032,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT
-			  sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			  sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "response" AS "aggr__2__key_0",
 			  count(*) AS "aggr__2__count",
 			  count() AS "aggr__2__order_1",
@@ -1261,7 +1261,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT
-			  sum(count(*)) OVER (PARTITION BY 1) AS "aggr__2__parent_count",
+			  sum(count(*)) OVER () AS "aggr__2__parent_count",
 			  "response" AS "aggr__2__key_0",
 			  count(*) AS "aggr__2__count",
 			  count() AS "aggr__2__order_1",


### PR DESCRIPTION
It turns out that we can generate simpler SQLS:
`sum(aggr_1_part) OVER (PARTITION BY 1)`
`count(*) AS aggr_1_part`

Can be just `sum(count(*)) OVER ()`.