### PR TITLE
Fix pancake order by

### DIFF
--- a/quesma/model/base_visitor.go
+++ b/quesma/model/base_visitor.go
@@ -117,7 +117,7 @@ func (v *BaseExprVisitor) VisitOrderByExpr(e OrderByExpr) interface{} {
 	if v.OverrideVisitOrderByExpr != nil {
 		return v.OverrideVisitOrderByExpr(v, e)
 	}
-	return OrderByExpr{Exprs: v.VisitChildren(e.Exprs), Direction: e.Direction, ExchangeToAliasInCTE: e.ExchangeToAliasInCTE}
+	return OrderByExpr{Expr: e.Expr.Accept(v).(Expr), Direction: e.Direction, ExchangeToAliasInCTE: e.ExchangeToAliasInCTE}
 }
 
 func (v *BaseExprVisitor) VisitDistinctExpr(e DistinctExpr) interface{} {

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Elastic-2.0
 package model
 
+import "strconv"
+
 // Expr is a generic representation of an expression which is a part of the SQL query.
 type Expr interface {
 	Accept(v ExprVisitor) interface{}
@@ -205,6 +207,10 @@ func NewAliasedExpr(expr Expr, alias string) AliasedExpr {
 }
 
 func (a AliasedExpr) Accept(v ExprVisitor) interface{} { return v.VisitAliasedExpr(a) }
+
+func (a AliasedExpr) AliasRef() LiteralExpr {
+	return LiteralExpr{Value: strconv.Quote(a.Alias)}
+}
 
 // WindowFunction representation e.g. `SUM(x) OVER (PARTITION BY y ORDER BY z)`
 type WindowFunction struct {

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -165,7 +165,7 @@ const (
 )
 
 type OrderByExpr struct {
-	Exprs                []Expr
+	Expr                 Expr
 	Direction            OrderByDirection
 	ExchangeToAliasInCTE bool
 }
@@ -174,19 +174,19 @@ func (o OrderByExpr) Accept(v ExprVisitor) interface{} {
 	return v.VisitOrderByExpr(o)
 }
 
-func NewOrderByExpr(exprs []Expr, direction OrderByDirection) OrderByExpr {
-	return OrderByExpr{Exprs: exprs, Direction: direction}
+func NewOrderByExpr(expr Expr, direction OrderByDirection) OrderByExpr {
+	return OrderByExpr{Expr: expr, Direction: direction}
 }
-func NewOrderByExprWithoutOrder(exprs ...Expr) OrderByExpr {
-	return OrderByExpr{Exprs: exprs, Direction: DefaultOrder}
+func NewOrderByExprWithoutOrder(expr Expr) OrderByExpr {
+	return OrderByExpr{Expr: expr, Direction: DefaultOrder}
 }
 
 // IsCountDesc returns true <=> this OrderByExpr is count() DESC
 func (o OrderByExpr) IsCountDesc() bool {
-	if len(o.Exprs) != 1 || o.Direction != DescOrder {
+	if o.Direction != DescOrder {
 		return false
 	}
-	function, ok := o.Exprs[0].(FunctionExpr)
+	function, ok := o.Expr.(FunctionExpr)
 	return ok && function.Name == "count"
 }
 

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -107,11 +107,7 @@ func (v *renderer) VisitInfix(e InfixExpr) interface{} {
 }
 
 func (v *renderer) VisitOrderByExpr(e OrderByExpr) interface{} {
-	var exprsAsStr []string
-	for _, expr := range e.Exprs {
-		exprsAsStr = append(exprsAsStr, expr.Accept(v).(string))
-	}
-	allExprs := strings.Join(exprsAsStr, ", ")
+	allExprs := e.Expr.Accept(v).(string)
 	if e.Direction == DescOrder {
 		return fmt.Sprintf("%s %s", allExprs, "DESC")
 	}
@@ -304,7 +300,7 @@ func (v *renderer) VisitWindowFunction(f WindowFunction) interface{} {
 		sb.WriteString(strings.Join(partitionBy, ", "))
 	}
 
-	if len(f.OrderBy) > 0 && len(f.OrderBy[0].Exprs) > 0 {
+	if len(f.OrderBy) > 0 {
 		if len(f.PartitionBy) > 0 {
 			sb.WriteString(" ")
 		}

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -93,11 +93,11 @@ func NewQueryExecutionHints() *QueryOptimizeHints {
 }
 
 func NewSortColumn(field string, direction OrderByDirection) OrderByExpr {
-	return NewOrderByExpr([]Expr{NewColumnRef(field)}, direction)
+	return NewOrderByExpr(NewColumnRef(field), direction)
 }
 
 func NewSortByCountColumn(direction OrderByDirection) OrderByExpr {
-	return NewOrderByExpr([]Expr{NewCountFunc()}, direction)
+	return NewOrderByExpr(NewCountFunc(), direction)
 }
 
 var NoMetadataField JsonMap = nil
@@ -149,16 +149,16 @@ func (q *Query) IsChild(maybeParent *Query) bool {
 
 func (q *Query) NewSelectExprWithRowNumber(selectFields []Expr, groupByFields []Expr,
 	whereClause Expr, orderByField string, orderByDesc bool) SelectCommand {
-	var orderByExpr OrderByExpr
+	orderBy := []OrderByExpr{}
 	if orderByField != "" {
 		if orderByDesc {
-			orderByExpr = NewOrderByExpr([]Expr{NewColumnRef(orderByField)}, DescOrder)
+			orderBy = []OrderByExpr{NewOrderByExpr(NewColumnRef(orderByField), DescOrder)}
 		} else {
-			orderByExpr = NewOrderByExpr([]Expr{NewColumnRef(orderByField)}, AscOrder)
+			orderBy = []OrderByExpr{NewOrderByExpr(NewColumnRef(orderByField), AscOrder)}
 		}
 	}
 	selectFields = append(selectFields, NewAliasedExpr(NewWindowFunction(
-		"ROW_NUMBER", nil, groupByFields, []OrderByExpr{orderByExpr},
+		"ROW_NUMBER", nil, groupByFields, orderBy,
 	), RowNumberColumnName))
 
 	return *NewSelectCommand(selectFields, nil, nil, q.SelectCommand.FromClause, whereClause, []Expr{}, 0, 0, false, []*SelectCommand{})

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -790,8 +790,8 @@ func (cw *ClickhouseQueryTranslator) tryBucketAggregation(currentAggr *aggrQuery
 
 		var mainOrderBy model.Expr = defaultMainOrderBy
 		fullOrderBy := []model.OrderByExpr{ // default
-			{Exprs: []model.Expr{mainOrderBy}, Direction: defaultDirection, ExchangeToAliasInCTE: true},
-			{Exprs: []model.Expr{fieldExpression}},
+			{Expr: mainOrderBy, Direction: defaultDirection, ExchangeToAliasInCTE: true},
+			{Expr: fieldExpression},
 		}
 		direction := defaultDirection
 		if orderRaw, exists := terms["order"]; exists {
@@ -808,15 +808,15 @@ func (cw *ClickhouseQueryTranslator) tryBucketAggregation(currentAggr *aggrQuery
 						}
 
 						if key == "_key" {
-							fullOrderBy = []model.OrderByExpr{{Exprs: []model.Expr{fieldExpression}, Direction: direction}}
+							fullOrderBy = []model.OrderByExpr{{Expr: fieldExpression, Direction: direction}}
 							break // mainOrderBy remains default
 						} else if key != "_count" {
 							mainOrderBy = cw.findMetricAggregation(queryMap, key, currentAggr)
 						}
 
 						fullOrderBy = []model.OrderByExpr{
-							{Exprs: []model.Expr{mainOrderBy}, Direction: direction, ExchangeToAliasInCTE: true},
-							{Exprs: []model.Expr{fieldExpression}},
+							{Expr: mainOrderBy, Direction: direction, ExchangeToAliasInCTE: true},
+							{Expr: fieldExpression},
 						}
 					}
 				} else {

--- a/quesma/queryparser/pancake_aggregation_parser_buckets.go
+++ b/quesma/queryparser/pancake_aggregation_parser_buckets.go
@@ -373,12 +373,12 @@ func (cw *ClickhouseQueryTranslator) parseOrder(terms, queryMap QueryMap, fieldE
 
 	fieldOrderBys := make([]model.OrderByExpr, 0, len(fieldExpressions))
 	for _, fieldExpression := range fieldExpressions {
-		fieldOrderBys = append(fieldOrderBys, model.OrderByExpr{Exprs: []model.Expr{fieldExpression}})
+		fieldOrderBys = append(fieldOrderBys, model.OrderByExpr{Expr: fieldExpression})
 	}
 
 	var mainOrderBy model.Expr = defaultMainOrderBy
 	fullOrderBy := []model.OrderByExpr{ // default
-		{Exprs: []model.Expr{mainOrderBy}, Direction: defaultDirection, ExchangeToAliasInCTE: true},
+		{Expr: mainOrderBy, Direction: defaultDirection, ExchangeToAliasInCTE: true},
 	}
 	fullOrderBy = append(fullOrderBy, fieldOrderBys...)
 	direction := defaultDirection
@@ -419,7 +419,7 @@ func (cw *ClickhouseQueryTranslator) parseOrder(terms, queryMap QueryMap, fieldE
 		}
 
 		fullOrderBy = []model.OrderByExpr{
-			{Exprs: []model.Expr{mainOrderBy}, Direction: direction, ExchangeToAliasInCTE: true},
+			{Expr: mainOrderBy, Direction: direction, ExchangeToAliasInCTE: true},
 		}
 		fullOrderBy = append(fullOrderBy, fieldOrderBys...)
 	}

--- a/quesma/queryparser/pancake_sql_query_generation.go
+++ b/quesma/queryparser/pancake_sql_query_generation.go
@@ -143,7 +143,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 
 		for i, orderBy := range bucketAggregation.orderBy {
 			columnId := len(bucketAggregation.selectedColumns) + i
-			orderByExpr := orderBy.Exprs[0]
+			orderByExpr := orderBy.Expr
 
 			partOfGroupByOpt := p.isPartOfGroupBy(orderByExpr, append(groupByColumns, addGroupBys...))
 			if partOfGroupByOpt != nil {
@@ -152,7 +152,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 					direction = model.AscOrder // primarily needed for tests
 				}
 				rankColumnOrderBy = append(rankColumnOrderBy, model.NewOrderByExpr(
-					[]model.Expr{p.newQuotedLiteral(partOfGroupByOpt.Alias)}, direction))
+					p.newQuotedLiteral(partOfGroupByOpt.Alias), direction))
 				continue
 			}
 
@@ -171,7 +171,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 			addSelectColumns = append(addSelectColumns, aliasedColumn)
 
 			rankColumnOrderBy = append(rankColumnOrderBy, model.NewOrderByExpr(
-				[]model.Expr{p.newQuotedLiteral(aliasedColumn.Alias)}, orderBy.Direction))
+				p.newQuotedLiteral(aliasedColumn.Alias), orderBy.Direction))
 		}
 
 		// We order by count, but add key to get right dense_rank()
@@ -179,7 +179,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 			alreadyAdded := false
 			for _, orderBy := range rankColumnOrderBy {
 				if toAdd, ok := addedGroupByAlias.(model.LiteralExpr); ok {
-					if added, ok2 := orderBy.Exprs[0].(model.LiteralExpr); ok2 {
+					if added, ok2 := orderBy.Expr.(model.LiteralExpr); ok2 {
 						if added.Value == toAdd.Value {
 							alreadyAdded = true
 							break
@@ -188,7 +188,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 				}
 			}
 			if !alreadyAdded {
-				rankColumnOrderBy = append(rankColumnOrderBy, model.NewOrderByExpr([]model.Expr{addedGroupByAlias}, model.AscOrder))
+				rankColumnOrderBy = append(rankColumnOrderBy, model.NewOrderByExpr(addedGroupByAlias, model.AscOrder))
 			}
 		}
 
@@ -210,7 +210,7 @@ func (p *pancakeSqlQueryGenerator) generateBucketSqlParts(bucketAggregation *pan
 			addRankWheres = append(addRankWheres, whereRank)
 		}
 
-		rankOrderBy := model.NewOrderByExpr([]model.Expr{p.newQuotedLiteral(aliasedRank.Alias)}, model.AscOrder)
+		rankOrderBy := model.NewOrderByExpr(p.newQuotedLiteral(aliasedRank.Alias), model.AscOrder)
 		addRankOrderBys = append(addRankOrderBys, rankOrderBy)
 	}
 	return

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -475,7 +475,7 @@ func (cw *ClickhouseQueryTranslator) combineQueries(queries []*model.Query) {
 		fmt.Println("parentIdx:", parentIndex)
 		parentQuery := queries[parentIndex]
 		parentQuery.SelectCommand.orderBy = append(parentQuery.SelectCommand.orderBy,
-			model.OrderByExpr{Exprs: parentQuery.SelectCommand.Columns[len(parentQuery.SelectCommand.Columns)-1:], Direction: model.DescOrder})
+			model.OrderByExpr{Expr: parentQuery.SelectCommand.Columns[len(parentQuery.SelectCommand.Columns)-1:], Direction: model.DescOrder})
 	}
 }
 */

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -583,7 +583,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", uint64(1647)),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1706875200000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", uint64(2)),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1706875200000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(2200)),
@@ -592,7 +591,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", uint64(1647)),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1706886000000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", uint64(27)),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1706886000000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(2200)),
@@ -601,7 +599,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", uint64(1647)),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1706896800000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", uint64(34)),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1706896800000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(2200)),
@@ -610,7 +607,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", uint64(45)),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1706875200000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", uint64(0)),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1706875200000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(2200)),
@@ -619,7 +615,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", uint64(45)),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1706886000000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", uint64(2)),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1706886000000/1000/60/60/3)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -654,26 +649,21 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-			  "aggr__0__1__order_1"
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1",
 				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
 				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "FlightDelayType" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS
