### PR TITLE
Ast cleanup

### DIFF
--- a/quesma/model/base_visitor.go
+++ b/quesma/model/base_visitor.go
@@ -6,7 +6,6 @@ type BaseExprVisitor struct {
 	OverrideVisitFunction       func(b *BaseExprVisitor, e FunctionExpr) interface{}
 	OverrideVisitMultiFunction  func(b *BaseExprVisitor, e MultiFunctionExpr) interface{}
 	OverrideVisitLiteral        func(b *BaseExprVisitor, l LiteralExpr) interface{}
-	OverrideVisitString         func(b *BaseExprVisitor, e StringExpr) interface{}
 	OverrideVisitInfix          func(b *BaseExprVisitor, e InfixExpr) interface{}
 	OverrideVisitColumnRef      func(b *BaseExprVisitor, e ColumnRef) interface{}
 	OverrideVisitPrefixExpr     func(b *BaseExprVisitor, e PrefixExpr) interface{}
@@ -97,13 +96,6 @@ func (v *BaseExprVisitor) VisitMultiFunction(e MultiFunctionExpr) interface{} {
 		return v.OverrideVisitMultiFunction(v, e)
 	}
 	return MultiFunctionExpr{Name: e.Name, Args: v.VisitChildren(e.Args)}
-}
-
-func (v *BaseExprVisitor) VisitString(e StringExpr) interface{} {
-	if v.OverrideVisitString != nil {
-		return v.OverrideVisitString(v, e)
-	}
-	return e
 }
 
 func (v *BaseExprVisitor) VisitTableRef(e TableRef) interface{} {

--- a/quesma/model/base_visitor.go
+++ b/quesma/model/base_visitor.go
@@ -4,7 +4,6 @@ package model
 
 type BaseExprVisitor struct {
 	OverrideVisitFunction       func(b *BaseExprVisitor, e FunctionExpr) interface{}
-	OverrideVisitMultiFunction  func(b *BaseExprVisitor, e MultiFunctionExpr) interface{}
 	OverrideVisitLiteral        func(b *BaseExprVisitor, l LiteralExpr) interface{}
 	OverrideVisitInfix          func(b *BaseExprVisitor, e InfixExpr) interface{}
 	OverrideVisitColumnRef      func(b *BaseExprVisitor, e ColumnRef) interface{}
@@ -89,13 +88,6 @@ func (v *BaseExprVisitor) VisitArrayAccess(e ArrayAccess) interface{} {
 	columnRef := e.ColumnRef.Accept(v).(ColumnRef)
 	index := e.Index.Accept(v).(Expr)
 	return NewArrayAccess(columnRef, index)
-}
-
-func (v *BaseExprVisitor) VisitMultiFunction(e MultiFunctionExpr) interface{} {
-	if v.OverrideVisitMultiFunction != nil {
-		return v.OverrideVisitMultiFunction(v, e)
-	}
-	return MultiFunctionExpr{Name: e.Name, Args: v.VisitChildren(e.Args)}
 }
 
 func (v *BaseExprVisitor) VisitTableRef(e TableRef) interface{} {

--- a/quesma/model/bucket_aggregations/dateRange.go
+++ b/quesma/model/bucket_aggregations/dateRange.go
@@ -33,17 +33,17 @@ func (interval DateTimeInterval) ToSQLSelectQuery(fieldName string) model.Expr {
 	if interval.Begin != UnboundedInterval && interval.End != UnboundedInterval {
 		return model.NewCountFunc(model.NewFunction("if",
 			model.NewInfixExpr(
-				model.NewInfixExpr(model.NewColumnRef(fieldName), " >= ", model.NewStringExpr(interval.Begin)),
+				model.NewInfixExpr(model.NewColumnRef(fieldName), " >= ", model.NewLiteral(interval.Begin)),
 				"AND",
-				model.NewInfixExpr(model.NewColumnRef(fieldName), " < ", model.NewStringExpr(interval.End)),
+				model.NewInfixExpr(model.NewColumnRef(fieldName), " < ", model.NewLiteral(interval.End)),
 			),
 			model.NewLiteral(1), model.NewLiteral("NULL")))
 	} else if interval.Begin != UnboundedInterval {
 		return model.NewCountFunc(model.NewFunction("if",
-			model.NewInfixExpr(model.NewColumnRef(fieldName), " >= ", model.NewStringExpr(interval.Begin)), model.NewLiteral(1), model.NewLiteral("NULL")))
+			model.NewInfixExpr(model.NewColumnRef(fieldName), " >= ", model.NewLiteral(interval.Begin)), model.NewLiteral(1), model.NewLiteral("NULL")))
 	} else if interval.End != UnboundedInterval {
 		return model.NewCountFunc(model.NewFunction("if",
-			model.NewInfixExpr(model.NewColumnRef(fieldName), " < ", model.NewStringExpr(interval.End)), model.NewLiteral(1), model.NewLiteral("NULL")))
+			model.NewInfixExpr(model.NewColumnRef(fieldName), " < ", model.NewLiteral(interval.End)), model.NewLiteral(1), model.NewLiteral("NULL")))
 	}
 	return model.NewCountFunc()
 }
