### PR TITLE
Add "get mapping" endpoints (GET /:index, /:index/_mapping)

### DIFF
--- a/quesma/elasticsearch/mappings.go
+++ b/quesma/elasticsearch/mappings.go
@@ -3,9 +3,9 @@
 package elasticsearch
 
 import (
-	"github.com/rs/zerolog/log"
 	"maps"
 	"quesma/elasticsearch/elasticsearch_field_types"
+	"quesma/logger"
 	"quesma/schema"
 )
 
@@ -14,7 +14,7 @@ func ParseMappings(namespace string, mappings map[string]interface{}) map[string
 
 	properties, found := mappings["properties"]
 	if !found {
-		log.Warn().Msgf("No 'properties' found in the mapping. The mapping was: %v", mappings)
+		logger.Warn().Msgf("No 'properties' found in the mapping. The mapping was: %v", mappings)
 		return result
 	}
 
@@ -29,23 +29,41 @@ func ParseMappings(namespace string, mappings map[string]interface{}) map[string
 		}
 
 		if typeMapping := fieldMappingAsMap["type"]; typeMapping != nil {
-			parsedType, _ := parseElasticType(typeMapping.(string))
+			parsedType, _ := ParseElasticType(typeMapping.(string))
 			if parsedType.Name == schema.TypeUnknown.Name {
-				log.Warn().Msgf("unknown type '%v' of field %s", typeMapping, fieldName)
+				logger.Warn().Msgf("unknown type '%v' of field %s", typeMapping, fieldName)
 			}
 			result[fieldName] = schema.Column{Name: fieldName, Type: parsedType.Name}
 		} else if fieldMappingAsMap["properties"] != nil {
 			// Nested field
 			maps.Copy(result, ParseMappings(fieldName, fieldMappingAsMap))
 		} else {
-			log.Warn().Msgf("Unsupported type of field %s. Skipping the field. Full mapping: %v", fieldName, fieldMapping)
+			logger.Warn().Msgf("Unsupported type of field %s. Skipping the field. Full mapping: %v", fieldName, fieldMapping)
 		}
 	}
 	return result
 }
 
+func GenerateMappings(schemaNode *schema.SchemaTreeNode) map[string]any {
+	if schemaNode.Field != nil {
+		result := map[string]any{"type": schemaTypeToElasticType(schemaNode.Field.Type)}
+		if schemaNode.Field.Type.Name == schema.TypeText.Name {
+			result["fields"] = map[string]any{
+				"keyword": map[string]any{"type": "keyword"},
+			}
+		}
+		return result
+	} else {
+		result := make(map[string]any)
+		for _, child := range schemaNode.Children {
+			result[child.Name] = GenerateMappings(child)
+		}
+		return map[string]any{"properties": result}
+	}
+}
+
 // FIXME: should be in elasticsearch_field_types, but this causes import cycle