-				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("timestamp") / 10800000) AS
-				  "aggr__0__1__order_1"
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))
@@ -1695,22 +1685,18 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 15.0),
 				model.NewQueryResultCol("aggr__0__count", 21),
-				model.NewQueryResultCol("aggr__0__order_1", 15.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 30.0),
 				model.NewQueryResultCol("aggr__0__count", 22),
-				model.NewQueryResultCol("aggr__0__order_1", 30.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 345.0),
 				model.NewQueryResultCol("aggr__0__count", 13),
-				model.NewQueryResultCol("aggr__0__order_1", 345.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 360.0),
 				model.NewQueryResultCol("aggr__0__count", 22),
-				model.NewQueryResultCol("aggr__0__order_1", 360.0),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -1723,14 +1709,13 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY "FlightDelayMin"`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "FlightDelayMin" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
-			  "FlightDelayMin" AS "aggr__0__order_1"
+			SELECT "FlightDelayMin" AS "aggr__0__key_0", count(*) AS "aggr__0__count"
 			FROM "logs-generic-default"
 			WHERE (("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z')) AND NOT (
 			  "FlightDelayMin"==0))
 			GROUP BY "FlightDelayMin" AS "aggr__0__key_0"
-			ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC`,
+			ORDER BY "aggr__0__key_0" ASC`,
 	},
 	{ // [9]
 		TestName: "double aggregation with histogram + harder query",
@@ -1944,7 +1929,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 102),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707480000000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 22),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707480000000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 167),
@@ -1953,7 +1937,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 102),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707490800000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 80),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707490800000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 167),
@@ -1962,7 +1945,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 49),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707480000000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 17),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707480000000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 167),
@@ -1971,7 +1953,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 49),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707490800000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 32),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707490800000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 167),
@@ -1980,7 +1961,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 16),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707480000000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 5),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707480000000/1000/60/60/3)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 167),
@@ -1989,7 +1969,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__order_1", 16),
 				model.NewQueryResultCol("aggr__0__1__key_0", int64(1707490800000/1000/60/60/3)),
 				model.NewQueryResultCol("aggr__0__1__count", 11),
-				model.NewQueryResultCol("aggr__0__1__order_1", int64(1707490800000/1000/60/60/3)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2027,26 +2006,21 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-			  "aggr__0__1__order_1"
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1",
 				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
 				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "severity" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS
-				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 10800000) AS
-				  "aggr__0__1__order_1"
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				WHERE ("host.name" iLIKE '%prometheus%' AND ("@timestamp">=
 				  parseDateTime64BestEffort('2024-02-02T16:36:49.940Z') AND "@timestamp"<=
@@ -2728,42 +2702,34 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021670000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 2),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021670000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021700000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 13),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021700000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021730000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 14),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021730000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021760000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 14),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021760000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021790000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 15),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021790000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021820000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 13),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021820000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021850000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 15),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021850000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1706021880000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 11),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1706021880000/30000)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2786,16 +2752,15 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY ` + timestampGroupByClause,
 		},
 		ExpectedPancakeSQL: `
-			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS "aggr__0__key_0",
-			count(*) AS "aggr__0__count", toInt64(toUnixTimestamp64Milli("@timestamp") / 30000)
-			AS "aggr__0__order_1"
+			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS "aggr__0__key_0"
+			  , count(*) AS "aggr__0__count"
 			FROM "logs-generic-default"
 			WHERE ("message" iLIKE '%user%' AND ("@timestamp">=parseDateTime64BestEffort(
 			  '2024-01-23T14:43:19.481Z') AND "@timestamp"<=parseDateTime64BestEffort(
 			  '2024-01-23T14:58:19.481Z')))
 			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 			  "aggr__0__key_0"
-			ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC`,
+			ORDER BY "aggr__0__key_0" ASC`,
 	},
 	{ // [13], "old" test, also can be found in testdata/requests.go TestAsyncSearch[4]
 		// Copied it also here to be more sure we do not create some regression
@@ -2920,7 +2885,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__stats__order_1", 348),
 				model.NewQueryResultCol("aggr__stats__series__key_0", int64(1713398400000/60000)),
 				model.NewQueryResultCol("aggr__stats__series__count", 85),
-				model.NewQueryResultCol("aggr__stats__series__order_1", int64(1713398400000/60000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__stats__parent_count", int64(4675)),
@@ -2929,7 +2893,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__stats__order_1", 348),
 				model.NewQueryResultCol("aggr__stats__series__key_0", int64(1714003200000/60000)),
 				model.NewQueryResultCol("aggr__stats__series__count", 79),
-				model.NewQueryResultCol("aggr__stats__series__order_1", int64(1714003200000/60000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__stats__parent_count", int64(4675)),
@@ -2938,7 +2901,6 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__stats__order_1", 188),
 				model.NewQueryResultCol("aggr__stats__series__key_0", int64(1713398400000/60000)),
 				model.NewQueryResultCol("aggr__stats__series__count", 79),
-				model.NewQueryResultCol("aggr__stats__series__order_1", int64(1713398400000/60000)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2967,16 +2929,15 @@ var AggregationTests = []AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT "aggr__stats__parent_count", "aggr__stats__key_0", "aggr__stats__count",
 			  "aggr__stats__order_1", "aggr__stats__series__key_0",
-			  "aggr__stats__series__count", "aggr__stats__series__order_1"
+			  "aggr__stats__series__count"
 			FROM (
 			  SELECT "aggr__stats__parent_count", "aggr__stats__key_0",
 				"aggr__stats__count", "aggr__stats__order_1", "aggr__stats__series__key_0",
-				"aggr__stats__series__count", "aggr__stats__series__order_1",
+				"aggr__stats__series__count",
 				dense_rank() OVER (ORDER BY "aggr__stats__order_1" DESC,
 				"aggr__stats__key_0" ASC) AS "aggr__stats__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__stats__key_0" ORDER BY
-				"aggr__stats__series__order_1", "aggr__stats__series__key_0" ASC) AS
-				"aggr__stats__series__order_1_rank"
+				"aggr__stats__series__key_0" ASC) AS "aggr__stats__series__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__stats__parent_count",
 				  COALESCE("event.dataset", 'unknown') AS "aggr__stats__key_0",
@@ -2985,9 +2946,7 @@ var AggregationTests = []AggregationTestCase{
 				  sum(count()) OVER (PARTITION BY "aggr__stats__key_0") AS
 				  "aggr__stats__order_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
-				  "aggr__stats__series__key_0", count(*) AS "aggr__stats__series__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
-				  "aggr__stats__series__order_1"
+				  "aggr__stats__series__key_0", count(*) AS "aggr__stats__series__count"
 				FROM "logs-generic-default"
 				WHERE ("@timestamp">parseDateTime64BestEffort('2024-01-25T14:53:59.033Z')
 				  AND "@timestamp"<=parseDateTime64BestEffort('2024-01-25T15:08:59.033Z'))
@@ -3245,13 +3204,11 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(19772)),
 				model.NewQueryResultCol("aggr__0__count", 31),
-				model.NewQueryResultCol("aggr__0__order_1", int64(19772)),
 				model.NewQueryResultCol("metric__0__1_col_0", 2221.5625),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(19773)),
 				model.NewQueryResultCol("aggr__0__count", 158),
-				model.NewQueryResultCol("aggr__0__order_1", int64(19773)),
 				model.NewQueryResultCol("metric__0__1_col_0", 11116.45703125),
 			}},
 		},
@@ -3283,14 +3240,13 @@ var AggregationTests = []AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT toInt64(toUnixTimestamp64Milli("order_date") / 86400000) AS
 			  "aggr__0__key_0", count(*) AS "aggr__0__count",
-			  toInt64(toUnixTimestamp64Milli("order_date") / 86400000) AS "aggr__0__order_1",
 			  sumOrNull("taxful_total_price") AS "metric__0__1_col_0"
 			FROM "logs-generic-default"
 			WHERE ("order_date">=parseDateTime64BestEffort('2024-02-19T17:40:56.351Z') AND
 			  "order_date"<=parseDateTime64BestEffort('2024-02-26T17:40:56.351Z'))
 			GROUP BY toInt64(toUnixTimestamp64Milli("order_date") / 86400000) AS
 			  "aggr__0__key_0"
-			ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC`,
+			ORDER BY "aggr__0__key_0" ASC`,
 	},
 	{ // [16]
 		TestName: "simple terms, seen at client's",
@@ -4031,13 +3987,11 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__sampler__count", uint64(15)),
 				model.NewQueryResultCol("aggr__sampler__eventRate__key_0", int64(1709816790000/15000)),
 				model.NewQueryResultCol("aggr__sampler__eventRate__count", 0),
-				model.NewQueryResultCol("aggr__sampler__eventRate__order_1", int64(1709816790000/15000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__sampler__count", uint64(15)),
 				model.NewQueryResultCol("aggr__sampler__eventRate__key_0", int64(1709816805000/15000)),
 				model.NewQueryResultCol("aggr__sampler__eventRate__count", 0),
-				model.NewQueryResultCol("aggr__sampler__eventRate__order_1", int64(1709816805000/15000)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -4053,20 +4007,17 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__sampler__count", "aggr__sampler__eventRate__key_0",
-			  "aggr__sampler__eventRate__count", "aggr__sampler__eventRate__order_1"
+			  "aggr__sampler__eventRate__count"
 			FROM (
 			  SELECT "aggr__sampler__count", "aggr__sampler__eventRate__key_0",
-				"aggr__sampler__eventRate__count", "aggr__sampler__eventRate__order_1",
-				dense_rank() OVER (ORDER BY "aggr__sampler__eventRate__order_1",
-				"aggr__sampler__eventRate__key_0" ASC) AS
+				"aggr__sampler__eventRate__count",
+				dense_rank() OVER (ORDER BY "aggr__sampler__eventRate__key_0" ASC) AS
 				"aggr__sampler__eventRate__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__sampler__count",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 15000) AS
 				  "aggr__sampler__eventRate__key_0",
-				  count(*) AS "aggr__sampler__eventRate__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 15000) AS
-				  "aggr__sampler__eventRate__order_1"
+				  count(*) AS "aggr__sampler__eventRate__count"
 				FROM (
 				  SELECT "@timestamp"
 				  FROM "logs-generic-default"
@@ -4988,7 +4939,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__timeseries__key_0", int64(1713571200000/79200000)),
 				model.NewQueryResultCol("aggr__timeseries__count", 1180),
-				model.NewQueryResultCol("aggr__timeseries__order_1", int64(1713571200000/79200000)),
 				model.NewQueryResultCol("metric__timeseries__61ca57f2-469d-11e7-af02-69e470af7417_col_0", 21),
 			}},
 		},
@@ -5005,14 +4955,13 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 79200000) AS
-			  "aggr__timeseries__key_0", count(*) AS "aggr__timeseries__count", toInt64(
-			  toUnixTimestamp64Milli("@timestamp") / 79200000) AS
-			  "aggr__timeseries__order_1", uniq("host.name") AS
+			  "aggr__timeseries__key_0", count(*) AS "aggr__timeseries__count",
+			  uniq("host.name") AS
 			  "metric__timeseries__61ca57f2-469d-11e7-af02-69e470af7417_col_0"
 			FROM "logs-generic-default"
 			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 79200000) AS
 			  "aggr__timeseries__key_0"
-			ORDER BY "aggr__timeseries__order_1", "aggr__timeseries__key_0" ASC`,
+			ORDER BY "aggr__timeseries__key_0" ASC`,
 	},
 	{ // [25]
 		TestName: "simple histogram, but min_doc_count: 0",
@@ -5150,12 +5099,10 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9100.0),
 				model.NewQueryResultCol("aggr__2__count", 1),
-				model.NewQueryResultCol("aggr__2__order_1", 9100.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9700.0),
 				model.NewQueryResultCol("aggr__2__count", 2),
-				model.NewQueryResultCol("aggr__2__order_1", 9700.0),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -5171,13 +5118,13 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY floor("bytes"/100.000000)*100.000000`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0", count(*) AS
-			  "aggr__2__count", floor("bytes"/100.000000)*100.000000 AS "aggr__2__order_1"
+			SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
+			  count(*) AS "aggr__2__count"
 			FROM "logs-generic-default"
 			WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T13:47:56.077Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:02:56.077Z'))
 			GROUP BY floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0"