@@ -53,7 +53,7 @@ func (interval DateTimeInterval) ToSQLSelectQuery(fieldName string) model.Expr {
 // It's only 1 more field to our SELECT query, so it shouldn't be a performance issue.
 func (interval DateTimeInterval) BeginTimestampToSQL() (sqlSelect model.Expr, selectNeeded bool) {
 	if interval.Begin != UnboundedInterval {
-		return model.NewFunction("toInt64", model.NewFunction("toUnixTimestamp", model.NewStringExpr(interval.Begin))), true
+		return model.NewFunction("toInt64", model.NewFunction("toUnixTimestamp", model.NewLiteral(interval.Begin))), true
 	}
 	return nil, false
 }
@@ -63,7 +63,7 @@ func (interval DateTimeInterval) BeginTimestampToSQL() (sqlSelect model.Expr, se
 // It's only 1 more field to our SELECT query, so it isn't a performance issue.
 func (interval DateTimeInterval) EndTimestampToSQL() (sqlSelect model.Expr, selectNeeded bool) {
 	if interval.End != UnboundedInterval {
-		return model.NewFunction("toInt64", model.NewFunction("toUnixTimestamp", model.NewStringExpr(interval.End))), true
+		return model.NewFunction("toInt64", model.NewFunction("toUnixTimestamp", model.NewLiteral(interval.End))), true
 	}
 	return nil, false
 }

--- a/quesma/model/bucket_aggregations/range.go
+++ b/quesma/model/bucket_aggregations/range.go
@@ -50,7 +50,7 @@ func (interval Interval) ToSQLSelectQuery(columnExpr model.Expr) model.Expr {
 		return model.NewFunction("count")
 	}
 	// count(if(sql, 1, NULL))
-	return model.NewFunction("count", model.NewFunction("if", sql, model.NewLiteral(1), model.NewStringExpr("NULL")))
+	return model.NewFunction("count", model.NewFunction("if", sql, model.NewLiteral(1), model.NewLiteral("NULL")))
 }
 
 func (interval Interval) ToWhereClause(field model.Expr) model.Expr { // returns a condition for the interval, just like we want it in SQL's WHERE

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -74,16 +74,6 @@ func (e FunctionExpr) Accept(v ExprVisitor) interface{} {
 	return v.VisitFunction(e)
 }
 
-// MultiFunctionExpr represents call of a function with multiple arguments lists, e.g. `quantile(level)(expr)`
-type MultiFunctionExpr struct {
-	Name string
-	Args []Expr
-}
-
-func (e MultiFunctionExpr) Accept(v ExprVisitor) interface{} {
-	return v.VisitMultiFunction(e)
-}
-
 type LiteralExpr struct {
 	Value any
 }
@@ -261,7 +251,6 @@ func (e JoinExpr) Accept(v ExprVisitor) interface{} {
 
 type ExprVisitor interface {
 	VisitFunction(e FunctionExpr) interface{}
-	VisitMultiFunction(e MultiFunctionExpr) interface{}
 	VisitLiteral(l LiteralExpr) interface{}
 	VisitInfix(e InfixExpr) interface{}
 	VisitColumnRef(e ColumnRef) interface{}

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -92,16 +92,6 @@ func (e LiteralExpr) Accept(v ExprVisitor) interface{} {
 	return v.VisitLiteral(e)
 }
 
-// Deprecated
-type StringExpr struct {
-	// StringExpr is just like LiteralExpr with string Value, but when rendering we don't quote it.
-	Value string
-}
-
-func (e StringExpr) Accept(v ExprVisitor) interface{} {
-	return v.VisitString(e)
-}
-
 type InfixExpr struct {
 	Left  Expr
 	Op    string
@@ -121,10 +111,6 @@ func NewCountFunc(args ...Expr) FunctionExpr {
 }
 
 var NewWildcardExpr = LiteralExpr{Value: "*"}
-
-func NewStringExpr(value string) StringExpr {
-	return StringExpr{Value: value}
-}
 
 func NewLiteral(value any) LiteralExpr {
 	return LiteralExpr{Value: value}
@@ -277,7 +263,6 @@ type ExprVisitor interface {
 	VisitFunction(e FunctionExpr) interface{}
 	VisitMultiFunction(e MultiFunctionExpr) interface{}
 	VisitLiteral(l LiteralExpr) interface{}
-	VisitString(e StringExpr) interface{}
 	VisitInfix(e InfixExpr) interface{}
 	VisitColumnRef(e ColumnRef) interface{}
 	VisitPrefixExpr(e PrefixExpr) interface{}

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -74,10 +74,6 @@ func (v *renderer) VisitLiteral(l LiteralExpr) interface{} {
 	}
 }
 
-func (v *renderer) VisitString(e StringExpr) interface{} {
-	return e.Value
-}
-
 func (v *renderer) VisitMultiFunction(f MultiFunctionExpr) interface{} {
 	args := make([]string, 0)
 	for _, arg := range f.Args {

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -74,15 +74,6 @@ func (v *renderer) VisitLiteral(l LiteralExpr) interface{} {
 	}
 }
 
-func (v *renderer) VisitMultiFunction(f MultiFunctionExpr) interface{} {
-	args := make([]string, 0)
-	for _, arg := range f.Args {
-		r := "(" + arg.Accept(v).(string) + ")"
-		args = append(args, r)
-	}
-	return f.Name + strings.Join(args, "")
-}
-
 func (v *renderer) VisitInfix(e InfixExpr) interface{} {
 	var lhs, rhs interface{} // TODO FOR NOW LITTLE PARANOID BUT HELPS ME NOT SEE MANY PANICS WHEN TESTING
 	if e.Left != nil {

--- a/quesma/model/noop_visitor.go
+++ b/quesma/model/noop_visitor.go
@@ -6,20 +6,19 @@ type NoOpVisitor struct {
 	ExprVisitor
 }
 
-func (NoOpVisitor) VisitFunction(e FunctionExpr) interface{}           { return e }
-func (NoOpVisitor) VisitMultiFunction(e MultiFunctionExpr) interface{} { return e }
-func (NoOpVisitor) VisitLiteral(l LiteralExpr) interface{}             { return l }
-func (NoOpVisitor) VisitInfix(e InfixExpr) interface{}                 { return e }
-func (NoOpVisitor) VisitColumnRef(e ColumnRef) interface{}             { return e }
-func (NoOpVisitor) VisitPrefixExpr(e PrefixExpr) interface{}           { return e }
-func (NoOpVisitor) VisitNestedProperty(e NestedProperty) interface{}   { return e }
-func (NoOpVisitor) VisitArrayAccess(e ArrayAccess) interface{}         { return e }
-func (NoOpVisitor) VisitOrderByExpr(e OrderByExpr) interface{}         { return e }
-func (NoOpVisitor) VisitDistinctExpr(e DistinctExpr) interface{}       { return e }
-func (NoOpVisitor) VisitTableRef(e TableRef) interface{}               { return e }
-func (NoOpVisitor) VisitAliasedExpr(e AliasedExpr) interface{}         { return e }
-func (NoOpVisitor) VisitSelectCommand(e SelectCommand) interface{}     { return e }
-func (NoOpVisitor) VisitWindowFunction(f WindowFunction) interface{}   { return f }
-func (NoOpVisitor) VisitParenExpr(e ParenExpr) interface{}             { return e }
-func (NoOpVisitor) VisitLambdaExpr(e LambdaExpr) interface{}           { return e }
-func (NoOpVisitor) VisitJoinExpr(e JoinExpr) interface{}               { return e }
+func (NoOpVisitor) VisitFunction(e FunctionExpr) interface{}         { return e }
+func (NoOpVisitor) VisitLiteral(l LiteralExpr) interface{}           { return l }
+func (NoOpVisitor) VisitInfix(e InfixExpr) interface{}               { return e }
+func (NoOpVisitor) VisitColumnRef(e ColumnRef) interface{}           { return e }
+func (NoOpVisitor) VisitPrefixExpr(e PrefixExpr) interface{}         { return e }
+func (NoOpVisitor) VisitNestedProperty(e NestedProperty) interface{} { return e }
+func (NoOpVisitor) VisitArrayAccess(e ArrayAccess) interface{}       { return e }
+func (NoOpVisitor) VisitOrderByExpr(e OrderByExpr) interface{}       { return e }
+func (NoOpVisitor) VisitDistinctExpr(e DistinctExpr) interface{}     { return e }
+func (NoOpVisitor) VisitTableRef(e TableRef) interface{}             { return e }
+func (NoOpVisitor) VisitAliasedExpr(e AliasedExpr) interface{}       { return e }
+func (NoOpVisitor) VisitSelectCommand(e SelectCommand) interface{}   { return e }
+func (NoOpVisitor) VisitWindowFunction(f WindowFunction) interface{} { return f }
+func (NoOpVisitor) VisitParenExpr(e ParenExpr) interface{}           { return e }
+func (NoOpVisitor) VisitLambdaExpr(e LambdaExpr) interface{}         { return e }
+func (NoOpVisitor) VisitJoinExpr(e JoinExpr) interface{}             { return e }

--- a/quesma/model/noop_visitor.go
+++ b/quesma/model/noop_visitor.go
@@ -9,7 +9,6 @@ type NoOpVisitor struct {
 func (NoOpVisitor) VisitFunction(e FunctionExpr) interface{}           { return e }
 func (NoOpVisitor) VisitMultiFunction(e MultiFunctionExpr) interface{} { return e }
 func (NoOpVisitor) VisitLiteral(l LiteralExpr) interface{}             { return l }
-func (NoOpVisitor) VisitString(e StringExpr) interface{}               { return e }
 func (NoOpVisitor) VisitInfix(e InfixExpr) interface{}                 { return e }
 func (NoOpVisitor) VisitColumnRef(e ColumnRef) interface{}             { return e }
 func (NoOpVisitor) VisitPrefixExpr(e PrefixExpr) interface{}           { return e }

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -117,9 +117,11 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 		for _, usersPercent := range usersPercents {
 			percentAsFloat := metricsAggr.Percentiles[usersPercent]
 			query.SelectCommand.Columns = append(query.SelectCommand.Columns, model.NewAliasedExpr(
-				model.MultiFunctionExpr{
-					Name: "quantiles",
-					Args: []model.Expr{model.NewLiteral(percentAsFloat), getFirstExpression()}},
+				model.FunctionExpr{
+					// Rare function that has two brackets: quantiles(0.5)(x)
+					// https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/quantiles
+					Name: fmt.Sprintf("quantiles(%f)", percentAsFloat),
+					Args: []model.Expr{getFirstExpression()}},
 				fmt.Sprintf("quantile_%s", usersPercent),
 			))
 

--- a/quesma/queryparser/pancake_aggregation_parser_metrics.go
+++ b/quesma/queryparser/pancake_aggregation_parser_metrics.go
@@ -34,9 +34,11 @@ func generateMetricSelectedColumns(ctx context.Context, metricsAggr metricsAggre
 		for _, usersPercent := range usersPercents {
 			percentAsFloat := metricsAggr.Percentiles[usersPercent]
 			result = append(result, model.NewAliasedExpr(
-				model.MultiFunctionExpr{
-					Name: "quantiles",
-					Args: []model.Expr{model.NewLiteral(percentAsFloat), getFirstExpression()}},
+				model.FunctionExpr{
+					// Rare function that has two brackets: quantiles(0.5)(x)
+					// https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/quantiles
+					Name: fmt.Sprintf("quantiles(%f)", percentAsFloat),
+					Args: []model.Expr{getFirstExpression()}},
 				fmt.Sprintf("quantile_%s", usersPercent),
 			))
 


### PR DESCRIPTION
Remove two AST types:
- deprecated `StringExpr`
- `MultiFunctionExpr`, it is a weird construct for quantiles, in fact this should be part of a function name. Got discussion with @nablaone 