### PR TITLE
Pancake filter implementation

### DIFF
--- a/quesma/model/bucket_aggregations/filter.go
+++ b/quesma/model/bucket_aggregations/filter.go
@@ -1,0 +1,37 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package bucket_aggregations
+
+import (
+	"context"
+	"quesma/logger"
+	"quesma/model"
+)
+
+type FilterAgg struct {
+	ctx         context.Context
+	WhereClause model.Expr
+}
+
+func NewFilterAgg(ctx context.Context, whereClause model.Expr) FilterAgg {
+	return FilterAgg{ctx: ctx, WhereClause: whereClause}
+}
+
+func (query FilterAgg) AggregationType() model.AggregationType {
+	return model.BucketAggregation
+}
+
+func (query FilterAgg) TranslateSqlResponseToJson(rows []model.QueryResultRow, level int) model.JsonMap {
+	if len(rows) == 0 {
+		logger.WarnWithCtx(query.ctx).Msg("no rows returned for count aggregation")
+		return make(model.JsonMap, 0)
+	}
+	if len(rows) > 1 {
+		logger.WarnWithCtx(query.ctx).Msg("More than one row returned for count aggregation")
+	}
+	return model.JsonMap{"doc_count": rows[0].Cols[level].Value}
+}
+
+func (query FilterAgg) String() string {
+	return "count"
+}