-			ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC`,
+			ORDER BY "aggr__2__key_0" ASC`,
 	},
 	{ // [26]
 		TestName: "simple date_histogram, but min_doc_count: 0",
@@ -5313,12 +5260,10 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1715351610000/30000)),
 				model.NewQueryResultCol("aggr__2__count", 1),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1715351610000/30000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1715351730000/30000)),
 				model.NewQueryResultCol("aggr__2__count", 2),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1715351730000/30000)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -5335,14 +5280,13 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT toInt64(toUnixTimestamp64Milli("timestamp") / 30000) AS "aggr__2__key_0",
-			   count(*) AS "aggr__2__count", toInt64(toUnixTimestamp64Milli("timestamp") /
-			  30000) AS "aggr__2__order_1"
+			  count(*) AS "aggr__2__count"
 			FROM "logs-generic-default"
 			WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T14:29:02.900Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:44:02.900Z'))
 			GROUP BY toInt64(toUnixTimestamp64Milli("timestamp") / 30000) AS
 			  "aggr__2__key_0"
-			ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC`,
+			ORDER BY "aggr__2__key_0" ASC`,
 	},
 	{ // [27]
 		TestName: "simple date_histogram, but min_doc_count: 0",
@@ -5504,7 +5448,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 0.0),
 				model.NewQueryResultCol("aggr__0__count", 3),
