### PR TITLE
Many pancakes out of one query

### DIFF
--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -97,6 +97,11 @@ func TestPancakeQueryGeneration(t *testing.T) {
 						fmt.Println(prettyPancakeSql)
 						continue
 					}
+					if pancakeIdx-1 >= len(test.ExpectedAdditionalPancakeResults) {
+						pp.Println("=== Expected additional results for SQL:")
+						fmt.Println(prettyPancakeSql)
+						continue
+					}
 					expectedSql = test.ExpectedAdditionalPancakeSQLs[pancakeIdx-1]
 				}
 				prettyExpectedSql := util.SqlPrettyPrint([]byte(strings.TrimSpace(expectedSql)))
@@ -107,10 +112,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				if !ok {
 					assert.Fail(t, "Expected pancake query type")
 				}
-			}
-
-			if len(pancakeSqls) > 1 {
-				return // TODO: Process all pancakes
 			}
 
 			expectedJson, err := util.JsonToMap(test.ExpectedResponse)
@@ -125,7 +126,12 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			}
 			assert.NotNil(t, expectedAggregationsPart, "Expected JSON should have 'response'/'aggregations' part")
 
-			pancakeJson, err := cw.MakeAggregationPartOfResponse(pancakeSqls, [][]model.QueryResultRow{test.ExpectedPancakeResults})
+			sqlResults := [][]model.QueryResultRow{test.ExpectedPancakeResults}
+			if len(test.ExpectedAdditionalPancakeResults) > 0 {
+				sqlResults = append(sqlResults, test.ExpectedAdditionalPancakeResults...)
+			}
+
+			pancakeJson, err := cw.MakeAggregationPartOfResponse(pancakeSqls, sqlResults)
 
 			if err != nil {
 				t.Fatal("Failed to render pancake JSON", err)

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -63,7 +63,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix top metrics")
 			}
 			if multiplePancakes(test.TestName) {
-				t.Skip("Fix multiple pancakes")
+				//t.Skip("Fix multiple pancakes")
 			}
 			if filter(test.TestName) {
 				t.Skip("Fix filter")
@@ -79,7 +79,8 @@ func TestPancakeQueryGeneration(t *testing.T) {
 
 			pancakeSqls, err := cw.PancakeParseAggregationJson(jsonp, false)
 			assert.NoError(t, err)
-			assert.True(t, len(pancakeSqls) == 1, "pancakeSqls should have only one query")
+			//pp.Println("pancakeSqls", pancakeSqls)
+			assert.True(t, len(pancakeSqls) >= 1, "pancakeSqls should have at least one query")
 			if len(pancakeSqls) < 1 {
 				return
 			}
@@ -102,6 +103,10 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			queryType, ok := pancakeSqls[0].Type.(PancakeQueryType)
 			if !ok {
 				assert.Fail(t, "Expected pancake query type")
+			}
+
+			if len(pancakeSqls) > 1 {
+				return // TODO: Process all pancakes
 			}
 
 			expectedJson, err := util.JsonToMap(test.ExpectedResponse)

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -62,9 +62,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if topMetrics(test.TestName) {
 				t.Skip("Fix top metrics")
 			}
-			if multiplePancakes(test.TestName) {
-				//t.Skip("Fix multiple pancakes")
-			}
 			if filter(test.TestName) {
 				t.Skip("Fix filter")
 			}
@@ -79,7 +76,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 
 			pancakeSqls, err := cw.PancakeParseAggregationJson(jsonp, false)
 			assert.NoError(t, err)
-			//pp.Println("pancakeSqls", pancakeSqls)
 			assert.True(t, len(pancakeSqls) >= 1, "pancakeSqls should have at least one query")
 			if len(pancakeSqls) < 1 {
 				return
@@ -129,9 +125,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			}
 			assert.NotNil(t, expectedAggregationsPart, "Expected JSON should have 'response'/'aggregations' part")
 
-			renderer := &pancakeJSONRenderer{}
-			queryType := pancakeSqls[0].Type.(PancakeQueryType)
-			pancakeJson, err := renderer.toJSON(queryType.pancakeAggregation, test.ExpectedPancakeResults)
+			pancakeJson, err := cw.MakeAggregationPartOfResponse(pancakeSqls, [][]model.QueryResultRow{test.ExpectedPancakeResults})
 
 			if err != nil {
 				t.Fatal("Failed to render pancake JSON", err)
@@ -197,11 +191,6 @@ func topMetrics(testName string) bool {
 	t3 := testName == "simplest top_metrics, with sort"
 	t4 := testName == "very long: multiple top_metrics + histogram" // also top_metrics
 	return t1 || t2 || t3 || t4
-}
-
-// TODO remove after fix
-func multiplePancakes(testName string) bool {
-	return testName == "histogram with all possible calendar_intervals"
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -161,24 +161,28 @@ func (a *pancakeTransformer) aggregationChildrenToLayers(aggrNames []string, chi
 	}
 	resultLayers = make([][]*pancakeModelLayer, 0, len(results))
 	for _, res := range results {
-		newLayer := []*pancakeModelLayer{res.layer}
 		if res.nextBucketAggregation != nil {
 			childLayers, err := a.aggregationChildrenToLayers(append(aggrNames, res.nextBucketAggregation.name), res.nextBucketAggregation.children)
 			if err != nil {
 				return nil, err
 			}
 			if len(childLayers) == 0 {
-				resultLayers = append(resultLayers, newLayer)
+				resultLayers = append(resultLayers, []*pancakeModelLayer{res.layer})
 			} else {
 				for i, childLayer := range childLayers {
-					if i > 0 {
-						// TODO: remove metrics
+					newLayer := res.layer
+					if i > 0 { // remove metrics
+						newLayer = &pancakeModelLayer{
+							currentMetricAggregations: make([]*pancakeModelMetricAggregation, 0),
+							nextBucketAggregation:     res.layer.nextBucketAggregation,
+						}
 					}
-					resultLayers = append(resultLayers, append(newLayer, childLayer...))
+
+					resultLayers = append(resultLayers, append([]*pancakeModelLayer{newLayer}, childLayer...))
 				}
 			}
 		} else {
-			resultLayers = append(resultLayers, newLayer)
+			resultLayers = append(resultLayers, []*pancakeModelLayer{res.layer})
 		}
 	}
 	return resultLayers, nil

--- a/quesma/queryparser/pancake_transformer_test.go
+++ b/quesma/queryparser/pancake_transformer_test.go
@@ -127,7 +127,9 @@ func Test_pancakeTranslateFromAggregationToLayered(t *testing.T) {
 
 			transformer := newPancakeTransformer()
 
-			pan, err := transformer.aggregationTreeToPancake(*tt.tree)
+			pancakes, err := transformer.aggregationTreeToPancakes(*tt.tree)
+			assert.Len(t, pancakes, 1)
+			pan := pancakes[0]
 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -376,7 +376,78 @@ var AggregationTests2 = []AggregationTestCase{
 				model.NewQueryResultCol("count()", uint64(33)),
 			}}},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__day1__key_0", int64(1717980400000/86400000)),
+				model.NewQueryResultCol("aggr__day1__count", uint64(33)),
+			}},
+		},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__day2__key_0", int64(1717980400000/86400000)),
+				model.NewQueryResultCol("aggr__day2__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__hour1__key_0", int64(1718024400000/3600000)),
+				model.NewQueryResultCol("aggr__hour1__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__hour2__key_0", int64(1718024400000/3600000)),
+				model.NewQueryResultCol("aggr__hour2__count", uint64(33)),
+			}}},
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__minute1__key_0", int64(1718025840000/60000)),
+					model.NewQueryResultCol("aggr__minute1__count", uint64(9)),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__minute1__key_0", int64(1718025900000/60000)),
+					model.NewQueryResultCol("aggr__minute1__count", uint64(24)),
+				}},
+			},
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__minute2__key_0", int64(1718025840000/60000)),
+					model.NewQueryResultCol("aggr__minute2__count", uint64(9)),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__minute2__key_0", int64(1718025900000/60000)),
+					model.NewQueryResultCol("aggr__minute2__count", uint64(24)),
+				}},
+			},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__month1__key_0", int64(1717192800000)),
+				model.NewQueryResultCol("aggr__month1__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__month2__key_0", int64(1717192800000)),
+				model.NewQueryResultCol("aggr__month2__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__quarter1__key_0", int64(1711922400000)),
+				model.NewQueryResultCol("aggr__quarter1__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__quarter2__key_0", int64(1711922400000)),
+				model.NewQueryResultCol("aggr__quarter2__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__week1__key_0", int64(1717970400000)),
+				model.NewQueryResultCol("aggr__week1__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__week2__key_0", int64(1717970400000)),
+				model.NewQueryResultCol("aggr__week2__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__year1__key_0", int64(1704063600000)),
+				model.NewQueryResultCol("aggr__year1__count", uint64(33)),
+			}}},
+			{{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__year2__key_0", int64(1704063600000)),
+				model.NewQueryResultCol("aggr__year2__count", uint64(33)),
+			}}},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() FROM ` + QuotedTableName,
 			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000), count() ` +

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -436,7 +436,13 @@ var AggregationTests2 = []AggregationTestCase{
 				`GROUP BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 ` +
 				`ORDER BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__day1__key_0", count(*) AS "aggr__day1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__day1__key_0"
+			ORDER BY "aggr__day1__key_0" ASC`,
 	},
 	{ // [43]
 		TestName: "Percentiles with another metric aggregation. It might get buggy after introducing pancakes.",

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -443,6 +443,86 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
 			  "aggr__day1__key_0"
 			ORDER BY "aggr__day1__key_0" ASC`,
+		ExpectedAdditionalPancakeSQLs: []string{
+			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__day2__key_0", count(*) AS "aggr__day2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__day2__key_0"
+			ORDER BY "aggr__day2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__hour1__key_0", count(*) AS "aggr__hour1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__hour1__key_0"
+			ORDER BY "aggr__hour1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__hour2__key_0", count(*) AS "aggr__hour2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__hour2__key_0"
+			ORDER BY "aggr__hour2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
+			  "aggr__minute1__key_0", count(*) AS "aggr__minute1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
+			  "aggr__minute1__key_0"
+			ORDER BY "aggr__minute1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
+			  "aggr__minute2__key_0", count(*) AS "aggr__minute2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 60000) AS
+			  "aggr__minute2__key_0"
+			ORDER BY "aggr__minute2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			  "aggr__month1__key_0", count(*) AS "aggr__month1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			  "aggr__month1__key_0"
+			ORDER BY "aggr__month1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			  "aggr__month2__key_0", count(*) AS "aggr__month2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			  "aggr__month2__key_0"
+			ORDER BY "aggr__month2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			  "aggr__quarter1__key_0", count(*) AS "aggr__quarter1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			  "aggr__quarter1__key_0"
+			ORDER BY "aggr__quarter1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			  "aggr__quarter2__key_0", count(*) AS "aggr__quarter2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			  "aggr__quarter2__key_0"
+			ORDER BY "aggr__quarter2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			  "aggr__week1__key_0", count(*) AS "aggr__week1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			  "aggr__week1__key_0"
+			ORDER BY "aggr__week1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			  "aggr__week2__key_0", count(*) AS "aggr__week2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			  "aggr__week2__key_0"
+			ORDER BY "aggr__week2__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			  "aggr__year1__key_0", count(*) AS "aggr__year1__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			  "aggr__year1__key_0"
+			ORDER BY "aggr__year1__key_0" ASC`,
+			`SELECT toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			  "aggr__year2__key_0", count(*) AS "aggr__year2__count"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			  "aggr__year2__key_0"
+			ORDER BY "aggr__year2__key_0" ASC`,
+		},
 	},
 	{ // [43]
 		TestName: "Percentiles with another metric aggregation. It might get buggy after introducing pancakes.",

--- a/quesma/testdata/model.go
+++ b/quesma/testdata/model.go
@@ -26,14 +26,15 @@ type AsyncSearchTestCase struct {
 }
 
 type AggregationTestCase struct {
-	TestName                      string
-	QueryRequestJson              string                   // JSON query request, just like received from Kibana
-	ExpectedResponse              string                   // JSON response, just like Elastic would respond to the query request
-	ExpectedResults               [][]model.QueryResultRow // [0] = result for first aggregation, [1] = result for second aggregation, etc.
-	ExpectedPancakeResults        []model.QueryResultRow   // nil if we don't have pancake results for this test
-	ExpectedSQLs                  []string                 // [0] = translated SQLs for first aggregation, [1] = translated SQL for second aggregation, etc.
-	ExpectedPancakeSQL            string                   // "" if we don't have pancake results for this test
-	ExpectedAdditionalPancakeSQLs []string                 // additional SQLs that are not part of the main query
+	TestName                         string
+	QueryRequestJson                 string                   // JSON query request, just like received from Kibana
+	ExpectedResponse                 string                   // JSON response, just like Elastic would respond to the query request
+	ExpectedResults                  [][]model.QueryResultRow // [0] = result for first aggregation, [1] = result for second aggregation, etc.
+	ExpectedPancakeResults           []model.QueryResultRow   // nil if we don't have pancake results for this test
+	ExpectedSQLs                     []string                 // [0] = translated SQLs for first aggregation, [1] = translated SQL for second aggregation, etc.
+	ExpectedPancakeSQL               string                   // "" if we don't have pancake results for this test
+	ExpectedAdditionalPancakeSQLs    []string                 // additional SQLs that are not part of the main query
+	ExpectedAdditionalPancakeResults [][]model.QueryResultRow // additional results that are not part of the main query
 }
 
 type UnsupportedQueryTestCase struct {

--- a/quesma/testdata/model.go
+++ b/quesma/testdata/model.go
@@ -26,13 +26,14 @@ type AsyncSearchTestCase struct {
 }
 
 type AggregationTestCase struct {
-	TestName               string
-	QueryRequestJson       string                   // JSON query request, just like received from Kibana
-	ExpectedResponse       string                   // JSON response, just like Elastic would respond to the query request
-	ExpectedResults        [][]model.QueryResultRow // [0] = result for first aggregation, [1] = result for second aggregation, etc.
-	ExpectedPancakeResults []model.QueryResultRow   // nil if we don't have pancake results for this test
-	ExpectedSQLs           []string                 // [0] = translated SQLs for first aggregation, [1] = translated SQL for second aggregation, etc.
-	ExpectedPancakeSQL     string                   // "" if we don't have pancake results for this test
+	TestName                      string
+	QueryRequestJson              string                   // JSON query request, just like received from Kibana
+	ExpectedResponse              string                   // JSON response, just like Elastic would respond to the query request
+	ExpectedResults               [][]model.QueryResultRow // [0] = result for first aggregation, [1] = result for second aggregation, etc.
+	ExpectedPancakeResults        []model.QueryResultRow   // nil if we don't have pancake results for this test
+	ExpectedSQLs                  []string                 // [0] = translated SQLs for first aggregation, [1] = translated SQL for second aggregation, etc.
+	ExpectedPancakeSQL            string                   // "" if we don't have pancake results for this test
+	ExpectedAdditionalPancakeSQLs []string                 // additional SQLs that are not part of the main query
 }
 
 type UnsupportedQueryTestCase struct {


### PR DESCRIPTION
Pancakes have quite a few limitations, and only one pancake can be created.

This allows more pancakes to be created per aggregation which brings it closer to feature completion.