--- a/quesma/model/bucket_aggregations/filter.go
+++ b/quesma/model/bucket_aggregations/filter.go
@@ -35,3 +35,7 @@ func (query FilterAgg) TranslateSqlResponseToJson(rows []model.QueryResultRow, l
 func (query FilterAgg) String() string {
 	return "count"
 }
+
+func (query FilterAgg) DoesNotHaveGroupBy() bool {
+	return true
+}

--- a/quesma/model/bucket_aggregations/filter.go
+++ b/quesma/model/bucket_aggregations/filter.go
@@ -23,11 +23,8 @@ func (query FilterAgg) AggregationType() model.AggregationType {
 
 func (query FilterAgg) TranslateSqlResponseToJson(rows []model.QueryResultRow, level int) model.JsonMap {
 	if len(rows) == 0 {
-		logger.WarnWithCtx(query.ctx).Msg("no rows returned for count aggregation")
+		logger.WarnWithCtx(query.ctx).Msg("no rows returned for filter aggregation")
 		return make(model.JsonMap, 0)
-	}
-	if len(rows) > 1 {
-		logger.WarnWithCtx(query.ctx).Msg("More than one row returned for count aggregation")
 	}
 	return model.JsonMap{"doc_count": rows[0].Cols[level].Value}
 }

--- a/quesma/model/bucket_aggregations/no_group_by_interface.go
+++ b/quesma/model/bucket_aggregations/no_group_by_interface.go
@@ -1,0 +1,7 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package bucket_aggregations
+
+type NoGroupByInterface interface {
+	DoesNotHaveGroupBy() bool
+}

--- a/quesma/model/bucket_aggregations/random_sampler.go
+++ b/quesma/model/bucket_aggregations/random_sampler.go
@@ -5,6 +5,7 @@ package bucket_aggregations
 import (
 	"context"
 	"fmt"
+	"quesma/logger"
 	"quesma/model"
 )
 
@@ -28,7 +29,11 @@ func (query RandomSampler) AggregationType() model.AggregationType {
 }
 
 func (query RandomSampler) TranslateSqlResponseToJson(rows []model.QueryResultRow, level int) model.JsonMap {
-	panic("does not create new results") // eventually we should add count
+	if len(rows) == 0 {
+		logger.WarnWithCtx(query.ctx).Msg("no rows returned for random sampler")
+		return make(model.JsonMap, 0)
+	}
+	return model.JsonMap{"doc_count": rows[0].Cols[level].Value}
 }
 
 func (query RandomSampler) String() string {

--- a/quesma/model/bucket_aggregations/random_sampler.go
+++ b/quesma/model/bucket_aggregations/random_sampler.go
@@ -38,3 +38,7 @@ func (query RandomSampler) String() string {
 func (query RandomSampler) GetSampleLimit() int {
 	return 20000 // TODO temporary, to be fixed
 }
+
+func (query RandomSampler) DoesNotHaveGroupBy() bool {
+	return true
+}

--- a/quesma/model/bucket_aggregations/sampler.go
+++ b/quesma/model/bucket_aggregations/sampler.go
@@ -5,6 +5,7 @@ package bucket_aggregations
 import (
 	"context"
 	"fmt"
+	"quesma/logger"
 	"quesma/model"
 )
 
@@ -24,7 +25,11 @@ func (query Sampler) AggregationType() model.AggregationType {
 }
 
 func (query Sampler) TranslateSqlResponseToJson(rows []model.QueryResultRow, level int) model.JsonMap {
-	panic("does not create new results") // eventually we should add count
+	if len(rows) == 0 {
+		logger.WarnWithCtx(query.ctx).Msg("no rows returned for sampler")
+		return make(model.JsonMap, 0)
+	}
+	return model.JsonMap{"doc_count": rows[0].Cols[level].Value}
 }
 
 func (query Sampler) String() string {

--- a/quesma/model/bucket_aggregations/sampler.go
+++ b/quesma/model/bucket_aggregations/sampler.go
@@ -34,3 +34,7 @@ func (query Sampler) String() string {
 func (query Sampler) GetSampleLimit() int {
 	return shardSizeToSampleLimitRatio * query.size
 }
+
+func (query Sampler) DoesNotHaveGroupBy() bool {
+	return true
+}

--- a/quesma/queryparser/pancake_aggregation_parser.go
+++ b/quesma/queryparser/pancake_aggregation_parser.go
@@ -150,7 +150,7 @@ func (cw *ClickhouseQueryTranslator) pancakeParseAggregation(aggregationName str
 		if filter, ok := filterRaw.(QueryMap); ok {
 			whereClause := cw.parseQueryMap(filter).WhereClause
 			aggregation.queryType = bucket_aggregations.NewFilterAgg(cw.Ctx, whereClause)
-			aggregation.selectedColumns = []model.Expr{model.NewFunction("countIf", model.NewLiteral("*"), whereClause)}
+			aggregation.selectedColumns = []model.Expr{model.NewFunction("countIf", whereClause)}
 		} else {
 			logger.WarnWithCtx(cw.Ctx).Msgf("filter is not a map, but %T, value: %v. Skipping", filterRaw, filterRaw)
 		}

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -121,11 +121,13 @@ func (p *pancakeJSONRenderer) layerToJSON(layerIdx int, layers []*pancakeModelLa
 	if layer.nextBucketAggregation != nil {
 		// sampler is special
 		if _, isSampler := layer.nextBucketAggregation.queryType.(bucket_aggregations.SamplerInterface); isSampler {
+			sampleRows := p.selectMetricRows(layer.nextBucketAggregation.internalName+"count", rows)
+			sampleJson := layer.nextBucketAggregation.queryType.TranslateSqlResponseToJson(sampleRows, 0)
 			jsonWithOmittedSampler, err := p.layerToJSON(layerIdx+1, layers, rows)
 			if err != nil {
 				return nil, err
 			}
-			result[layer.nextBucketAggregation.name] = jsonWithOmittedSampler
+			result[layer.nextBucketAggregation.name] = util.MergeMaps(context.Background(), sampleJson, jsonWithOmittedSampler, model.KeyAddedByQuesma)
 			return result, nil
 		}
 

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -134,14 +134,11 @@ func (p *pancakeJSONRenderer) layerToJSON(layerIdx int, layers []*pancakeModelLa
 			// Maybe metadata?
 			filterRows := p.selectMetricRows(layer.nextBucketAggregation.internalName+"_col_", rows)
 			filterJson := filter.TranslateSqlResponseToJson(filterRows, 0)
-			if filterJson["doc_count"] != 0 {
-				subAggr, err := p.layerToJSON(layerIdx+1, layers, rows)
-				if err != nil {
-					return nil, err
-				}
-				filterJson = util.MergeMaps(context.Background(), filterJson, subAggr, model.KeyAddedByQuesma)
+			subAggr, err := p.layerToJSON(layerIdx+1, layers, rows)
+			if err != nil {
+				return nil, err
 			}
-			result[layer.nextBucketAggregation.name] = filterJson
+			result[layer.nextBucketAggregation.name] = util.MergeMaps(context.Background(), filterJson, subAggr, model.KeyAddedByQuesma)
 			return result, nil
 		}
 

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -128,7 +128,14 @@ func (p *pancakeJSONRenderer) layerToJSON(layerIdx int, layers []*pancakeModelLa
 			result[layer.nextBucketAggregation.name] = jsonWithOmittedSampler
 			return result, nil
 		}
-		// if filter/filters/range/dateRange do something special
+
+		// TODO: if filter/filters/range/dateRange do something special
+		if filter, isFilter := layer.nextBucketAggregation.queryType.(bucket_aggregations.FilterAgg); isFilter {
+			// Maybe metadata?
+			filterRows := p.selectMetricRows(layer.nextBucketAggregation.internalName+"_col_", rows)
+			result[layer.nextBucketAggregation.name] = filter.TranslateSqlResponseToJson(filterRows, 0)
+			return result, nil
+		}
 
 		bucketRows, subAggrRows := p.splitBucketRows(layer.nextBucketAggregation, rows)
 

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -133,7 +133,12 @@ func (p *pancakeJSONRenderer) layerToJSON(layerIdx int, layers []*pancakeModelLa
 		if filter, isFilter := layer.nextBucketAggregation.queryType.(bucket_aggregations.FilterAgg); isFilter {
 			// Maybe metadata?
 			filterRows := p.selectMetricRows(layer.nextBucketAggregation.internalName+"_col_", rows)
-			result[layer.nextBucketAggregation.name] = filter.TranslateSqlResponseToJson(filterRows, 0)
+			filterDocCountJson := filter.TranslateSqlResponseToJson(filterRows, 0)
+			subAggr, err := p.layerToJSON(layerIdx+1, layers, rows)
+			if err != nil {
+				return nil, err
+			}
+			result[layer.nextBucketAggregation.name] = util.MergeMaps(context.Background(), filterDocCountJson, subAggr, model.KeyAddedByQuesma)
 			return result, nil
 		}
 

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -128,6 +128,7 @@ func (p *pancakeJSONRenderer) layerToJSON(layerIdx int, layers []*pancakeModelLa
 			result[layer.nextBucketAggregation.name] = jsonWithOmittedSampler
 			return result, nil
 		}
+		// if filter/filters/range/dateRange do something special
 
 		bucketRows, subAggrRows := p.splitBucketRows(layer.nextBucketAggregation, rows)
 

--- a/quesma/queryparser/pancake_model.go
+++ b/quesma/queryparser/pancake_model.go
@@ -5,6 +5,7 @@ package queryparser
 import (
 	"fmt"
 	"quesma/model"
+	"quesma/model/bucket_aggregations"
 )
 
 // Pancake model.
@@ -69,4 +70,9 @@ func (p pancakeModelBucketAggregation) InternalNameForCount() string {
 // Used by terms aggregation to get the total count, so we can calculate sum_other_doc_count
 func (p pancakeModelBucketAggregation) InternalNameForParentCount() string {
 	return fmt.Sprintf("%sparent_count", p.internalName)
+}
+
+func (p pancakeModelBucketAggregation) DoesHaveGroupBy() bool {
+	_, noGroupBy := p.queryType.(bucket_aggregations.NoGroupByInterface)
+	return !noGroupBy
 }

--- a/quesma/queryparser/pancake_sql_query_generation.go
+++ b/quesma/queryparser/pancake_sql_query_generation.go
@@ -264,8 +264,8 @@ func (p *pancakeSqlQueryGenerator) generateSelectCommand(aggregation *pancakeMod
 		if layer.nextBucketAggregation != nil {
 			if filter, isFilter := layer.nextBucketAggregation.queryType.(bucket_aggregations.FilterAgg); isFilter {
 
-				for i, newFilterColumn := range layer.nextBucketAggregation.selectedColumns {
-					aliasName := fmt.Sprintf("%s_col_%d", layer.nextBucketAggregation.internalName, i)
+				for _, newFilterColumn := range layer.nextBucketAggregation.selectedColumns { // it is just one column
+					aliasName := layer.nextBucketAggregation.InternalNameForCount()
 					aliasedColumn := model.NewAliasedExpr(newFilterColumn, aliasName)
 					selectColumns = append(selectColumns, aliasedColumn)
 				}

--- a/quesma/queryparser/pancake_sql_query_generation.go
+++ b/quesma/queryparser/pancake_sql_query_generation.go
@@ -214,6 +214,9 @@ func (p *pancakeSqlQueryGenerator) generateSelectCommand(aggregation *pancakeMod
 		}
 
 		if layer.nextBucketAggregation != nil {
+			// if it is filter/filters than do something else
+			// if layerId == 0 and single filter than add to WHERE // optimion
+			// if filter, but last one, than pass count if combinators
 			hasMoreBucketAggregations = hasMoreBucketAggregations && aggregation.layers[layerId+1].nextBucketAggregation != nil
 			addSelectColumns, addGroupBys, addRankColumns, addRankWheres, addRankOrderBys, err :=
 				p.generateBucketSqlParts(layer.nextBucketAggregation, groupBys, hasMoreBucketAggregations)

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -62,8 +62,8 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if topMetrics(test.TestName) {
 				t.Skip("Fix top metrics")
 			}
-			if filter(test.TestName) {
-				t.Skip("Fix filter")
+			if percentilesAndTest(test.TestName) {
+				t.Skip("Fix percentiles")
 			}
 			if filters(test.TestName) {
 				t.Skip("Fix filters")
@@ -199,6 +199,7 @@ func topMetrics(testName string) bool {
 	return t1 || t2 || t3 || t4
 }
 
+/*
 // TODO remove after fix
 func filter(testName string) bool {
 	//t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
@@ -214,7 +215,23 @@ func filter(testName string) bool {
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t6 || t8 || t9
+	return t6 || t9
+}
+*/
+
+// TODO remove after fix
+
+func percentilesAndTest(testName string) bool {
+	t1 := testName == "Field statistics > summary for numeric fields" // also percentiles
+	// to be deleted after pancakes
+	t2 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
+		"Output more or less works, but is different and worse than what Elastic returns."+
+		"If it starts failing, maybe that's a good thing"
+	// below test is replacing it
+	// testName == "it's the same input as in previous test, but with the original output from Elastic."+
+	//	"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
+	//	"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
+	return t1 || t2
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -202,19 +202,19 @@ func topMetrics(testName string) bool {
 // TODO remove after fix
 func filter(testName string) bool {
 	//t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
-	t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
+	//t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
 	//t3 := testName == "2 sibling count aggregations"
 	//t4 := testName == "simple filter/count"
 	//t5 := testName == "triple nested aggs"
 	t6 := testName == "Field statistics > summary for numeric fields" // also percentiles
-	t7 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
-		"Output more or less works, but is different and worse than what Elastic returns."+
-		"If it starts failing, maybe that's a good thing"
+	//t7 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
+	//	"Output more or less works, but is different and worse than what Elastic returns."+
+	//		"If it starts failing, maybe that's a good thing"
 	t8 := testName == "it's the same input as in previous test, but with the original output from Elastic."+
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t2 || t6 || t7 || t8 || t9
+	return t6 || t8 || t9
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -205,7 +205,7 @@ func filter(testName string) bool {
 	t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
 	//t3 := testName == "2 sibling count aggregations"
 	//t4 := testName == "simple filter/count"
-	t5 := testName == "triple nested aggs"
+	//t5 := testName == "triple nested aggs"
 	t6 := testName == "Field statistics > summary for numeric fields" // also percentiles
 	t7 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
 		"Output more or less works, but is different and worse than what Elastic returns."+
@@ -214,7 +214,7 @@ func filter(testName string) bool {
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t1 || t2 || t5 || t6 || t7 || t8 || t9
+	return t1 || t2 || t6 || t7 || t8 || t9
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -138,7 +138,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			}
 
 			// FIXME we can quite easily remove 'probability' and 'seed' from above - just start remembering them in RandomSampler struct and print in JSON response.
-			acceptableDifference := []string{"probability", "seed", "bg_count", "doc_count", model.KeyAddedByQuesma,
+			acceptableDifference := []string{"probability", "seed", "bg_count", model.KeyAddedByQuesma,
 				"doc_count_error_upper_bound"} // Don't know why, but those 2 are still needed in new (clients/ophelia) tests. Let's fix it in another PR
 
 			actualMinusExpected, expectedMinusActual := util.MapDifference(pancakeJson,

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -203,7 +203,7 @@ func topMetrics(testName string) bool {
 func filter(testName string) bool {
 	t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
 	t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
-	t3 := testName == "2 sibling count aggregations"
+	//t3 := testName == "2 sibling count aggregations"
 	//t4 := testName == "simple filter/count"
 	t5 := testName == "triple nested aggs"
 	t6 := testName == "Field statistics > summary for numeric fields" // also percentiles
@@ -214,7 +214,7 @@ func filter(testName string) bool {
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t1 || t2 || t3 || t5 || t6 || t7 || t8 || t9
+	return t1 || t2 || t5 || t6 || t7 || t8 || t9
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -199,28 +199,7 @@ func topMetrics(testName string) bool {
 	return t1 || t2 || t3 || t4
 }
 
-/*
 // TODO remove after fix
-func filter(testName string) bool {
-	//t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
-	//t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
-	//t3 := testName == "2 sibling count aggregations"
-	//t4 := testName == "simple filter/count"
-	//t5 := testName == "triple nested aggs"
-	t6 := testName == "Field statistics > summary for numeric fields" // also percentiles
-	//t7 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
-	//	"Output more or less works, but is different and worse than what Elastic returns."+
-	//		"If it starts failing, maybe that's a good thing"
-	t8 := testName == "it's the same input as in previous test, but with the original output from Elastic."+
-		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
-		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
-	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t6 || t9
-}
-*/
-
-// TODO remove after fix
-
 func percentilesAndTest(testName string) bool {
 	t1 := testName == "Field statistics > summary for numeric fields" // also percentiles
 	// to be deleted after pancakes

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -201,7 +201,7 @@ func topMetrics(testName string) bool {
 
 // TODO remove after fix
 func filter(testName string) bool {
-	t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
+	//t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
 	t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
 	//t3 := testName == "2 sibling count aggregations"
 	//t4 := testName == "simple filter/count"
@@ -214,7 +214,7 @@ func filter(testName string) bool {
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t1 || t2 || t6 || t7 || t8 || t9
+	return t2 || t6 || t7 || t8 || t9
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -204,7 +204,7 @@ func filter(testName string) bool {
 	t1 := testName == "Terms, completely different tree results from 2 queries - merging them didn't work before"
 	t2 := testName == "Kibana Visualize -> Last Value. Used to panic" // also top_metrics
 	t3 := testName == "2 sibling count aggregations"
-	t4 := testName == "simple filter/count"
+	//t4 := testName == "simple filter/count"
 	t5 := testName == "triple nested aggs"
 	t6 := testName == "Field statistics > summary for numeric fields" // also percentiles
 	t7 := testName == "clients/kunkka/test_0, used to be broken before aggregations merge fix"+
@@ -214,7 +214,7 @@ func filter(testName string) bool {
 		"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 		"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	t9 := testName == "clients/kunkka/test_1, used to be broken before aggregations merge fix" // also filters
-	return t1 || t2 || t3 || t4 || t5 || t6 || t7 || t8 || t9
+	return t1 || t2 || t3 || t5 || t6 || t7 || t8 || t9
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -207,6 +207,18 @@ func (a *pancakeTransformer) aggregationTreeToPancakes(topLevel pancakeAggregati
 			}
 		}
 
+		// for now we support filter only as last bucket aggregation
+		for layerIdx, layer := range layers {
+			if layer.nextBucketAggregation != nil {
+				switch layer.nextBucketAggregation.queryType.(type) {
+				case bucket_aggregations.FilterAgg:
+					if layerIdx+1 < len(layers) && layers[layerIdx+1].nextBucketAggregation != nil {
+						return nil, fmt.Errorf("filter aggregation must be last bucket aggregation")
+					}
+				}
+			}
+		}
+
 		pancakeResults = append(pancakeResults, &pancakeModel{
 			layers:      layers,
 			whereClause: topLevel.whereClause,

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -347,41 +347,22 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__key_0", "Abu Dhabi"),
 				model.NewQueryResultCol("aggr__0__count", uint64(23)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 7),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", 3),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 46),
 				model.NewQueryResultCol("aggr__0__key_0", "Adelaide"),
 				model.NewQueryResultCol("aggr__0__count", uint64(20)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 3),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", 2),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 46),
 				model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
 				model.NewQueryResultCol("aggr__0__count", uint64(3)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 0),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", 2),
 			}},
-		},
-		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
-			{
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", 46),
-					model.NewQueryResultCol("aggr__0__key_0", "Abu Dhabi"),
-					model.NewQueryResultCol("aggr__0__count", uint64(23)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", 3),
-				}},
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", 46),
-					model.NewQueryResultCol("aggr__0__key_0", "Adelaide"),
-					model.NewQueryResultCol("aggr__0__count", uint64(20)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", 2),
-				}},
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", 46),
-					model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
-					model.NewQueryResultCol("aggr__0__count", uint64(3)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", 2),
-				}},
-			},
 		},
 		ExpectedSQLs: []string{
 			`WITH cte_1 AS ` +
@@ -429,16 +410,16 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__1-bucket___col_0"
+			  "metric__0__3-bucket_col_0", "aggr__0__1-bucket___col_0"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-				"aggr__0__1-bucket___col_0",
+				"metric__0__3-bucket_col_0", "aggr__0__1-bucket___col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginCityName" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0",
 				  countIf("FlightDelay"==true) AS "aggr__0__1-bucket___col_0"
 				FROM "logs-generic-default"
 				WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z')
@@ -446,24 +427,6 @@ var AggregationTests = []AggregationTestCase{
 				GROUP BY "OriginCityName" AS "aggr__0__key_0"))
 			WHERE "aggr__0__order_1_rank"<=1001
 			ORDER BY "aggr__0__order_1_rank" ASC`,
-		ExpectedAdditionalPancakeSQLs: []string{`
-			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__3-bucket___col_0"
-			FROM (
-			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-				"aggr__0__3-bucket___col_0",
-				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			  FROM (
-				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "OriginCityName" AS "aggr__0__key_0",
-				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  countIf("Cancelled"==true) AS "aggr__0__3-bucket___col_0"
-				FROM "logs-generic-default"
-				WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z')
-				  AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))
-				GROUP BY "OriginCityName" AS "aggr__0__key_0"))
-			WHERE "aggr__0__order_1_rank"<=1001
-			ORDER BY "aggr__0__order_1_rank" ASC`},
 	},
 	{ // [2]
 		TestName: "date_histogram",
@@ -5812,41 +5775,22 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
 				model.NewQueryResultCol("aggr__0__count", uint64(4)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(1)),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(2)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
 				model.NewQueryResultCol("aggr__0__key_0", "Atlanta"),
 				model.NewQueryResultCol("aggr__0__count", uint64(5)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(0)),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(0)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
 				model.NewQueryResultCol("aggr__0__key_0", "Baltimore"),
 				model.NewQueryResultCol("aggr__0__count", uint64(5)),
 				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(2)),
+				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(0)),
 			}},
-		},
-		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
-			{
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
-					model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
-					model.NewQueryResultCol("aggr__0__count", uint64(4)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", uint64(2)),
-				}},
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
-					model.NewQueryResultCol("aggr__0__key_0", "Atlanta"),
-					model.NewQueryResultCol("aggr__0__count", uint64(5)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", uint64(0)),
-				}},
-				{Cols: []model.QueryResultCol{
-					model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
-					model.NewQueryResultCol("aggr__0__key_0", "Baltimore"),
-					model.NewQueryResultCol("aggr__0__count", uint64(5)),
-					model.NewQueryResultCol("aggr__0__3-bucket___col_0", uint64(0)),
-				}},
-			},
 		},
 		ExpectedSQLs: []string{
 			`WITH cte_1 AS ` +
@@ -5884,37 +5828,21 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__1-bucket___col_0"
+			  "metric__0__3-bucket_col_0", "aggr__0__1-bucket___col_0"
 			FROM (
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-				"aggr__0__1-bucket___col_0",
+				"metric__0__3-bucket_col_0", "aggr__0__1-bucket___col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginCityName" AS "aggr__0__key_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0",
 				  countIf("FlightDelay"==true) AS "aggr__0__1-bucket___col_0"
 				FROM "logs-generic-default"
 				GROUP BY "OriginCityName" AS "aggr__0__key_0"))
 			WHERE "aggr__0__order_1_rank"<=1001
 			ORDER BY "aggr__0__order_1_rank" ASC`,
-		ExpectedAdditionalPancakeSQLs: []string{
-			`SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-			  "aggr__0__3-bucket___col_0"
-			FROM (
-			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
-				"aggr__0__3-bucket___col_0",
-				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			  FROM (
-				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
-				  "OriginCityName" AS "aggr__0__key_0",
-				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  countIf("Cancelled"==true) AS "aggr__0__3-bucket___col_0"
-				FROM "logs-generic-default"
-				GROUP BY "OriginCityName" AS "aggr__0__key_0"))
-			WHERE "aggr__0__order_1_rank"<=1001
-			ORDER BY "aggr__0__order_1_rank" ASC`,
-		},
 	},
 	{ // [29]
 		TestName: "Terms, completely different tree results from 2 queries - merging them didn't work before (logs) TODO add results",

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -346,21 +346,21 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__parent_count", 46),
 				model.NewQueryResultCol("aggr__0__key_0", "Abu Dhabi"),
 				model.NewQueryResultCol("aggr__0__count", uint64(23)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 7),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", 7),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", 3),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 46),
 				model.NewQueryResultCol("aggr__0__key_0", "Adelaide"),
 				model.NewQueryResultCol("aggr__0__count", uint64(20)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 3),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", 3),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", 2),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", 46),
 				model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
 				model.NewQueryResultCol("aggr__0__count", uint64(3)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", 0),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", 0),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", 2),
 			}},
 		},
@@ -412,7 +412,7 @@ var AggregationTests = []AggregationTestCase{
 			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "OriginCityName" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
 			  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0",
-			  countIf("FlightDelay"==true) AS "aggr__0__1-bucket___col_0"
+			  countIf("FlightDelay"==true) AS "aggr__0__1-bucket__count"
 			FROM "logs-generic-default"
 			WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))
@@ -1091,7 +1091,7 @@ var AggregationTests = []AggregationTestCase{
 		},
 		ExpectedPancakeResults: []model.QueryResultRow{
 			{Cols: []model.QueryResultCol{
-				model.NewQueryResultCol("aggr__0-bucket___col_0", uint64(553)),
+				model.NewQueryResultCol("aggr__0-bucket__count", uint64(553)),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -1106,7 +1106,7 @@ var AggregationTests = []AggregationTestCase{
 				`AND "FlightDelay"==true)`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT countIf("FlightDelay"==true) AS "aggr__0-bucket___col_0"
+			SELECT countIf("FlightDelay"==true) AS "aggr__0-bucket__count"
 			FROM "logs-generic-default"
 			WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
 			  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))`,
@@ -3580,19 +3580,19 @@ var AggregationTests = []AggregationTestCase{
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(39551)),
 				model.NewQueryResultCol("aggr__0__count", uint64(10)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(0)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(0)),
 				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 0.0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(39552)),
 				model.NewQueryResultCol("aggr__0__count", uint64(83)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(13)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(13)),
 				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 1222.65625),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(39553)),
 				model.NewQueryResultCol("aggr__0__count", uint64(83)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(9)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(9)),
 				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 931.96875),
 			}},
 		},
@@ -3632,7 +3632,7 @@ var AggregationTests = []AggregationTestCase{
 			SELECT toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
 			  "aggr__0__key_0", count(*) AS "aggr__0__count",
 			  countIf("products.product_name" ILIKE '%watch%') AS
-			  "aggr__0__1-bucket___col_0",
+			  "aggr__0__1-bucket__count",
 			  sumOrNullIf("taxful_total_price", "products.product_name" ILIKE '%watch%') AS
 			  "metric__0__1-bucket__1-metric_col_0"
 			FROM "logs-generic-default"
@@ -5746,21 +5746,21 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
 				model.NewQueryResultCol("aggr__0__key_0", "Albuquerque"),
 				model.NewQueryResultCol("aggr__0__count", uint64(4)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(1)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(1)),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(2)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
 				model.NewQueryResultCol("aggr__0__key_0", "Atlanta"),
 				model.NewQueryResultCol("aggr__0__count", uint64(5)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(0)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(0)),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(0)),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__parent_count", uint64(14)),
 				model.NewQueryResultCol("aggr__0__key_0", "Baltimore"),
 				model.NewQueryResultCol("aggr__0__count", uint64(5)),
-				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(2)),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", uint64(2)),
 				model.NewQueryResultCol("metric__0__3-bucket_col_0", uint64(0)),
 			}},
 		},
@@ -5802,7 +5802,7 @@ var AggregationTests = []AggregationTestCase{
 			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "OriginCityName" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
 			  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0",
-			  countIf("FlightDelay"==true) AS "aggr__0__1-bucket___col_0"
+			  countIf("FlightDelay"==true) AS "aggr__0__1-bucket__count"
 			FROM "logs-generic-default"
 			GROUP BY "OriginCityName" AS "aggr__0__key_0"
 			ORDER BY "aggr__0__key_0" ASC

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -453,7 +453,6 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__3-bucket___col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginCityName" AS "aggr__0__key_0",
@@ -3689,7 +3688,6 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1-bucket___col_0",
 				"metric__0__1-bucket__1-metric_col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
 				  "aggr__0__key_0",
@@ -5891,7 +5889,6 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__1-bucket___col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginCityName" AS "aggr__0__key_0",
@@ -5908,7 +5905,6 @@ var AggregationTests = []AggregationTestCase{
 			  SELECT "aggr__0__parent_count", "aggr__0__key_0", "aggr__0__count",
 				"aggr__0__3-bucket___col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 				  "OriginCityName" AS "aggr__0__key_0",

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -3630,7 +3630,26 @@ var AggregationTests = []AggregationTestCase{
 				{Cols: []model.QueryResultCol{model.NewQueryResultCol("key", int64(39553)), model.NewQueryResultCol("doc_count", uint64(83))}},
 			},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(39551)),
+				model.NewQueryResultCol("aggr__0__count", uint64(10)),
+				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(0)),
+				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 0.0),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(39552)),
+				model.NewQueryResultCol("aggr__0__count", uint64(83)),
+				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(13)),
+				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 1222.65625),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(39553)),
+				model.NewQueryResultCol("aggr__0__count", uint64(83)),
+				model.NewQueryResultCol("aggr__0__1-bucket___col_0", uint64(9)),
+				model.NewQueryResultCol("metric__0__1-bucket__1-metric_col_0", 931.96875),
+			}},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() ` +
 				`FROM ` + QuotedTableName + ` ` +
@@ -3663,7 +3682,28 @@ var AggregationTests = []AggregationTestCase{
 				`GROUP BY ` + groupBySQL("order_date", clickhouse.DateTime64, 12*time.Hour) + ` ` +
 				`ORDER BY ` + groupBySQL("order_date", clickhouse.DateTime64, 12*time.Hour),
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1-bucket___col_0",
+			  "metric__0__1-bucket__1-metric_col_0"
+			FROM (
+			  SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1-bucket___col_0",
+				"metric__0__1-bucket__1-metric_col_0",
+				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
+			
+			  FROM (
+				SELECT toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				  "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  countIf("products.product_name" ILIKE '%watch%') AS
+				  "aggr__0__1-bucket___col_0",
+				  sumOrNullIf("taxful_total_price", "products.product_name" ILIKE '%watch%')
+				  AS "metric__0__1-bucket__1-metric_col_0"
+				FROM "logs-generic-default"
+				WHERE ("order_date">=parseDateTime64BestEffort('2024-02-22T18:47:34.149Z')
+				  AND "order_date"<=parseDateTime64BestEffort('2024-02-29T18:47:34.149Z'))
+				GROUP BY toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				  "aggr__0__key_0"))
+			ORDER BY "aggr__0__order_1_rank" ASC`,
 	},
 	{ // [18]
 		TestName: "complex filters",

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -1055,7 +1055,11 @@ var AggregationTests = []AggregationTestCase{
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("value", uint64(2200))}}},
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("doc_count", uint64(553))}}},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0-bucket___col_0", uint64(553)),
+			}},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() ` +
 				`FROM ` + QuotedTableName + ` ` +
@@ -1067,7 +1071,11 @@ var AggregationTests = []AggregationTestCase{
 				`AND "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z')) ` +
 				`AND "FlightDelay"==true)`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT countIf("FlightDelay"==true) AS "aggr__0-bucket___col_0"
+			FROM "logs-generic-default"
+			WHERE ("timestamp">=parseDateTime64BestEffort('2024-02-02T13:47:16.029Z') AND
+			  "timestamp"<=parseDateTime64BestEffort('2024-02-09T13:47:16.029Z'))`,
 	},
 	{ // [6]
 		TestName: "filters",

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2932,7 +2932,7 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__stats__count", int64(188)),
 				model.NewQueryResultCol("aggr__stats__order_1", 188),
 				model.NewQueryResultCol("aggr__stats__series__key_0", int64(1713398400000/60000)),
-				model.NewQueryResultCol("aggr__stats__series__count", 79),
+				model.NewQueryResultCol("aggr__stats__series__count", 35),
 			}},
 		},
 		ExpectedSQLs: []string{
@@ -5317,8 +5317,12 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__2__count", 1),
 			}},
 			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__2__key_0", int64(1715351640000/30000)),
+				model.NewQueryResultCol("aggr__2__count", 1),
+			}},
+			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__2__key_0", int64(1715351730000/30000)),
-				model.NewQueryResultCol("aggr__2__count", 2),
+				model.NewQueryResultCol("aggr__2__count", 1),
 			}},
 		},
 		ExpectedSQLs: []string{

--- a/quesma/testdata/clients/kunkka.go
+++ b/quesma/testdata/clients/kunkka.go
@@ -448,21 +448,21 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1718794800000/3600000)),
 				model.NewQueryResultCol("aggr__0__count", uint64(2)),
 				model.NewQueryResultCol("metric__0__1_col_0", 6.600000023841858),
-				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("aggr__0__2-bucket__count", 0),
 				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1718798400000/3600000)),
 				model.NewQueryResultCol("aggr__0__count", uint64(3)),
 				model.NewQueryResultCol("metric__0__1_col_0", 12.100000143051147),
-				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("aggr__0__2-bucket__count", 0),
 				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__0__key_0", int64(1718802000000/3600000)),
 				model.NewQueryResultCol("aggr__0__count", uint64(2)),
 				model.NewQueryResultCol("metric__0__1_col_0", 4.399999976158142),
-				model.NewQueryResultCol("aggr__0__2-bucket___col_0", uint64(1)),
+				model.NewQueryResultCol("aggr__0__2-bucket__count", uint64(1)),
 				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 1.0),
 			}},
 		},
@@ -491,7 +491,7 @@ var KunkkaTests = []testdata.AggregationTestCase{
 			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
 			  "aggr__0__key_0", count(*) AS "aggr__0__count",
 			  sumOrNull("spent") AS "metric__0__1_col_0",
-			  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket___col_0",
+			  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket__count",
 			  sumOrNullIf("multiplier", "message" iLIKE '%started%') AS
 			  "metric__0__2-bucket__2-metric_col_0"
 			FROM "logs-generic-default"

--- a/quesma/testdata/clients/kunkka.go
+++ b/quesma/testdata/clients/kunkka.go
@@ -488,25 +488,16 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				`ORDER BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000)`,
 		},
 		ExpectedPancakeSQL: `
-			SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
-			  "aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0"
-			FROM (
-			  SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
-				"aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0",
-				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			  FROM (
-				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
-				  "aggr__0__key_0",
-				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
-				  sumOrNull(sumOrNull("spent")) OVER (PARTITION BY "aggr__0__key_0") AS
-				  "metric__0__1_col_0",
-				  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket___col_0",
-				  sumOrNullIf("multiplier", "message" iLIKE '%started%') AS
-				  "metric__0__2-bucket__2-metric_col_0"
-				FROM "logs-generic-default"
-				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
-				  "aggr__0__key_0"))
-			ORDER BY "aggr__0__order_1_rank" ASC`,
+			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__0__key_0", count(*) AS "aggr__0__count",
+			  sumOrNull("spent") AS "metric__0__1_col_0",
+			  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket___col_0",
+			  sumOrNullIf("multiplier", "message" iLIKE '%started%') AS
+			  "metric__0__2-bucket__2-metric_col_0"
+			FROM "logs-generic-default"
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+			  "aggr__0__key_0"
+			ORDER BY "aggr__0__key_0" ASC`,
 	},
 	{ // [2]
 		TestName: "clients/kunkka/test_1, used to be broken before aggregations merge fix",

--- a/quesma/testdata/clients/kunkka.go
+++ b/quesma/testdata/clients/kunkka.go
@@ -187,7 +187,29 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				}},
 			},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718794800000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(2)),
+				model.NewQueryResultCol("metric__0__1_col_0", 6.600000023841858),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718798400000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(3)),
+				model.NewQueryResultCol("metric__0__1_col_0", 12.100000143051147),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718802000000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(2)),
+				model.NewQueryResultCol("metric__0__1_col_0", 4.399999976158142),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", uint64(1)),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 1.0),
+			}},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() FROM (SELECT 1 FROM ` + testdata.QuotedTableName + ` LIMIT 10000)`,
 			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000), sumOrNull("spent") ` +
@@ -209,7 +231,27 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				`GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) ` +
 				`ORDER BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000)`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
+			  "aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0"
+			FROM (
+			  SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
+				"aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0",
+				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
+			
+			  FROM (
+				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+				  "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sumOrNull(sumOrNull("spent")) OVER (PARTITION BY "aggr__0__key_0") AS
+				  "metric__0__1_col_0",
+				  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket___col_0",
+				  sumOrNullIf("multiplier", "message" iLIKE '%started%') AS
+				  "metric__0__2-bucket__2-metric_col_0"
+				FROM "logs-generic-default"
+				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+				  "aggr__0__key_0"))
+			ORDER BY "aggr__0__order_1_rank" ASC`,
 	},
 	{ // [1]
 		TestName: "it's the same input as in previous test, but with the original output from Elastic." +

--- a/quesma/testdata/clients/kunkka.go
+++ b/quesma/testdata/clients/kunkka.go
@@ -238,7 +238,6 @@ var KunkkaTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
 				"aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
 				  "aggr__0__key_0",
@@ -495,7 +494,6 @@ var KunkkaTests = []testdata.AggregationTestCase{
 			  SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
 				"aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0",
 				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
-			
 			  FROM (
 				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
 				  "aggr__0__key_0",

--- a/quesma/testdata/clients/kunkka.go
+++ b/quesma/testdata/clients/kunkka.go
@@ -355,7 +355,7 @@ var KunkkaTests = []testdata.AggregationTestCase{
 								},
 								"doc_count": 2,
 								"key": 1718794800000,
-								"key_as_string": "2024/06/19 13:00:00"
+								"key_as_string": "2024-06-19T11:00:00.000"
 							},
 							{
 								"1": {
@@ -369,7 +369,7 @@ var KunkkaTests = []testdata.AggregationTestCase{
 								},
 								"doc_count": 3,
 								"key": 1718798400000,
-								"key_as_string": "2024/06/19 14:00:00"
+								"key_as_string": "2024-06-19T12:00:00.000"
 							},
 							{
 								"1": {
@@ -383,7 +383,7 @@ var KunkkaTests = []testdata.AggregationTestCase{
 								},
 								"doc_count": 2,
 								"key": 1718802000000,
-								"key_as_string": "2024/06/19 15:00:00"
+								"key_as_string": "2024-06-19T13:00:00.000"
 							}
 						]
 					}
@@ -444,7 +444,29 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				}},
 			},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718794800000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(2)),
+				model.NewQueryResultCol("metric__0__1_col_0", 6.600000023841858),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718798400000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(3)),
+				model.NewQueryResultCol("metric__0__1_col_0", 12.100000143051147),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", 0),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 0),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1718802000000/3600000)),
+				model.NewQueryResultCol("aggr__0__count", uint64(2)),
+				model.NewQueryResultCol("metric__0__1_col_0", 4.399999976158142),
+				model.NewQueryResultCol("aggr__0__2-bucket___col_0", uint64(1)),
+				model.NewQueryResultCol("metric__0__2-bucket__2-metric_col_0", 1.0),
+			}},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() FROM (SELECT 1 FROM ` + testdata.QuotedTableName + ` LIMIT 10000)`,
 			`SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000), sumOrNull("spent") ` +
@@ -466,7 +488,27 @@ var KunkkaTests = []testdata.AggregationTestCase{
 				`GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) ` +
 				`ORDER BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000)`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
+			  "aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0"
+			FROM (
+			  SELECT "aggr__0__key_0", "aggr__0__count", "metric__0__1_col_0",
+				"aggr__0__2-bucket___col_0", "metric__0__2-bucket__2-metric_col_0",
+				dense_rank() OVER (ORDER BY "aggr__0__key_0" ASC) AS "aggr__0__order_1_rank"
+			
+			  FROM (
+				SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+				  "aggr__0__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__0__key_0") AS "aggr__0__count",
+				  sumOrNull(sumOrNull("spent")) OVER (PARTITION BY "aggr__0__key_0") AS
+				  "metric__0__1_col_0",
+				  countIf("message" iLIKE '%started%') AS "aggr__0__2-bucket___col_0",
+				  sumOrNullIf("multiplier", "message" iLIKE '%started%') AS
+				  "metric__0__2-bucket__2-metric_col_0"
+				FROM "logs-generic-default"
+				GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 3600000) AS
+				  "aggr__0__key_0"))
+			ORDER BY "aggr__0__order_1_rank" ASC`,
 	},
 	{ // [2]
 		TestName: "clients/kunkka/test_1, used to be broken before aggregations merge fix",

--- a/quesma/testdata/clients/ophelia.go
+++ b/quesma/testdata/clients/ophelia.go
@@ -2122,7 +2122,8 @@ var OpheliaTests = []testdata.AggregationTestCase{
 				  "aggr__2__8__count",
 				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
 				  "aggr__2__8__key_0") AS "aggr__2__8__order_1",
-				  sumOrNull("total") AS "metric__2__8__1_col_0",
+				  sumOrNull(sumOrNull("total")) OVER (PARTITION BY "aggr__2__key_0",
+				  "aggr__2__8__key_0") AS "metric__2__8__1_col_0",
 				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0", "aggr__2__8__key_0") AS
 				  "aggr__2__8__4__parent_count", "organName" AS "aggr__2__8__4__key_0",
 				  count(*) AS "aggr__2__8__4__count"

--- a/quesma/util/sql_pretty_fmt.go
+++ b/quesma/util/sql_pretty_fmt.go
@@ -4,7 +4,6 @@ package util
 
 import (
 	"github.com/DataDog/go-sqllexer"
-	"github.com/k0kubun/pp"
 	"strings"
 )
 
@@ -70,10 +69,6 @@ func SqlPrettyPrint(sqlData []byte) string {
 
 		// Add new line if needed
 		if newLineKeywords[token.Value] {
-			if token.Value == "FROM" {
-				pp.Println("JM sql pretty", sb.String())
-				pp.Println("JM2", tokens[tokenIdx-1])
-			}
 			sb.WriteString("\n")
 			lineLength = 0
 			isBreakIndent = false

--- a/quesma/util/sql_pretty_fmt.go
+++ b/quesma/util/sql_pretty_fmt.go
@@ -4,6 +4,7 @@ package util
 
 import (
 	"github.com/DataDog/go-sqllexer"
+	"github.com/k0kubun/pp"
 	"strings"
 )
 
@@ -69,6 +70,10 @@ func SqlPrettyPrint(sqlData []byte) string {
 
 		// Add new line if needed
 		if newLineKeywords[token.Value] {
+			if token.Value == "FROM" {
+				pp.Println("JM sql pretty", sb.String())
+				pp.Println("JM2", tokens[tokenIdx-1])
+			}
 			sb.WriteString("\n")
 			lineLength = 0
 			isBreakIndent = false
@@ -124,6 +129,9 @@ func SqlPrettyPrint(sqlData []byte) string {
 
 		// Break line if needed
 		if lineLength > 0 && len(token.Value)+lineLength > lineLengthLimit {
+			if token.Type == sqllexer.WS && tokenIdx+1 < len(tokens) && newLineKeywords[tokens[tokenIdx+1].Value] {
+				continue // we will break line in next token anyway, no need to double break
+			}
 			lineLength = 0
 			isBreakIndent = true
 			sb.WriteString("\n")


### PR DESCRIPTION
Now, we can use filters in pancakes:
1. It fixes many panels in flight sample dashboards.
2. Feature parity and even exceed original implementation.

While implementing that, I needed to fix some more issues:
- the `doc_count` was ignored in tests, fixed it while also addressing underlying issue
- our query simplification got bugs and fixed that too

The code is a bit more complex, but I prefer smaller ones. After `filters`, `range`, and `dataRange`, I will do the final refactor, though I still need to think through a few cases.