-				model.NewQueryResultCol("aggr__0__order_1", 0.0),
 				model.NewQueryResultCol("aggr__0__2__parent_count", 3),
 				model.NewQueryResultCol("aggr__0__2__key_0", "a"),
 				model.NewQueryResultCol("aggr__0__2__count", int64(2)),
@@ -5513,7 +5456,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 0.0),
 				model.NewQueryResultCol("aggr__0__count", 3),
-				model.NewQueryResultCol("aggr__0__order_1", 0.0),
 				model.NewQueryResultCol("aggr__0__2__parent_count", 3),
 				model.NewQueryResultCol("aggr__0__2__key_0", "b"),
 				model.NewQueryResultCol("aggr__0__2__count", int64(1)),
@@ -5522,7 +5464,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", 4000.0),
 				model.NewQueryResultCol("aggr__0__count", 1),
-				model.NewQueryResultCol("aggr__0__order_1", 4000.0),
 				model.NewQueryResultCol("aggr__0__2__parent_count", 1),
 				model.NewQueryResultCol("aggr__0__2__key_0", "c"),
 				model.NewQueryResultCol("aggr__0__2__count", int64(1)),
@@ -5542,22 +5483,19 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY floor("rspContentLen" / 2000.000000) * 2000.000000`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-			  "aggr__0__2__parent_count", "aggr__0__2__key_0", "aggr__0__2__count",
-			  "aggr__0__2__order_1"
+			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__2__parent_count",
+			  "aggr__0__2__key_0", "aggr__0__2__count", "aggr__0__2__order_1"
 			FROM (
-			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-				"aggr__0__2__parent_count", "aggr__0__2__key_0", "aggr__0__2__count",
-				"aggr__0__2__order_1",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank",
+			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__2__parent_count",
+				"aggr__0__2__key_0", "aggr__0__2__count", "aggr__0__2__order_1",
+				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
+				,
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__2__order_1" DESC, "aggr__0__2__key_0" ASC) AS
 				"aggr__0__2__order_1_rank"
 			  FROM (
 				SELECT floor("rspContentLen"/2000.000000)*2000.000000 AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  floor("rspContentLen"/2000.000000)*2000.000000 AS "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__2__parent_count", "message" AS "aggr__0__2__key_0",
 				  count(*) AS "aggr__0__2__count", count() AS "aggr__0__2__order_1"
@@ -6749,7 +6687,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716333600000/600000)),
 				model.NewQueryResultCol("aggr__0__count", 1),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716333600000/600000)),
 				model.NewQueryResultCol("metric__0__1_col_0", 1),
 				model.NewQueryResultCol("metric__0__1_col_1", 7676.0),
 				model.NewQueryResultCol("metric__0__1_col_2", 7676.0),
@@ -6774,7 +6711,6 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716377400000/600000)),
 				model.NewQueryResultCol("aggr__0__count", 8),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716377400000/600000)),
 				model.NewQueryResultCol("metric__0__1_col_0", 8),
 				model.NewQueryResultCol("metric__0__1_col_1", 2426.0),
 				model.NewQueryResultCol("metric__0__1_col_2", 7708.0),
@@ -6843,11 +6779,8 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY toInt64(toUnixTimestamp64Milli("timestamp") / 600000)`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT
-			  toInt64(toUnixTimestamp64Milli("timestamp") / 600000) AS "aggr__0__key_0",
-			  count(*) AS "aggr__0__count",
-			  toInt64(toUnixTimestamp64Milli("timestamp") / 600000) AS "aggr__0__order_1",
-			  count("bytes") AS "metric__0__1_col_0",
+			SELECT toInt64(toUnixTimestamp64Milli("timestamp") / 600000) AS "aggr__0__key_0"
+			  , count(*) AS "aggr__0__count", count("bytes") AS "metric__0__1_col_0",
 			  minOrNull("bytes") AS "metric__0__1_col_1",
 			  maxOrNull("bytes") AS "metric__0__1_col_2",
 			  avgOrNull("bytes") AS "metric__0__1_col_3",