-func parseElasticType(t string) (schema.Type, bool) {
+func ParseElasticType(t string) (schema.Type, bool) {
 	switch t {
 	case elasticsearch_field_types.FieldTypeText:
 		return schema.TypeText, true
@@ -65,5 +83,37 @@ func parseElasticType(t string) (schema.Type, bool) {
 		return schema.TypePoint, true
 	default:
 		return schema.TypeUnknown, false
+	}
+}
+
+func schemaTypeToElasticType(t schema.Type) string {
+	switch t.Name {
+	case schema.TypeText.Name:
+		return elasticsearch_field_types.FieldTypeText
+	case schema.TypeKeyword.Name:
+		return elasticsearch_field_types.FieldTypeKeyword
+	case schema.TypeInteger.Name:
+		return elasticsearch_field_types.FieldTypeInteger
+	case schema.TypeLong.Name:
+		return elasticsearch_field_types.FieldTypeLong
+	case schema.TypeUnsignedLong.Name:
+		return elasticsearch_field_types.FieldTypeUnsignedLong
+	case schema.TypeTimestamp.Name:
+		return elasticsearch_field_types.FieldTypeDate
+	case schema.TypeDate.Name:
+		return elasticsearch_field_types.FieldTypeDate
+	case schema.TypeFloat.Name:
+		return elasticsearch_field_types.FieldTypeDouble
+	case schema.TypeBoolean.Name:
+		return elasticsearch_field_types.FieldTypeBoolean
+	case schema.TypeObject.Name:
+		return elasticsearch_field_types.FieldTypeObject
+	case schema.TypeIp.Name:
+		return elasticsearch_field_types.FieldTypeIp
+	case schema.TypePoint.Name:
+		return elasticsearch_field_types.FieldTypeGeoPoint
+	default:
+		logger.Error().Msgf("Unknown type '%s', defaulting to 'text' type", t.Name)
+		return elasticsearch_field_types.FieldTypeText
 	}
 }

--- a/quesma/quesma/mappings_test.go
+++ b/quesma/quesma/mappings_test.go
@@ -3,12 +3,109 @@
 package quesma
 
 import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"quesma/elasticsearch"
 	"quesma/quesma/types"
 	"quesma/schema"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+var (
+	kibanaSampleFlightsFields = map[string]schema.Column{
+		"AvgTicketPrice":     {Name: "AvgTicketPrice", Type: "float"},
+		"Cancelled":          {Name: "Cancelled", Type: "boolean"},
+		"Carrier":            {Name: "Carrier", Type: "keyword"},
+		"Dest":               {Name: "Dest", Type: "keyword"},
+		"DestAirportID":      {Name: "DestAirportID", Type: "keyword"},
+		"DestCityName":       {Name: "DestCityName", Type: "keyword"},
+		"DestCountry":        {Name: "DestCountry", Type: "keyword"},
+		"DestLocation":       {Name: "DestLocation", Type: "point"},
+		"DestRegion":         {Name: "DestRegion", Type: "keyword"},
+		"DestWeather":        {Name: "DestWeather", Type: "keyword"},
+		"DistanceKilometers": {Name: "DistanceKilometers", Type: "float"},
+		"DistanceMiles":      {Name: "DistanceMiles", Type: "float"},
+		"FlightDelay":        {Name: "FlightDelay", Type: "boolean"},
+		"FlightDelayMin":     {Name: "FlightDelayMin", Type: "long"},
+		"FlightDelayType":    {Name: "FlightDelayType", Type: "keyword"},
+		"FlightNum":          {Name: "FlightNum", Type: "keyword"},
+		"FlightTimeHour":     {Name: "FlightTimeHour", Type: "keyword"},
+		"FlightTimeMin":      {Name: "FlightTimeMin", Type: "float"},
+		"Origin":             {Name: "Origin", Type: "keyword"},
+		"OriginAirportID":    {Name: "OriginAirportID", Type: "keyword"},
+		"OriginCityName":     {Name: "OriginCityName", Type: "keyword"},
+		"OriginCountry":      {Name: "OriginCountry", Type: "keyword"},
+		"OriginLocation":     {Name: "OriginLocation", Type: "point"},
+		"OriginRegion":       {Name: "OriginRegion", Type: "keyword"},
+		"OriginWeather":      {Name: "OriginWeather", Type: "keyword"},
+		"dayOfWeek":          {Name: "dayOfWeek", Type: "long"},
+		"timestamp":          {Name: "timestamp", Type: "timestamp"},
+	}
+	kibanaSampleEcommerceFields = map[string]schema.Column{
+		"category":                      {Name: "category", Type: "text"},
+		"currency":                      {Name: "currency", Type: "keyword"},
+		"customer_birth_date":           {Name: "customer_birth_date", Type: "timestamp"},
+		"customer_first_name":           {Name: "customer_first_name", Type: "text"},
+		"customer_full_name":            {Name: "customer_full_name", Type: "text"},
+		"customer_gender":               {Name: "customer_gender", Type: "keyword"},
+		"customer_id":                   {Name: "customer_id", Type: "keyword"},
+		"customer_last_name":            {Name: "customer_last_name", Type: "text"},
+		"customer_phone":                {Name: "customer_phone", Type: "keyword"},
+		"day_of_week":                   {Name: "day_of_week", Type: "keyword"},
+		"day_of_week_i":                 {Name: "day_of_week_i", Type: "long"},
+		"email":                         {Name: "email", Type: "keyword"},
+		"event.dataset":                 {Name: "event.dataset", Type: "keyword"},
+		"geoip.city_name":               {Name: "geoip.city_name", Type: "keyword"},
+		"geoip.continent_name":          {Name: "geoip.continent_name", Type: "keyword"},
+		"geoip.country_iso_code":        {Name: "geoip.country_iso_code", Type: "keyword"},
+		"geoip.location":                {Name: "geoip.location", Type: "point"},
+		"geoip.region_name":             {Name: "geoip.region_name", Type: "keyword"},
+		"manufacturer":                  {Name: "manufacturer", Type: "text"},
+		"order_date":                    {Name: "order_date", Type: "timestamp"},
+		"order_id":                      {Name: "order_id", Type: "keyword"},
+		"products._id":                  {Name: "products._id", Type: "text"},
+		"products.base_price":           {Name: "products.base_price", Type: "float"},
+		"products.base_unit_price":      {Name: "products.base_unit_price", Type: "float"},
+		"products.category":             {Name: "products.category", Type: "text"},
+		"products.created_on":           {Name: "products.created_on", Type: "timestamp"},
+		"products.discount_amount":      {Name: "products.discount_amount", Type: "float"},
+		"products.discount_percentage":  {Name: "products.discount_percentage", Type: "float"},
+		"products.manufacturer":         {Name: "products.manufacturer", Type: "text"},
+		"products.min_price":            {Name: "products.min_price", Type: "float"},
+		"products.price":                {Name: "products.price", Type: "float"},
+		"products.product_id":           {Name: "products.product_id", Type: "long"},
+		"products.product_name":         {Name: "products.product_name", Type: "text"},
+		"products.quantity":             {Name: "products.quantity", Type: "long"},
+		"products.sku":                  {Name: "products.sku", Type: "keyword"},
+		"products.tax_amount":           {Name: "products.tax_amount", Type: "float"},
+		"products.taxful_price":         {Name: "products.taxful_price", Type: "float"},
+		"products.taxless_price":        {Name: "products.taxless_price", Type: "float"},
+		"products.unit_discount_amount": {Name: "products.unit_discount_amount", Type: "float"},
+		"sku":                           {Name: "sku", Type: "keyword"},
+		"taxful_total_price":            {Name: "taxful_total_price", Type: "float"},
+		"taxless_total_price":           {Name: "taxless_total_price", Type: "float"},
+		"total_quantity":                {Name: "total_quantity", Type: "long"},
+		"total_unique_products":         {Name: "total_unique_products", Type: "long"},
+		"type":                          {Name: "type", Type: "keyword"},
+		"user":                          {Name: "user", Type: "keyword"},
+	}
+)
+
+func newSchemaFromColumns(fields map[string]schema.Column) schema.Schema {
+	schemaFields := make(map[schema.FieldName]schema.Field)
+	for name, column := range fields {
+		parsedType, _ := schema.ParseQuesmaType(column.Type)
+		schemaFields[schema.FieldName(name)] = schema.Field{
+			PropertyName:         schema.FieldName(name),
+			InternalPropertyName: schema.FieldName(strings.Replace(name, ".", "::", -1)),
+			Type:                 parsedType,
+		}
+	}
+	return schema.NewSchema(schemaFields, true)
+}
 
 func TestParseMappings_KibanaSampleFlights(t *testing.T) {
 	json := `{"properties": {
@@ -94,41 +191,104 @@ func TestParseMappings_KibanaSampleFlights(t *testing.T) {
 			"type": "date"
 		}
 	}}`
-	expectedMappings := map[string]schema.Column{
-		"AvgTicketPrice":     {Name: "AvgTicketPrice", Type: "float"},
-		"Cancelled":          {Name: "Cancelled", Type: "boolean"},
-		"Carrier":            {Name: "Carrier", Type: "keyword"},
-		"Dest":               {Name: "Dest", Type: "keyword"},
-		"DestAirportID":      {Name: "DestAirportID", Type: "keyword"},
-		"DestCityName":       {Name: "DestCityName", Type: "keyword"},
-		"DestCountry":        {Name: "DestCountry", Type: "keyword"},
-		"DestLocation":       {Name: "DestLocation", Type: "point"},
-		"DestRegion":         {Name: "DestRegion", Type: "keyword"},
-		"DestWeather":        {Name: "DestWeather", Type: "keyword"},
-		"DistanceKilometers": {Name: "DistanceKilometers", Type: "float"},
-		"DistanceMiles":      {Name: "DistanceMiles", Type: "float"},
-		"FlightDelay":        {Name: "FlightDelay", Type: "boolean"},
-		"FlightDelayMin":     {Name: "FlightDelayMin", Type: "long"},
-		"FlightDelayType":    {Name: "FlightDelayType", Type: "keyword"},
-		"FlightNum":          {Name: "FlightNum", Type: "keyword"},
-		"FlightTimeHour":     {Name: "FlightTimeHour", Type: "keyword"},
-		"FlightTimeMin":      {Name: "FlightTimeMin", Type: "float"},
-		"Origin":             {Name: "Origin", Type: "keyword"},
-		"OriginAirportID":    {Name: "OriginAirportID", Type: "keyword"},
-		"OriginCityName":     {Name: "OriginCityName", Type: "keyword"},
-		"OriginCountry":      {Name: "OriginCountry", Type: "keyword"},
-		"OriginLocation":     {Name: "OriginLocation", Type: "point"},
-		"OriginRegion":       {Name: "OriginRegion", Type: "keyword"},
-		"OriginWeather":      {Name: "OriginWeather", Type: "keyword"},
-		"dayOfWeek":          {Name: "dayOfWeek", Type: "long"},
-		"timestamp":          {Name: "timestamp", Type: "timestamp"},
-	}
 	parsedJson, _ := types.ParseJSON(json)
 	mappings := elasticsearch.ParseMappings("", parsedJson)
 
-	if !reflect.DeepEqual(mappings, expectedMappings) {
-		t.Errorf("ParseMappings() got = %v, want %v", mappings, expectedMappings)
+	if !reflect.DeepEqual(mappings, kibanaSampleFlightsFields) {
+		t.Errorf("ParseMappings() got = %v, want %v", mappings, kibanaSampleFlightsFields)
 	}
+}
+
+func TestGenerateMappings_KibanaSampleFlights(t *testing.T) {
+	expectedJson := `{"properties": {
+		"AvgTicketPrice": {
+			"type": "double"
+		},
+		"Cancelled": {
+			"type": "boolean"
+		},
+		"Carrier": {
+			"type": "keyword"
+		},
+		"Dest": {
+			"type": "keyword"
+		},
+		"DestAirportID": {
+			"type": "keyword"
+		},
+		"DestCityName": {
+			"type": "keyword"
+		},
+		"DestCountry": {
+			"type": "keyword"
+		},
+		"DestLocation": {
+			"type": "geo_point"
+		},
+		"DestRegion": {
+			"type": "keyword"
+		},
+		"DestWeather": {
+			"type": "keyword"
+		},
+		"DistanceKilometers": {
+			"type": "double"
+		},
+		"DistanceMiles": {
+			"type": "double"
+		},
+		"FlightDelay": {
+			"type": "boolean"
+		},
+		"FlightDelayMin": {
+			"type": "long"
+		},
+		"FlightDelayType": {
+			"type": "keyword"
+		},
+		"FlightNum": {
+			"type": "keyword"
+		},
+		"FlightTimeHour": {
+			"type": "keyword"
+		},
+		"FlightTimeMin": {
+			"type": "double"
+		},
+		"Origin": {
+			"type": "keyword"
+		},
+		"OriginAirportID": {
+			"type": "keyword"
+		},
+		"OriginCityName": {
+			"type": "keyword"
+		},
+		"OriginCountry": {
+			"type": "keyword"
+		},
+		"OriginLocation": {
+			"type": "geo_point"
+		},
+		"OriginRegion": {
+			"type": "keyword"
+		},
+		"OriginWeather": {
+			"type": "keyword"
+		},
+		"dayOfWeek": {
+			"type": "long"
+		},
+		"timestamp": {
+			"type": "date"
+		}
+	}}`
+	s := newSchemaFromColumns(kibanaSampleFlightsFields)
+	mappings := elasticsearch.GenerateMappings(schema.SchemaToHierarchicalSchema(&s))
+
+	marshaled, err := json.Marshal(mappings)
+	assert.Nil(t, err)
+	require.JSONEq(t, expectedJson, string(marshaled))
 }
 
 func TestParseMappings_KibanaSampleEcommerce(t *testing.T) {
@@ -162,7 +322,8 @@ func TestParseMappings_KibanaSampleEcommerce(t *testing.T) {
 					"ignore_above": 256,
 					"type": "keyword"
 				}
-			},                "type": "text"
+			},                
+			"type": "text"
 		},
 		"customer_gender": {
 			"type": "keyword"
@@ -333,58 +494,216 @@ func TestParseMappings_KibanaSampleEcommerce(t *testing.T) {
 			"type": "keyword"
 		}
 	}}`
-	expectedMappings := map[string]schema.Column{
-		"category":                      {Name: "category", Type: "text"},
-		"currency":                      {Name: "currency", Type: "keyword"},
-		"customer_birth_date":           {Name: "customer_birth_date", Type: "timestamp"},
-		"customer_first_name":           {Name: "customer_first_name", Type: "text"},
-		"customer_full_name":            {Name: "customer_full_name", Type: "text"},
-		"customer_gender":               {Name: "customer_gender", Type: "keyword"},
-		"customer_id":                   {Name: "customer_id", Type: "keyword"},
-		"customer_last_name":            {Name: "customer_last_name", Type: "text"},
-		"customer_phone":                {Name: "customer_phone", Type: "keyword"},
-		"day_of_week":                   {Name: "day_of_week", Type: "keyword"},
-		"day_of_week_i":                 {Name: "day_of_week_i", Type: "long"},
-		"email":                         {Name: "email", Type: "keyword"},
-		"event.dataset":                 {Name: "event.dataset", Type: "keyword"},
-		"geoip.city_name":               {Name: "geoip.city_name", Type: "keyword"},
-		"geoip.continent_name":          {Name: "geoip.continent_name", Type: "keyword"},
-		"geoip.country_iso_code":        {Name: "geoip.country_iso_code", Type: "keyword"},
-		"geoip.location":                {Name: "geoip.location", Type: "point"},
-		"geoip.region_name":             {Name: "geoip.region_name", Type: "keyword"},
-		"manufacturer":                  {Name: "manufacturer", Type: "text"},
-		"order_date":                    {Name: "order_date", Type: "timestamp"},
-		"order_id":                      {Name: "order_id", Type: "keyword"},
-		"products._id":                  {Name: "products._id", Type: "text"},
-		"products.base_price":           {Name: "products.base_price", Type: "float"},
-		"products.base_unit_price":      {Name: "products.base_unit_price", Type: "float"},
-		"products.category":             {Name: "products.category", Type: "text"},
-		"products.created_on":           {Name: "products.created_on", Type: "timestamp"},
-		"products.discount_amount":      {Name: "products.discount_amount", Type: "float"},
-		"products.discount_percentage":  {Name: "products.discount_percentage", Type: "float"},
-		"products.manufacturer":         {Name: "products.manufacturer", Type: "text"},
-		"products.min_price":            {Name: "products.min_price", Type: "float"},
-		"products.price":                {Name: "products.price", Type: "float"},
-		"products.product_id":           {Name: "products.product_id", Type: "long"},
-		"products.product_name":         {Name: "products.product_name", Type: "text"},
-		"products.quantity":             {Name: "products.quantity", Type: "long"},
-		"products.sku":                  {Name: "products.sku", Type: "keyword"},
-		"products.tax_amount":           {Name: "products.tax_amount", Type: "float"},
-		"products.taxful_price":         {Name: "products.taxful_price", Type: "float"},
-		"products.taxless_price":        {Name: "products.taxless_price", Type: "float"},
-		"products.unit_discount_amount": {Name: "products.unit_discount_amount", Type: "float"},
-		"sku":                           {Name: "sku", Type: "keyword"},
-		"taxful_total_price":            {Name: "taxful_total_price", Type: "float"},
-		"taxless_total_price":           {Name: "taxless_total_price", Type: "float"},
-		"total_quantity":                {Name: "total_quantity", Type: "long"},
-		"total_unique_products":         {Name: "total_unique_products", Type: "long"},
-		"type":                          {Name: "type", Type: "keyword"},
-		"user":                          {Name: "user", Type: "keyword"},
-	}
 	parsedJson, _ := types.ParseJSON(json)
 	mappings := elasticsearch.ParseMappings("", parsedJson)
 
-	if !reflect.DeepEqual(mappings, expectedMappings) {
-		t.Errorf("ParseMappings() got = %v, want %v", mappings, expectedMappings)
+	if !reflect.DeepEqual(mappings, kibanaSampleEcommerceFields) {
+		t.Errorf("ParseMappings() got = %v, want %v", mappings, kibanaSampleEcommerceFields)
 	}
+}
+
+func TestGenerateMappings_KibanaSampleEcommerce(t *testing.T) {
+	expectedJson := `{"properties": {
+		"category": {
+			"fields": {
+				"keyword": {
+					"type": "keyword"
+				}
+			},
+			"type": "text"
+		},
+		"currency": {
+			"type": "keyword"
+		},
+		"customer_birth_date": {
+			"type": "date"
+		},
+		"customer_first_name": {
+			"fields": {
+				"keyword": {
+					"type": "keyword"
+				}
+			},
+			"type": "text"
+		},
+		"customer_full_name": {
+			"fields": {
+				"keyword": {
+					"type": "keyword"
+				}
+			},                
+			"type": "text"
+		},
+		"customer_gender": {
+			"type": "keyword"
+		},
+		"customer_id": {
+			"type": "keyword"
+		},
+		"customer_last_name": {
+			"fields": {
+				"keyword": {
+					"type": "keyword"
+				}
+			},
+			"type": "text"
+		},
+		"customer_phone": {
+			"type": "keyword"
+		},
+		"day_of_week": {
+			"type": "keyword"
+		},
+		"day_of_week_i": {
+			"type": "long"
+		},
+		"email": {
+			"type": "keyword"
+		},
+		"event": {
+			"properties": {
+				"dataset": {
+					"type": "keyword"
+				}
+			}
+		},
+		"geoip": {
+			"properties": {
+				"city_name": {
+					"type": "keyword"
+				},
+				"continent_name": {
+					"type": "keyword"
+				},
+				"country_iso_code": {
+					"type": "keyword"
+				},
+				"location": {
+					"type": "geo_point"
+				},
+				"region_name": {
+					"type": "keyword"
+				}
+			}
+		},
+		"manufacturer": {
+			"fields": {
+				"keyword": {
+					"type": "keyword"
+				}
+			},
+			"type": "text"
+		},
+		"order_date": {
+			"type": "date"
+		},
+		"order_id": {
+			"type": "keyword"
+		},
+		"products": {
+			"properties": {
+				"_id": {
+					"fields": {
+						"keyword": {
+							"type": "keyword"
+						}
+					},
+					"type": "text"
+				},
+				"base_price": {
+					"type": "double"
+				},
+				"base_unit_price": {
+					"type": "double"
+				},
+				"category": {
+					"fields": {
+						"keyword": {
+							"type": "keyword"
+						}
+					},
+					"type": "text"
+				},
+				"created_on": {
+					"type": "date"
+				},
+				"discount_amount": {
+					"type": "double"
+				},
+				"discount_percentage": {
+					"type": "double"
+				},
+				"manufacturer": {
+					"fields": {
+						"keyword": {
+							"type": "keyword"
+						}
+					},
+					"type": "text"
+				},
+				"min_price": {
+					"type": "double"
+				},
+				"price": {
+					"type": "double"
+				},
+				"product_id": {
+					"type": "long"
+				},
+				"product_name": {
+					"fields": {
+						"keyword": {
+							"type": "keyword"
+						}
+					},
+					"type": "text"
+				},
+				"quantity": {
+					"type": "long"
+				},
+				"sku": {
+					"type": "keyword"
+				},
+				"tax_amount": {
+					"type": "double"
+				},
+				"taxful_price": {
+					"type": "double"
+				},
+				"taxless_price": {
+					"type": "double"
+				},
+				"unit_discount_amount": {
+					"type": "double"
+				}
+			}
+		},
+		"sku": {
+			"type": "keyword"
+		},
+		"taxful_total_price": {
+			"type": "double"
+		},
+		"taxless_total_price": {
+			"type": "double"
+		},
+		"total_quantity": {
+			"type": "long"
+		},
+		"total_unique_products": {
+			"type": "long"
+		},
+		"type": {
+			"type": "keyword"
+		},
+		"user": {
+			"type": "keyword"
+		}
+	}}`
+	s := newSchemaFromColumns(kibanaSampleEcommerceFields)
+	mappings := elasticsearch.GenerateMappings(schema.SchemaToHierarchicalSchema(&s))
+
+	marshaled, err := json.Marshal(mappings)
+	assert.Nil(t, err)
+	require.JSONEq(t, expectedJson, string(marshaled))
 }

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -49,7 +49,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		}
 
 		results, err := bulk.Write(ctx, nil, body, lm, cfg, phoneHomeAgent)
-		return bulkInsertResult(results, err), nil
+		return bulkInsertResult(results, err)
 	})
 
 	router.Register(routes.IndexRefreshPath, and(method("POST"), matchedExact(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -64,7 +64,11 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		}
 
 		err = doc.Write(ctx, req.Params["index"], body, lm, cfg)
-		return indexDocResult(req.Params["index"], http.StatusOK), err
+		if err != nil {
+			return nil, err
+		}
+
+		return indexDocResult(req.Params["index"], http.StatusOK)
 	})
 
 	router.Register(routes.IndexBulkPath, and(method("POST", "PUT"), matchedExact(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -76,7 +80,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		}
 
 		results, err := bulk.Write(ctx, &index, body, lm, cfg, phoneHomeAgent)
-		return bulkInsertResult(results, err), nil
+		return bulkInsertResult(results, err)
 	})
 
 	router.Register(routes.ResolveIndexPath, method("GET"), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -84,7 +88,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		if err != nil {
 			return nil, err
 		}
-		return resolveIndexResult(sources), nil
+		return resolveIndexResult(sources)
 	})
 
 	router.Register(routes.IndexCountPath, and(method("GET"), matchedAgainstPattern(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -100,7 +104,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		if cnt == -1 {
 			return &mux.Result{StatusCode: http.StatusNotFound}, nil
 		} else {
-			return elasticsearchCountResult(cnt, http.StatusOK), nil
+			return elasticsearchCountResult(cnt, http.StatusOK)
 		}
 	})
 
@@ -197,7 +201,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 
 		sr.UpdateDynamicConfiguration(schema.TableName(index), schema.Table{Columns: columns})
 
-		return putIndexResult(index), nil
+		return putIndexResult(index)
 	})
 
 	router.Register(routes.IndexMappingPath, and(method("GET"), matchedAgainstPattern(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -211,7 +215,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		hierarchicalSchema := schema.SchemaToHierarchicalSchema(&foundSchema)
 		mappings := elasticsearch.GenerateMappings(hierarchicalSchema)
 
-		return getIndexMappingResult(index, mappings), nil
+		return getIndexMappingResult(index, mappings)
 	})
 
 	router.Register(routes.AsyncSearchIdPath, and(method("GET"), matchedAgainstAsyncId()), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -295,13 +299,13 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		mappings, ok := body["mappings"]
 		if !ok {
 			logger.Warn().Msgf("no mappings found in PUT /%s request, ignoring that request. Full content: %s", index, req.Body)
-			return putIndexResult(index), nil
+			return putIndexResult(index)
 		}
 		columns := elasticsearch.ParseMappings("", mappings.(map[string]interface{}))
 
 		sr.UpdateDynamicConfiguration(schema.TableName(index), schema.Table{Columns: columns})
 
-		return putIndexResult(index), nil
+		return putIndexResult(index)
 	})
 
 	router.Register(routes.IndexPath, and(method("GET"), matchedAgainstPattern(cfg)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
@@ -315,7 +319,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 		hierarchicalSchema := schema.SchemaToHierarchicalSchema(&foundSchema)
 		mappings := elasticsearch.GenerateMappings(hierarchicalSchema)
 
-		return getIndexResult(index, mappings), nil
+		return getIndexResult(index, mappings)
 	})
 
 	return router
@@ -333,7 +337,7 @@ func matchedExact(config config.QuesmaConfiguration) mux.RequestMatcher {
 	})
 }
 
-func elasticsearchCountResult(body int64, statusCode int) *mux.Result {
+func elasticsearchCountResult(body int64, statusCode int) (*mux.Result, error) {
 	var result = countResult{
 		Shards: struct {
 			Failed     int `json:"failed"`
@@ -350,12 +354,12 @@ func elasticsearchCountResult(body int64, statusCode int) *mux.Result {
 	}
 	serialized, err := json.Marshal(result)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	return &mux.Result{Body: string(serialized), Meta: map[string]string{
 		"Content-Type":            "application/json",
 		"X-Quesma-Headers-Source": "Quesma",
-	}, StatusCode: statusCode}
+	}, StatusCode: statusCode}, nil
 }
 
 type countResult struct {
@@ -375,12 +379,12 @@ func elasticsearchQueryResult(body string, statusCode int) *mux.Result {
 	}, StatusCode: statusCode}
 }
 
-func bulkInsertResult(ops []bulk.BulkItem, err error) *mux.Result {
+func bulkInsertResult(ops []bulk.BulkItem, err error) (*mux.Result, error) {
 	if err != nil {
 		return &mux.Result{
 			Body:       string(queryparser.BadRequestParseError(err)),
 			StatusCode: http.StatusBadRequest,
-		}
+		}, nil
 	}
 
 	body, err := json.Marshal(bulk.BulkResponse{
@@ -389,10 +393,10 @@ func bulkInsertResult(ops []bulk.BulkItem, err error) *mux.Result {
 		Took:   42,
 	})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return elasticsearchInsertResult(string(body), http.StatusOK)
+	return elasticsearchInsertResult(string(body), http.StatusOK), nil
 }
 
 func elasticsearchInsertResult(body string, statusCode int) *mux.Result {
@@ -403,23 +407,23 @@ func elasticsearchInsertResult(body string, statusCode int) *mux.Result {
 	}, StatusCode: statusCode}
 }
 
-func resolveIndexResult(sources elasticsearch.Sources) *mux.Result {
+func resolveIndexResult(sources elasticsearch.Sources) (*mux.Result, error) {
 	if len(sources.Aliases) == 0 && len(sources.DataStreams) == 0 && len(sources.Indices) == 0 {
-		return &mux.Result{StatusCode: http.StatusNotFound}
+		return &mux.Result{StatusCode: http.StatusNotFound}, nil
 	}
 
 	body, err := json.Marshal(sources)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &mux.Result{
 		Body:       string(body),
 		Meta:       map[string]string{},
-		StatusCode: http.StatusOK}
+		StatusCode: http.StatusOK}, nil
 }
 
-func indexDocResult(index string, statusCode int) *mux.Result {
+func indexDocResult(index string, statusCode int) (*mux.Result, error) {
 	body, err := json.Marshal(indexDocResponse{
 		Id:          "fakeId",
 		Index:       index,
@@ -434,12 +438,12 @@ func indexDocResult(index string, statusCode int) *mux.Result {
 		Result:  "created",
 	})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return elasticsearchInsertResult(string(body), statusCode)
+	return elasticsearchInsertResult(string(body), statusCode), nil
 }
 
-func putIndexResult(index string) *mux.Result {
+func putIndexResult(index string) (*mux.Result, error) {
 	result := putIndexResponse{
 		Acknowledged:       true,
 		ShardsAcknowledged: true,
@@ -447,13 +451,13 @@ func putIndexResult(index string) *mux.Result {
 	}
 	serialized, err := json.Marshal(result)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &mux.Result{StatusCode: http.StatusOK, Body: string(serialized)}
+	return &mux.Result{StatusCode: http.StatusOK, Body: string(serialized)}, nil
 }
 
-func getIndexMappingResult(index string, mappings map[string]any) *mux.Result {
+func getIndexMappingResult(index string, mappings map[string]any) (*mux.Result, error) {
 	result := map[string]any{
 		index: map[string]any{
 			"mappings": mappings,
@@ -461,13 +465,13 @@ func getIndexMappingResult(index string, mappings map[string]any) *mux.Result {
 	}
 	serialized, err := json.Marshal(result)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &mux.Result{StatusCode: http.StatusOK, Body: string(serialized)}
+	return &mux.Result{StatusCode: http.StatusOK, Body: string(serialized)}, nil
 }
 
-func getIndexResult(index string, mappings map[string]any) *mux.Result {
+func getIndexResult(index string, mappings map[string]any) (*mux.Result, error) {
 	// For now return the same as getIndexMappingResult,
 	// but "GET /:index" can also contain "settings" and "aliases" (in the future)
 	return getIndexMappingResult(index, mappings)

--- a/quesma/schema/hierarchical_schema.go
+++ b/quesma/schema/hierarchical_schema.go
@@ -36,6 +36,11 @@ func addToTree(root *SchemaTreeNode, field *Field) {
 	currentNode.Children = append(currentNode.Children, &SchemaTreeNode{Name: leafComponent, Field: field})
 }
 
+// SchemaToHierarchicalSchema unflattens a "flat" Schema to a tree representation (returns a pointer to the root SchemaTreeNode).
+//
+// For example, if a field "product" with subfields "product_id" and "base_price", it's represented as two flat fields
+// "product.product_id", "product.base_price" in Schema. This function will convert it to a tree with a root node "",
+// a child node "product" with two grandchildren "product_id" and "base_price".
 func SchemaToHierarchicalSchema(s *Schema) *SchemaTreeNode {
 	root := SchemaTreeNode{Name: ""}
 

--- a/quesma/schema/hierarchical_schema.go
+++ b/quesma/schema/hierarchical_schema.go
@@ -1,0 +1,47 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package schema
+
+type SchemaTreeNode struct {
+	Name string // for example: "products" or "manufacturer" for "products.manufacturer", "" for root
+
+	// Either this is a leaf node (non-nil field) or a branch node (non-empty children)
+	Field    *Field
+	Children []*SchemaTreeNode
+}
+
+func addToTree(root *SchemaTreeNode, field *Field) {
+	components := field.PropertyName.Components()
+
+	leafComponent := components[len(components)-1]
+	components = components[:len(components)-1]
+
+	currentNode := root
+	for _, component := range components {
+		found := false
+		for _, child := range currentNode.Children {
+			if child.Name == component {
+				currentNode = child
+				found = true
+				break
+			}
+		}
+		if !found {
+			newNode := SchemaTreeNode{Name: component}
+			currentNode.Children = append(currentNode.Children, &newNode)
+			currentNode = &newNode
+		}
+	}
+
+	currentNode.Children = append(currentNode.Children, &SchemaTreeNode{Name: leafComponent, Field: field})
+}
+
+func SchemaToHierarchicalSchema(s *Schema) *SchemaTreeNode {
+	root := SchemaTreeNode{Name: ""}
+
+	for _, field := range s.Fields {
+		addToTree(&root, &field)
+	}
+
+	return &root
+}

--- a/quesma/schema/hierarchical_schema_test.go
+++ b/quesma/schema/hierarchical_schema_test.go
@@ -1,0 +1,44 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package schema
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_SchemaToHierarchicalSchema(t *testing.T) {
+	s := NewSchemaWithAliases(map[FieldName]Field{
+		"id":                     {PropertyName: "id", InternalPropertyName: "id", Type: TypeInteger},
+		"total_amount":           {PropertyName: "total_amount", InternalPropertyName: "total_amount", Type: TypeFloat},
+		"product.name":           {PropertyName: "product.name", InternalPropertyName: "product::name", Type: TypeText},
+		"product.product_id":     {PropertyName: "product.product_id", InternalPropertyName: "product::product_id", Type: TypeInteger},
+		"triple.nested.example1": {PropertyName: "triple.nested.example1", InternalPropertyName: "triple::nested::example1", Type: TypeText},
+		"triple.nested.example2": {PropertyName: "triple.nested.example2", InternalPropertyName: "triple::nested::example2", Type: TypeKeyword},
+	}, map[FieldName]FieldName{}, true)
+
+	hs := SchemaToHierarchicalSchema(&s)
+	assert.Equal(t, "", hs.Name)
+	assert.Nil(t, hs.Field)
+	assert.Equal(t, 4, len(hs.Children)) // "id", "total_amount", "product", "triple"
+
+	childrenNames := make([]string, 0)
+	for _, child := range hs.Children {
+		childrenNames = append(childrenNames, child.Name)
+		if child.Name == "product" {
+			assert.Equal(t, 2, len(child.Children))
+			assert.True(t, child.Children[0].Name == "name" || child.Children[1].Name == "name", "Expected 'name' field in 'product'")
+			assert.True(t, child.Children[0].Name == "product_id" || child.Children[1].Name == "product_id", "Expected 'product_id' field in 'product'")
+		} else if child.Name == "triple" {
+			assert.Equal(t, 1, len(child.Children))
+			assert.Equal(t, "nested", child.Children[0].Name)
+			assert.Equal(t, 2, len(child.Children[0].Children))
+			assert.True(t, child.Children[0].Children[0].Name == "example1" || child.Children[0].Children[1].Name == "example1", "Expected 'example1' field in 'triple.nested'")
+			assert.True(t, child.Children[0].Children[0].Name == "example2" || child.Children[0].Children[1].Name == "example2", "Expected 'example2' field in 'triple.nested'")
+		} else {
+			assert.NotNil(t, child.Field)
+			assert.Equal(t, child.Field.PropertyName.AsString(), child.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"id", "total_amount", "product", "triple"}, childrenNames)
+}

--- a/quesma/schema/schema.go
+++ b/quesma/schema/schema.go
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Elastic-2.0
 package schema
 
+import "strings"
+
 type (
 	Schema struct {
 		Fields              map[FieldName]Field
@@ -37,8 +39,12 @@ func NewSchema(fields map[FieldName]Field, existsInDataSource bool) Schema {
 	return NewSchemaWithAliases(fields, map[FieldName]FieldName{}, existsInDataSource)
 }
 
-func (t FieldName) AsString() string {
-	return string(t)
+func (f FieldName) AsString() string {
+	return string(f)
+}
+
+func (f FieldName) Components() []string {
+	return strings.Split(f.AsString(), ".")
 }
 
 func (t TableName) AsString() string {


### PR DESCRIPTION
This commit adds support for `GET /:index` and `GET /:index/_mapping` endpoints. The primary use of those endpoints is to get the (static) mapping of an index. Those endpoints are actively used by some Elastic clients, such as ElasticSearch Kafka Sink Connector.

The implementation generates the mapping based on the schema found in the schema registry.

`hierarchical_schema.go` was introduced since the schema registry stores the schema in a "flat" format (e.g. `products.product_id`, `products.base_price`), but the mapping we need to return should be nested. `SchemaToHierarchicalSchema` in that file transforms the flat schema into a tree (for example `products` is a node with `product_id`, `base_price` children), which is more convenient to use.

The added tests in `mappings_test.go` show that a round-trip should be possible: sending a mapping to Quesma, it getting parsed and stored as a `Schema` struct and generating back a mapping based on that `Schema` struct representation. (It's not 100% equal, since we change numeric types to wider types, for example floats to doubles.)