@@ -6870,8 +6803,9 @@ var AggregationTests = []AggregationTestCase{
 			FROM "logs-generic-default"
 			WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-21T21:35:34.210Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-05-22T12:35:34.210Z'))
-			GROUP BY toInt64(toUnixTimestamp64Milli("timestamp") / 600000) AS "aggr__0__key_0"
-			ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC`,
+			GROUP BY toInt64(toUnixTimestamp64Milli("timestamp") / 600000) AS
+			  "aggr__0__key_0"
+			ORDER BY "aggr__0__key_0" ASC`,
 	},
 	{ // [33]
 		TestName: "0 result rows in 2x terms",
@@ -7164,8 +7098,8 @@ var AggregationTests = []AggregationTestCase{
 				"aggr__0__1__order_1" DESC, "aggr__0__1__key_0" ASC) AS
 				"aggr__0__1__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__1__key_0" ORDER
-				BY "aggr__0__1__2__order_1" DESC, "aggr__0__1__2__key_0" ASC) AS
-				"aggr__0__1__2__order_1_rank"
+				BY "aggr__0__1__2__order_1" DESC, "aggr__0__1__key_0" ASC,
+				"aggr__0__1__2__key_0" ASC) AS "aggr__0__1__2__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
@@ -7291,24 +7225,20 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-			  "aggr__0__1__order_1"
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1",
 				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
 				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
-				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  "FlightDelayMin" AS "aggr__0__1__order_1"
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0",
@@ -7434,24 +7364,20 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-			  "aggr__0__1__order_1"
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1",
 				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
 				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
-				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  "FlightDelayMin" AS "aggr__0__1__order_1"
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0",
@@ -7564,24 +7490,20 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-			  "aggr__0__1__order_1"
+			  "aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__order_1", "aggr__0__1__key_0", "aggr__0__1__count",
-				"aggr__0__1__order_1",
 				dense_rank() OVER (ORDER BY "aggr__0__order_1" DESC, "aggr__0__key_0" ASC)
 				AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "host.name" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__order_1",
-				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  "FlightDelayMin" AS "aggr__0__1__order_1"
+				  "FlightDelayMin" AS "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				WHERE ("message" IS NOT NULL AND NOT ("message" iLIKE '%US%'))
 				GROUP BY "host.name" AS "aggr__0__key_0",

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -1809,18 +1809,14 @@ var AggregationTests2 = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1706021670000/30000)),
 				model.NewQueryResultCol("aggr__2__count", 2),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1706021670000/30000)),
 				model.NewQueryResultCol("aggr__2__3__key_0", int64(1706021820000/40000)),
 				model.NewQueryResultCol("aggr__2__3__count", 13),
-				model.NewQueryResultCol("aggr__2__3__order_1", int64(1706021820000/40000)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1706021820000/30000)),
 				model.NewQueryResultCol("aggr__2__count", 13),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1706021820000/30000)),
 				model.NewQueryResultCol("aggr__2__3__key_0", int64(1706021670000/40000)),
 				model.NewQueryResultCol("aggr__2__3__count", 2),
-				model.NewQueryResultCol("aggr__2__3__order_1", int64(1706021670000/40000)),
 			}},
 		},
 		/*
@@ -1845,26 +1841,21 @@ var AggregationTests2 = []AggregationTestCase{
 			},
 		*/
 		ExpectedPancakeSQL: `
-			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-			  "aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1"
+			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+			  "aggr__2__3__count"
 			FROM (
-			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
-				"aggr__2__order_1_rank",
+			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+				"aggr__2__3__count",
+				dense_rank() OVER (ORDER BY "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank"
+				,
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
-				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
-				"aggr__2__3__order_1_rank"
+				"aggr__2__3__key_0" ASC) AS "aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__2__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__2__order_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
-				  "aggr__2__3__key_0", count(*) AS "aggr__2__3__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 40000) AS
-				  "aggr__2__3__order_1"
+				  "aggr__2__3__key_0", count(*) AS "aggr__2__3__count"
 				FROM "logs-generic-default"
 				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__2__key_0",
@@ -2013,18 +2004,14 @@ var AggregationTests2 = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9100.0),
 				model.NewQueryResultCol("aggr__2__count", 1),
-				model.NewQueryResultCol("aggr__2__order_1", 9100.0),
 				model.NewQueryResultCol("aggr__2__3__key_0", 12),
 				model.NewQueryResultCol("aggr__2__3__count", 1),
-				model.NewQueryResultCol("aggr__2__3__order_1", 1),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9700.0),
 				model.NewQueryResultCol("aggr__2__count", 2),
-				model.NewQueryResultCol("aggr__2__order_1", 9700.0),
 				model.NewQueryResultCol("aggr__2__3__key_0", nil),
 				model.NewQueryResultCol("aggr__2__3__count", 1),
-				model.NewQueryResultCol("aggr__2__3__order_1", nil),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2040,23 +2027,20 @@ var AggregationTests2 = []AggregationTestCase{
 				`ORDER BY floor("bytes"/100.000000)*100.000000`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-			  "aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1"
+			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+			  "aggr__2__3__count"
 			FROM (
-			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
-				"aggr__2__order_1_rank",
+			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+				"aggr__2__3__count",
+				dense_rank() OVER (ORDER BY "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank"
+				,
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
-				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
-				"aggr__2__3__order_1_rank"
+				"aggr__2__3__key_0" ASC) AS "aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
-				  floor("bytes"/100.000000)*100.000000 AS "aggr__2__order_1",
 				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0",
-				  count(*) AS "aggr__2__3__count",
-				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1"
+				  count(*) AS "aggr__2__3__count"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T13:47:56.077Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:02:56.077Z'))
@@ -2225,18 +2209,14 @@ var AggregationTests2 = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9100.0),
 				model.NewQueryResultCol("aggr__2__count", 1),
-				model.NewQueryResultCol("aggr__2__order_1", 9100.0),
 				model.NewQueryResultCol("aggr__2__3__key_0", 12),
 				model.NewQueryResultCol("aggr__2__3__count", 1),
-				model.NewQueryResultCol("aggr__2__3__order_1", 1),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 9700.0),
 				model.NewQueryResultCol("aggr__2__count", 2),
-				model.NewQueryResultCol("aggr__2__order_1", 9700.0),
 				model.NewQueryResultCol("aggr__2__3__key_0", nil),
 				model.NewQueryResultCol("aggr__2__3__count", 1),
-				model.NewQueryResultCol("aggr__2__3__order_1", nil),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2252,23 +2232,20 @@ var AggregationTests2 = []AggregationTestCase{
 				`ORDER BY floor("bytes"/100.000000)*100.000000`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-			  "aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1"
+			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+			  "aggr__2__3__count"
 			FROM (
-			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__order_1",
-				"aggr__2__3__key_0", "aggr__2__3__count", "aggr__2__3__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC) AS
-				"aggr__2__order_1_rank",
+			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__key_0",
+				"aggr__2__3__count",
+				dense_rank() OVER (ORDER BY "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank"
+				,
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
-				"aggr__2__3__order_1", "aggr__2__3__key_0" ASC) AS
-				"aggr__2__3__order_1_rank"
+				"aggr__2__3__key_0" ASC) AS "aggr__2__3__order_1_rank"
 			  FROM (
 				SELECT floor("bytes"/100.000000)*100.000000 AS "aggr__2__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
-				  floor("bytes"/100.000000)*100.000000 AS "aggr__2__order_1",
 				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__key_0",
-				  count(*) AS "aggr__2__3__count",
-				  floor("bytes2"/5.000000)*5.000000 AS "aggr__2__3__order_1"
+				  count(*) AS "aggr__2__3__count"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T13:47:56.077Z')
 				  AND "timestamp"<=parseDateTime64BestEffort('2024-05-10T14:02:56.077Z'))

--- a/quesma/testdata/clients/ophelia.go
+++ b/quesma/testdata/clients/ophelia.go
@@ -1963,7 +1963,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 24),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c12"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(24)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c12"),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
@@ -1979,7 +1978,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 21),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c11"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(21)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c11"),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
@@ -1995,7 +1993,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c22"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(17)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c22"),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
@@ -2011,7 +2008,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c21"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(17)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c21"),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -2097,21 +2093,20 @@ var OpheliaTests = []testdata.AggregationTestCase{
 			  "aggr__2__order_1", "metric__2__1_col_0", "aggr__2__8__parent_count",
 			  "aggr__2__8__key_0", "aggr__2__8__count", "aggr__2__8__order_1",
 			  "metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
-			  "aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1"
+			  "aggr__2__8__4__key_0", "aggr__2__8__4__count"
 			FROM (
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
 				"aggr__2__order_1", "metric__2__1_col_0", "aggr__2__8__parent_count",
 				"aggr__2__8__key_0", "aggr__2__8__count", "aggr__2__8__order_1",
 				"metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
-				"aggr__2__8__4__key_0", "aggr__2__8__4__count", "aggr__2__8__4__order_1",
+				"aggr__2__8__4__key_0", "aggr__2__8__4__count",
 				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
 				AS "aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0" ORDER
-				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
-				"aggr__2__8__4__order_1_rank"
+				BY "aggr__2__8__4__key_0" DESC) AS "aggr__2__8__4__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
@@ -2130,8 +2125,7 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				  sumOrNull("total") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
-				  count(*) AS "aggr__2__8__4__count",
-				  "organName" AS "aggr__2__8__4__order_1"
+				  count(*) AS "aggr__2__8__4__count"
 				FROM "logs-generic-default"
 				GROUP BY "surname" AS "aggr__2__key_0",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -2503,7 +2497,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
 				model.NewQueryResultCol("aggr__2__key_0", "a2"),
 				model.NewQueryResultCol("aggr__2__count", uint64(34)),
-				model.NewQueryResultCol("aggr__2__order_1", "a2"),
 				model.NewQueryResultCol("aggr__2__8__parent_count", 34),
 				model.NewQueryResultCol("aggr__2__8__key_0", "b22"),
 				model.NewQueryResultCol("aggr__2__8__count", int64(17)),
@@ -2512,7 +2505,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c22"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(17)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c22"),
 				model.NewQueryResultCol("aggr__2__8__4__5__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__5__key_0", "d22"),
 				model.NewQueryResultCol("aggr__2__8__4__5__count", int64(17)),
@@ -2522,7 +2514,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
 				model.NewQueryResultCol("aggr__2__key_0", "a2"),
 				model.NewQueryResultCol("aggr__2__count", uint64(34)),
-				model.NewQueryResultCol("aggr__2__order_1", "a2"),
 				model.NewQueryResultCol("aggr__2__8__parent_count", 34),
 				model.NewQueryResultCol("aggr__2__8__key_0", "b21"),
 				model.NewQueryResultCol("aggr__2__8__count", int64(17)),
@@ -2531,7 +2522,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c21"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(17)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c21"),
 				model.NewQueryResultCol("aggr__2__8__4__5__parent_count", 17),
 				model.NewQueryResultCol("aggr__2__8__4__5__key_0", "d21"),
 				model.NewQueryResultCol("aggr__2__8__4__5__count", int64(17)),
@@ -2541,7 +2531,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
 				model.NewQueryResultCol("aggr__2__key_0", "a1"),
 				model.NewQueryResultCol("aggr__2__count", uint64(1036)),
-				model.NewQueryResultCol("aggr__2__order_1", "a1"),
 				model.NewQueryResultCol("aggr__2__8__parent_count", 1036),
 				model.NewQueryResultCol("aggr__2__8__key_0", "b12"),
 				model.NewQueryResultCol("aggr__2__8__count", int64(24)),
@@ -2550,7 +2539,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__8__4__parent_count", 24),
 				model.NewQueryResultCol("aggr__2__8__4__key_0", "c12"),
 				model.NewQueryResultCol("aggr__2__8__4__count", int64(24)),
-				model.NewQueryResultCol("aggr__2__8__4__order_1", "c12"),
 				model.NewQueryResultCol("aggr__2__8__4__5__parent_count", 24),
 				model.NewQueryResultCol("aggr__2__8__4__5__key_0", "d12"),
 				model.NewQueryResultCol("aggr__2__8__4__5__count", int64(24)),
@@ -2560,7 +2548,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__parent_count", 34290),
 				model.NewQueryResultCol("aggr__2__key_0", "a1"),
 				model.NewQueryResultCol("aggr__2__count", uint64(1036)),
-				model.NewQueryResultCol("aggr__2__order_1", "a1"),
 				model.NewQueryResultCol("aggr__2__8__parent_count", 1036),
 				model.NewQueryResultCol("aggr__2__8__key_0", "b11"),
 				model.NewQueryResultCol("aggr__2__8__count", int64(21)),
@@ -2674,36 +2661,34 @@ var OpheliaTests = []testdata.AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
-			  "aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
-			  "aggr__2__8__count", "aggr__2__8__order_1", "metric__2__8__1_col_0",
-			  "aggr__2__8__4__parent_count", "aggr__2__8__4__key_0", "aggr__2__8__4__count",
-			  "aggr__2__8__4__order_1", "aggr__2__8__4__5__parent_count",
-			  "aggr__2__8__4__5__key_0", "aggr__2__8__4__5__count",
-			  "aggr__2__8__4__5__order_1"
+			  "aggr__2__8__parent_count", "aggr__2__8__key_0", "aggr__2__8__count",
+			  "aggr__2__8__order_1", "metric__2__8__1_col_0", "aggr__2__8__4__parent_count",
+			  "aggr__2__8__4__key_0", "aggr__2__8__4__count",
+			  "aggr__2__8__4__5__parent_count", "aggr__2__8__4__5__key_0",
+			  "aggr__2__8__4__5__count", "aggr__2__8__4__5__order_1"
 			FROM (
 			  SELECT "aggr__2__parent_count", "aggr__2__key_0", "aggr__2__count",
-				"aggr__2__order_1", "aggr__2__8__parent_count", "aggr__2__8__key_0",
-				"aggr__2__8__count", "aggr__2__8__order_1", "metric__2__8__1_col_0",
+				"aggr__2__8__parent_count", "aggr__2__8__key_0", "aggr__2__8__count",
+				"aggr__2__8__order_1", "metric__2__8__1_col_0",
 				"aggr__2__8__4__parent_count", "aggr__2__8__4__key_0",
-				"aggr__2__8__4__count", "aggr__2__8__4__order_1",
-				"aggr__2__8__4__5__parent_count", "aggr__2__8__4__5__key_0",
-				"aggr__2__8__4__5__count", "aggr__2__8__4__5__order_1",
-				dense_rank() OVER (ORDER BY "aggr__2__order_1" DESC, "aggr__2__key_0" ASC)
-				AS "aggr__2__order_1_rank",
+				"aggr__2__8__4__count", "aggr__2__8__4__5__parent_count",
+				"aggr__2__8__4__5__key_0", "aggr__2__8__4__5__count",
+				"aggr__2__8__4__5__order_1",
+				dense_rank() OVER (ORDER BY "aggr__2__key_0" DESC) AS
+				"aggr__2__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
 				"aggr__2__8__order_1" ASC, "aggr__2__8__key_0" ASC) AS
 				"aggr__2__8__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0" ORDER
-				BY "aggr__2__8__4__order_1" DESC, "aggr__2__8__4__key_0" ASC) AS
-				"aggr__2__8__4__order_1_rank",
+				BY "aggr__2__8__4__key_0" DESC) AS "aggr__2__8__4__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0",
 				"aggr__2__8__4__key_0" ORDER BY "aggr__2__8__4__5__order_1" DESC,
-				"aggr__2__8__4__5__key_0" ASC) AS "aggr__2__8__4__5__order_1_rank"
+				"aggr__2__8__4__key_0" ASC, "aggr__2__8__4__5__key_0" ASC) AS
+				"aggr__2__8__4__5__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__2__parent_count",
 				  "surname" AS "aggr__2__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
-				  "surname" AS "aggr__2__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
 				  "aggr__2__8__parent_count",
 				  COALESCE("limbName", '__missing__') AS "aggr__2__8__key_0",
@@ -2717,7 +2702,6 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0",
 				  "aggr__2__8__4__key_0") AS "aggr__2__8__4__count",
-				  "organName" AS "aggr__2__8__4__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0",
 				  "aggr__2__8__4__key_0") AS "aggr__2__8__4__5__parent_count",
 				  "organName" AS "aggr__2__8__4__5__key_0",

--- a/quesma/testdata/kibana-visualize/aggregation_requests.go
+++ b/quesma/testdata/kibana-visualize/aggregation_requests.go
@@ -223,7 +223,6 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 4),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__1__parent_count", uint64(4)),
 				model.NewQueryResultCol("aggr__0__1__key_0", "artemis"),
 				model.NewQueryResultCol("aggr__0__1__key_1", "error"),
@@ -233,7 +232,6 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 4),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__1__parent_count", uint64(4)),
 				model.NewQueryResultCol("aggr__0__1__key_0", "artemis"),
 				model.NewQueryResultCol("aggr__0__1__key_1", "info"),
@@ -243,7 +241,6 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 4),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716834210000/30000)),
 				model.NewQueryResultCol("aggr__0__1__parent_count", uint64(4)),
 				model.NewQueryResultCol("aggr__0__1__key_0", "jupiter"),
 				model.NewQueryResultCol("aggr__0__1__key_1", "info"),
@@ -253,7 +250,6 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716834270000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 16),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716834270000/30000)),
 				model.NewQueryResultCol("aggr__0__1__parent_count", uint64(15)),
 				model.NewQueryResultCol("aggr__0__1__key_0", "apollo"),
 				model.NewQueryResultCol("aggr__0__1__key_1", "info"),
@@ -263,7 +259,6 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1716834270000/30000)),
 				model.NewQueryResultCol("aggr__0__count", 16),
-				model.NewQueryResultCol("aggr__0__order_1", int64(1716834270000/30000)),
 				model.NewQueryResultCol("aggr__0__1__parent_count", uint64(15)),
 				model.NewQueryResultCol("aggr__0__1__key_0", "cassandra"),
 				model.NewQueryResultCol("aggr__0__1__key_1", "debug"),
@@ -292,24 +287,22 @@ var AggregationTests = []testdata.AggregationTestCase{
 				`ORDER BY toInt64(toUnixTimestamp64Milli("@timestamp") / 30000)`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-			  "aggr__0__1__parent_count", "aggr__0__1__key_0", "aggr__0__1__key_1",
-			  "aggr__0__1__count", "aggr__0__1__order_2"
+			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1__parent_count",
+			  "aggr__0__1__key_0", "aggr__0__1__key_1", "aggr__0__1__count",
+			  "aggr__0__1__order_2"
 			FROM (
-			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__order_1",
-				"aggr__0__1__parent_count", "aggr__0__1__key_0", "aggr__0__1__key_1",
-				"aggr__0__1__count", "aggr__0__1__order_2",
-				dense_rank() OVER (ORDER BY "aggr__0__order_1", "aggr__0__key_0" ASC) AS
-				"aggr__0__order_1_rank",
+			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1__parent_count",
+				"aggr__0__1__key_0", "aggr__0__1__key_1", "aggr__0__1__count",
+				"aggr__0__1__order_2",
+				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
+				,
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0" ORDER BY
 				"aggr__0__1__order_2" DESC, "aggr__0__1__key_0" ASC, "aggr__0__1__key_1" ASC
-				) AS "aggr__0__1__order_2_rank"
+				) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__order_1",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS
 				  "aggr__0__1__parent_count", "severity" AS "aggr__0__1__key_0",
 				  "source" AS "aggr__0__1__key_1", count(*) AS "aggr__0__1__count",
@@ -320,8 +313,8 @@ var AggregationTests = []testdata.AggregationTestCase{
 				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__key_0", "severity" AS "aggr__0__1__key_0",
 				  "source" AS "aggr__0__1__key_1"))
-			WHERE "aggr__0__1__order_2_rank"<=3
-			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_2_rank" ASC`,
+			WHERE "aggr__0__1__order_1_rank"<=3
+			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [1]
 		TestName: "Multi_terms with simple count. Visualize: Bar Vertical: Horizontal Axis: Top values (2 values), Vertical: Count of records, Breakdown: @timestamp",
@@ -522,16 +515,15 @@ var AggregationTests = []testdata.AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 			  "aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
-			  "aggr__0__1__count", "aggr__0__1__order_1"
+			  "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
-				"aggr__0__1__count", "aggr__0__1__order_1",
+				"aggr__0__1__count",
 				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
-				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				"aggr__0__key_1" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "message" AS "aggr__0__key_0", "host.name" AS "aggr__0__key_1",
@@ -540,15 +532,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
 				  "aggr__0__order_2",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1"
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				GROUP BY "message" AS "aggr__0__key_0", "host.name" AS "aggr__0__key_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0"))
-			WHERE "aggr__0__order_2_rank"<=3
-			ORDER BY "aggr__0__order_2_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
+			WHERE "aggr__0__order_1_rank"<=3
+			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ //[2],
 		TestName: "Multi_terms with double-nested subaggregations. Visualize: Bar Vertical: Horizontal Axis: Top values (2 values), Vertical: Unique count, Breakdown: @timestamp",
@@ -839,18 +829,15 @@ var AggregationTests = []testdata.AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 			  "aggr__0__count", "aggr__0__order_2", "metric__0__2_col_0",
-			  "aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-			  "metric__0__1__2_col_0"
+			  "aggr__0__1__key_0", "aggr__0__1__count", "metric__0__1__2_col_0"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "metric__0__2_col_0",
-				"aggr__0__1__key_0", "aggr__0__1__count", "aggr__0__1__order_1",
-				"metric__0__1__2_col_0",
+				"aggr__0__1__key_0", "aggr__0__1__count", "metric__0__1__2_col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
-				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				"aggr__0__key_1" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "severity" AS "aggr__0__key_0", "source" AS "aggr__0__key_1",
@@ -862,14 +849,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 				  "aggr__0__key_1") AS "metric__0__2_col_0",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1", uniq("severity") AS "metric__0__1__2_col_0"
+				  uniq("severity") AS "metric__0__1__2_col_0"
 				FROM "logs-generic-default"
 				GROUP BY "severity" AS "aggr__0__key_0", "source" AS "aggr__0__key_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0"))
-			WHERE "aggr__0__order_2_rank"<=3
-			ORDER BY "aggr__0__order_2_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
+			WHERE "aggr__0__order_1_rank"<=3
+			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 	{ // [3]
 		TestName: "Quite simple multi_terms, but with non-string keys. Visualize: Bar Vertical: Horizontal Axis: Date Histogram, Vertical Axis: Count of records, Breakdown: Top values (2 values)",
@@ -1100,16 +1086,15 @@ var AggregationTests = []testdata.AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 			  "aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
-			  "aggr__0__1__count", "aggr__0__1__order_1"
+			  "aggr__0__1__count"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__key_1",
 				"aggr__0__count", "aggr__0__order_2", "aggr__0__1__key_0",
-				"aggr__0__1__count", "aggr__0__1__order_1",
+				"aggr__0__1__count",
 				dense_rank() OVER (ORDER BY "aggr__0__order_2" DESC, "aggr__0__key_0" ASC,
-				"aggr__0__key_1" ASC) AS "aggr__0__order_2_rank",
+				"aggr__0__key_1" ASC) AS "aggr__0__order_1_rank",
 				dense_rank() OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1" ORDER BY
-				"aggr__0__1__order_1", "aggr__0__1__key_0" ASC) AS
-				"aggr__0__1__order_1_rank"
+				"aggr__0__1__key_0" ASC) AS "aggr__0__1__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "Cancelled" AS "aggr__0__key_0", "AvgTicketPrice" AS "aggr__0__key_1",
@@ -1118,15 +1103,13 @@ var AggregationTests = []testdata.AggregationTestCase{
 				  sum(count()) OVER (PARTITION BY "aggr__0__key_0", "aggr__0__key_1") AS
 				  "aggr__0__order_2",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count",
-				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
-				  "aggr__0__1__order_1"
+				  "aggr__0__1__key_0", count(*) AS "aggr__0__1__count"
 				FROM "logs-generic-default"
 				GROUP BY "Cancelled" AS "aggr__0__key_0",
 				  "AvgTicketPrice" AS "aggr__0__key_1",
 				  toInt64(toUnixTimestamp64Milli("@timestamp") / 30000) AS
 				  "aggr__0__1__key_0"))
-			WHERE "aggr__0__order_2_rank"<=3
-			ORDER BY "aggr__0__order_2_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
+			WHERE "aggr__0__order_1_rank"<=3
+			ORDER BY "aggr__0__order_1_rank" ASC, "aggr__0__1__order_1_rank" ASC`,
 	},
 }

--- a/quesma/testdata/opensearch-visualize/aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/aggregation_requests.go
@@ -1422,14 +1422,12 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1714860000000/3600000)),
 				model.NewQueryResultCol("aggr__2__count", 9),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1714860000000/3600000)),
 				model.NewQueryResultCol("metric__2__1_col_0", 0.0),
 				model.NewQueryResultCol("metric__2__1_col_1", 100.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1714863600000/3600000)),
 				model.NewQueryResultCol("aggr__2__count", 12),
-				model.NewQueryResultCol("aggr__2__order_1", int64(1714863600000/3600000)),
 				model.NewQueryResultCol("metric__2__1_col_0", 0.0),
 				model.NewQueryResultCol("metric__2__1_col_1", 50.0),
 			}},
@@ -1448,14 +1446,14 @@ var AggregationTests = []testdata.AggregationTestCase{
 				`ORDER BY toInt64(toUnixTimestamp64Milli("timestamp") / 3600000)`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT toInt64(toUnixTimestamp64Milli("timestamp") / 3600000) AS "aggr__2__key_0",
-			  count(*) AS "aggr__2__count",
-			  toInt64(toUnixTimestamp64Milli("timestamp") / 3600000) AS "aggr__2__order_1",
+			SELECT toInt64(toUnixTimestamp64Milli("timestamp") / 3600000) AS
+			  "aggr__2__key_0", count(*) AS "aggr__2__count",
 			  countIf("AvgTicketPrice"<=0.000000)/count(*)*100 AS "metric__2__1_col_0",
 			  countIf("AvgTicketPrice"<=50000.000000)/count(*)*100 AS "metric__2__1_col_1"
 			FROM "logs-generic-default"
-			GROUP BY toInt64(toUnixTimestamp64Milli("timestamp") / 3600000) AS "aggr__2__key_0"
-			ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC`,
+			GROUP BY toInt64(toUnixTimestamp64Milli("timestamp") / 3600000) AS
+			  "aggr__2__key_0"
+			ORDER BY "aggr__2__key_0" ASC`,
 	},
 	{ // [8]
 		TestName: "Min/max with simple script. Reproduce: Visualize -> Line -> Metrics: Count, Buckets: X-Asis Histogram",
@@ -1678,17 +1676,14 @@ var AggregationTests = []testdata.AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 0.0),
 				model.NewQueryResultCol("aggr__2__count", 44),
-				model.NewQueryResultCol("aggr__2__order_1", 0.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 1.0),
 				model.NewQueryResultCol("aggr__2__count", 43),
-				model.NewQueryResultCol("aggr__2__order_1", 1.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", 2.0),
 				model.NewQueryResultCol("aggr__2__count", 34),
-				model.NewQueryResultCol("aggr__2__order_1", 2.0),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -1698,10 +1693,9 @@ var AggregationTests = []testdata.AggregationTestCase{
 				`ORDER BY toHour("timestamp")`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT toHour("timestamp") AS "aggr__2__key_0", count(*) AS "aggr__2__count",
-			  toHour("timestamp") AS "aggr__2__order_1"
+			SELECT toHour("timestamp") AS "aggr__2__key_0", count(*) AS "aggr__2__count"
 			FROM "logs-generic-default"
 			GROUP BY toHour("timestamp") AS "aggr__2__key_0"
-			ORDER BY "aggr__2__order_1", "aggr__2__key_0" ASC`,
+			ORDER BY "aggr__2__key_0" ASC`,
 	},
 }


### PR DESCRIPTION
I simplified the order by implementing it in the first revision of the pancakes. It ignored all but the first order and added its own for dense_rank.

Now:
- We generate all order by's. We need that for correctness.
- We no longer generate order columns if they were part of the key (e.g. `date_histogram`).
- We deduplicate sort.
- We also replaced `Exprs []model.Expr` with `Expr model.Expr` previously we never used it and this was a trap.

This make SQL shorter and more performant. It turn out I had to implement that optimization to make queries correct.