### PR TITLE
Move aliases and types to schema overrides

### DIFF
--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -31,34 +31,44 @@ processors:
       indexes:
         kibana_sample_data_ecommerce:
           enabled: true
-          mappings:
-            products.manufacturer: "text"
-            products.product_name: "text"
-            geoip.location: "geo_point"
-            category: "text"
-            manufacturer: "text"
+          schemaOverrides:
+            fields:
+              "geoip.location":
+                type: geo_point
+              "products.manufacturer":
+                type: text
+              "products.product_name":
+                type: text
+              category:
+                type: text
+              manufacturer:
+                type: text
         kibana_sample_data_flights:
           enabled: true
-          mappings:
-            DestLocation: "geo_point"
-            OriginLocation: "geo_point"
+          schemaOverrides:
+            fields:
+              "DestLocation":
+                type: geo_point
+              "OriginLocation":
+                type: geo_point
         logs-generic-default:
           enabled: true
-          static-schema:
+          schemaOverrides:
             fields:
+              "@timestamp":
+                type: date
+                isTimestampField: true
+              timestamp:
+                type: alias
+                targetColumnName: "@timestamp"
               message:
-                type: "text"
-              host.name:
-                type: "keyword"
+                type: text
               service.name:
                 type: "keyword"
               source:
                 type: "keyword"
               severity:
                 type: "keyword"
-              severity_alias:
-                type: "alias"
-                aliased-field: "severity"
           fullTextFields: [ "message", "host.name" ]
 
 

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -55,9 +55,6 @@ processors:
           enabled: true
           schemaOverrides:
             fields:
-              "@timestamp":
-                type: date
-                isTimestampField: true
               timestamp:
                 type: alias
                 targetColumnName: "@timestamp"

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -62,7 +62,7 @@ processors:
                 type: text
               "host.name":
                 type: "keyword"
-              service.name:
+              "service.name":
                 type: "keyword"
               source:
                 type: "keyword"

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -60,6 +60,8 @@ processors:
                 targetColumnName: "@timestamp"
               message:
                 type: text
+              "host.name":
+                type: "keyword"
               service.name:
                 type: "keyword"
               source:

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -146,7 +146,9 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter TableColumNameF
 			fType = "Nullable(DateTime64)"
 		case schema.TypeDate.Name:
 			fType = "Nullable(Date)"
-			// TODO if someone sets `type: date` to a field in schemaOverrides AND this is a timestamp field for which we have dedicated logic (use DateTime64 + add DEFAULT now64())
+			// TODO: This (and Nullable(DateTime64) above) can be problematic for ingest when when set by user explicitly. We should either not use Nullable in this case
+			// or add some validation logic so that its handled properly.
+			// Example if someone sets `type: date` to a field in schemaOverrides AND this is a timestamp field for which we have dedicated logic (use DateTime64 + add DEFAULT now64())
 			// Ingest will FAIL creating table with "Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled"
 		case schema.TypeFloat.Name:
 			fType = "Nullable(Float64)"

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -146,6 +146,7 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter TableColumNameF
 			fType = "Nullable(DateTime64)"
 		case schema.TypeDate.Name:
 			fType = "Nullable(Date)"
+			// TODO if someone sets this in schemaOverrides AND this is a timestamp field, we end up with "Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled"
 		case schema.TypeFloat.Name:
 			fType = "Nullable(Float64)"
 		case schema.TypeBoolean.Name:

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -146,7 +146,8 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter TableColumNameF
 			fType = "Nullable(DateTime64)"
 		case schema.TypeDate.Name:
 			fType = "Nullable(Date)"
-			// TODO if someone sets this in schemaOverrides AND this is a timestamp field, we end up with "Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled"
+			// TODO if someone sets `type: date` to a field in schemaOverrides AND this is a timestamp field for which we have dedicated logic (use DateTime64 + add DEFAULT now64())
+			// Ingest will FAIL creating table with "Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled"
 		case schema.TypeFloat.Name:
 			fType = "Nullable(Float64)"
 		case schema.TypeBoolean.Name:

--- a/quesma/clickhouse/table.go
+++ b/quesma/clickhouse/table.go
@@ -21,8 +21,8 @@ type Table struct {
 	Config       *ChTableConfig
 	Created      bool // do we need to create it during first insert
 	indexes      []IndexStatement
-	aliases      map[string]string //deprecated TODO looks like we've reached the point where this becomes a problem
-	//we should use aliases directly from configuration, not store them here
+	aliases      map[string]string //deprecated
+	// TODO: we should use aliases directly from configuration, not store them here
 	Comment          string // this human-readable comment
 	CreateTableQuery string
 	TimestampColumn  *string

--- a/quesma/clickhouse/table.go
+++ b/quesma/clickhouse/table.go
@@ -165,15 +165,8 @@ func (t *Table) AliasFields(ctx context.Context) []*Column {
 	return aliasFields
 }
 
-func (t *Table) AliasList() []config.FieldAlias {
-	result := make([]config.FieldAlias, 0)
-	for key, val := range t.aliases {
-		result = append(result, config.FieldAlias{
-			SourceFieldName: key,
-			TargetFieldName: val,
-		})
-	}
-	return result
+func (t *Table) Aliases() map[string]string {
+	return t.aliases
 }
 
 func (t *Table) GetAttributesList() []Attribute {

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -156,11 +156,6 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]string, d
 	for table, columns := range tables {
 		if indexConfig, found := td.cfg.IndexConfig[table]; found {
 			if indexConfig.Enabled {
-				for colName := range columns {
-					if _, exists := indexConfig.Aliases[colName]; exists {
-						logger.Error().Msgf("column [%s] clashes with an existing alias, table [%s]", colName, table)
-					}
-				}
 				comment := td.tableComment(databaseName, table)
 				createTableQuery := td.createTableQuery(databaseName, table)
 				configuredTables[table] = discoveredTable{table, columns, indexConfig, comment, createTableQuery}

--- a/quesma/model/typical_queries/hits.go
+++ b/quesma/model/typical_queries/hits.go
@@ -125,9 +125,9 @@ func (query Hits) addAndHighlightHit(hit *model.SearchHit, resultRow *model.Quer
 	}
 
 	// TODO: highlight and field checks
-	for _, alias := range query.table.AliasList() {
-		if v, ok := hit.Fields[alias.TargetFieldName]; ok {
-			hit.Fields[alias.SourceFieldName] = v
+	for fieldName, target := range query.table.Aliases() {
+		if v, ok := hit.Fields[target]; ok {
+			hit.Fields[fieldName] = v
 		}
 	}
 }

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -15,7 +15,6 @@ import (
 	"quesma/elasticsearch/elasticsearch_field_types"
 	"quesma/index"
 	"quesma/network"
-	"slices"
 	"strings"
 )
 
@@ -93,9 +92,10 @@ func (c *QuesmaConfiguration) IsFullTextMatchField(indexName, fieldName string) 
 }
 
 func (c *QuesmaConfiguration) AliasFields(indexName string) map[string]FieldAlias {
-	if indexConfig, found := c.IndexConfig[indexName]; found {
-		return indexConfig.Aliases
-	}
+	//if indexConfig, found := c.IndexConfig[indexName]; found {
+	//	return indexConfig.Aliases
+	//}
+	// why e'd need that
 	return map[string]FieldAlias{}
 }
 
@@ -126,10 +126,10 @@ func Load() QuesmaConfiguration {
 	for name, idxConfig := range config.IndexConfig {
 		idxConfig.Name = name
 		config.IndexConfig[name] = idxConfig
-		if idxConfig.SchemaConfiguration != nil {
-			for fieldName, configuration := range idxConfig.SchemaConfiguration.Fields {
-				configuration.Name = fieldName
-				idxConfig.SchemaConfiguration.Fields[fieldName] = configuration
+		if idxConfig.SchemaOverrides != nil {
+			for fieldName, configuration := range idxConfig.SchemaOverrides.Fields {
+				//configuration.Name = fieldName
+				idxConfig.SchemaOverrides.Fields[fieldName] = configuration
 			}
 		}
 	}
@@ -195,9 +195,9 @@ func (c *QuesmaConfiguration) validateDeprecated(indexName IndexConfiguration, r
 	if len(indexName.FullTextFields) > 0 {
 		fmt.Printf("index configuration %s contains deprecated field 'fullTextFields'", indexName.Name)
 	}
-	if len(indexName.Aliases) > 0 {
-		fmt.Printf("index configuration %s contains deprecated field 'aliases'", indexName.Name)
-	}
+	//if len(indexName.Aliases) > 0 {
+	//	fmt.Printf("index configuration %s contains deprecated field 'aliases'", indexName.Name)
+	//}
 	if len(indexName.IgnoredFields) > 0 {
 		fmt.Printf("index configuration %s contains deprecated field 'ignoredFields'", indexName.Name)
 	}
@@ -348,40 +348,40 @@ Quesma Configuration:
 }
 
 func (c *QuesmaConfiguration) validateSchemaConfiguration(config IndexConfiguration, err error) error {
-	if config.SchemaConfiguration == nil {
+	if config.SchemaOverrides == nil {
 		return err
 	}
 
 	fmt.Println("schema configuration is not yet in use!")
 
-	for fieldName, fieldConfig := range config.SchemaConfiguration.Fields {
+	for fieldName, fieldConfig := range config.SchemaOverrides.Fields {
 		if fieldConfig.Type == "" {
 			err = multierror.Append(err, fmt.Errorf("field %s in index %s has no type", fieldName, config.Name))
 		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) {
 			err = multierror.Append(err, fmt.Errorf("field %s in index %s has invalid type %s", fieldName, config.Name, fieldConfig.Type))
 		}
 
-		if slices.Contains(config.SchemaConfiguration.Ignored, fieldName.AsString()) {
-			err = multierror.Append(err, fmt.Errorf("field %s in index %s is both enabled and ignored", fieldName, config.Name))
-		}
+		//if slices.Contains(config.SchemaOverrides.Ignored, fieldName.AsString()) {
+		//	err = multierror.Append(err, fmt.Errorf("field %s in index %s is both enabled and ignored", fieldName, config.Name))
+		//}
 
-		if field, found := config.SchemaConfiguration.Fields[fieldName]; found && field.Type.AsString() == elasticsearch_field_types.FieldTypeAlias && field.AliasedField == "" {
-			err = multierror.Append(err, fmt.Errorf("field %s in index %s is aliased to an empty field", fieldName, config.Name))
-		}
+		//if field, found := config.SchemaOverrides.Fields[fieldName]; found && field.Type.AsString() == elasticsearch_field_types.FieldTypeAlias && field.AliasedField == "" {
+		//	err = multierror.Append(err, fmt.Errorf("field %s in index %s is aliased to an empty field", fieldName, config.Name))
+		//}
 
-		if countPrimaryKeys(config) > 1 {
-			err = multierror.Append(err, fmt.Errorf("index %s has more than one primary key", config.Name))
-		}
+		//if countPrimaryKeys(config) > 1 {
+		//	err = multierror.Append(err, fmt.Errorf("index %s has more than one primary key", config.Name))
+		//}
 	}
 
 	return err
 }
 
-func countPrimaryKeys(config IndexConfiguration) (count int) {
-	for _, configuration := range config.SchemaConfiguration.Fields {
-		if configuration.IsPrimaryKey {
-			count++
-		}
-	}
-	return count
-}
+//func countPrimaryKeys(config IndexConfiguration) (count int) {
+//	for _, configuration := range config.SchemaOverrides.Fields {
+//		if configuration.IsPrimaryKey {
+//			count++
+//		}
+//	}
+//	return count
+//}

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -345,13 +345,14 @@ func (c *QuesmaConfiguration) validateSchemaConfiguration(config IndexConfigurat
 		return err
 	}
 
-	fmt.Println("schema configuration is not yet in use!")
-
 	for fieldName, fieldConfig := range config.SchemaOverrides.Fields {
 		if fieldConfig.Type == "" {
-			err = multierror.Append(err, fmt.Errorf("field %s in index %s has no type", fieldName, config.Name))
+			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has no type", fieldName, config.Name))
 		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) {
-			err = multierror.Append(err, fmt.Errorf("field %s in index %s has invalid type %s", fieldName, config.Name, fieldConfig.Type))
+			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has invalid type %s", fieldName, config.Name, fieldConfig.Type))
+		}
+		if fieldConfig.Type == TypeAlias && fieldConfig.TargetColumnName == "" {
+			err = multierror.Append(err, fmt.Errorf("field [%s] of type alias in index [%s] cannot have `targetColumnName` property unset", fieldName, config.Name))
 		}
 
 		// TODO This validation will be fixed on further field config cleanup

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -354,6 +354,7 @@ func (c *QuesmaConfiguration) validateSchemaConfiguration(config IndexConfigurat
 			err = multierror.Append(err, fmt.Errorf("field %s in index %s has invalid type %s", fieldName, config.Name, fieldConfig.Type))
 		}
 
+		// TODO This validation will be fixed on further field config cleanup
 		//if slices.Contains(config.SchemaOverrides.Ignored, fieldName.AsString()) {
 		//	err = multierror.Append(err, fmt.Errorf("field %s in index %s is both enabled and ignored", fieldName, config.Name))
 		//}

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -125,7 +125,6 @@ func Load() QuesmaConfiguration {
 		config.IndexConfig[name] = idxConfig
 		if idxConfig.SchemaOverrides != nil {
 			for fieldName, configuration := range idxConfig.SchemaOverrides.Fields {
-				//configuration.Name = fieldName
 				idxConfig.SchemaOverrides.Fields[fieldName] = configuration
 			}
 		}

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -46,7 +46,7 @@ func (c IndexConfiguration) String() string {
 		}
 		extraString += strings.Join(fields, ", ")
 	}
-	var str = fmt.Sprintf("\n\t\t%s, disabled: %t, schema overrides: %s, override: %s",
+	var str = fmt.Sprintf("\n\t\t%s, enabled: %t, schema overrides: %s, override: %s",
 		c.Name,
 		c.Enabled,
 		c.SchemaOverrides.String(),

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -16,9 +16,7 @@ type IndexConfiguration struct {
 	// TODO to be deprecated
 	IgnoredFields map[string]bool `koanf:"ignoredFields"`
 	// TODO to be deprecated
-	TimestampField *string `koanf:"timestampField"`
-	// this is hidden from the user right now
-	// deprecated
+	TimestampField    *string                           `koanf:"timestampField"`
 	SchemaOverrides   *SchemaConfiguration              `koanf:"schemaOverrides"`
 	EnabledOptimizers map[string]OptimizerConfiguration `koanf:"optimizers"`
 	Override          string                            `koanf:"override"`

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -14,8 +14,6 @@ type IndexConfiguration struct {
 	// TODO to be deprecated
 	FullTextFields []string `koanf:"fullTextFields"`
 	// TODO to be deprecated
-	TypeMappings map[string]string `koanf:"mappings"`
-	// TODO to be deprecated
 	IgnoredFields map[string]bool `koanf:"ignoredFields"`
 	// TODO to be deprecated
 	TimestampField *string `koanf:"timestampField"`

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -10,11 +10,9 @@ import (
 
 type IndexConfiguration struct {
 	Name    string `koanf:"name"`
-	Enabled bool   `koanf:"enabled"`
+	Enabled bool   `koanf:"enabled"` // TODO rename to `Disabled` to reduce already polluted config
 	// TODO to be deprecated
 	FullTextFields []string `koanf:"fullTextFields"`
-	// TODO to be deprecated
-	Aliases map[string]FieldAlias `koanf:"aliases"`
 	// TODO to be deprecated
 	TypeMappings map[string]string `koanf:"mappings"`
 	// TODO to be deprecated
@@ -23,9 +21,9 @@ type IndexConfiguration struct {
 	TimestampField *string `koanf:"timestampField"`
 	// this is hidden from the user right now
 	// deprecated
-	SchemaConfiguration *SchemaConfiguration              `koanf:"static-schema"`
-	EnabledOptimizers   map[string]OptimizerConfiguration `koanf:"optimizers"`
-	Override            string                            `koanf:"override"`
+	SchemaOverrides   *SchemaConfiguration              `koanf:"schemaOverrides"`
+	EnabledOptimizers map[string]OptimizerConfiguration `koanf:"optimizers"`
+	Override          string                            `koanf:"override"`
 }
 
 func (c IndexConfiguration) HasFullTextField(fieldName string) bool {
@@ -42,14 +40,6 @@ func (c IndexConfiguration) GetTimestampField() (tsField string) {
 func (c IndexConfiguration) String() string {
 	var extraString string
 	extraString = ""
-	if len(c.Aliases) > 0 {
-		extraString += "; aliases: "
-		var aliases []string
-		for _, alias := range c.Aliases {
-			aliases = append(aliases, fmt.Sprintf("%s <- %s", alias.SourceFieldName, alias.TargetFieldName))
-		}
-		extraString += strings.Join(aliases, ", ")
-	}
 	if len(c.IgnoredFields) > 0 {
 		extraString += "; ignored fields: "
 		var fields []string
@@ -58,10 +48,10 @@ func (c IndexConfiguration) String() string {
 		}
 		extraString += strings.Join(fields, ", ")
 	}
-	var str = fmt.Sprintf("\n\t\t%s, enabled: %t, static-schema: %v, override: %s",
+	var str = fmt.Sprintf("\n\t\t%s, disabled: %t, schema overrides: %s, override: %s",
 		c.Name,
 		c.Enabled,
-		c.SchemaConfiguration,
+		c.SchemaOverrides.String(),
 		c.Override,
 	)
 

--- a/quesma/quesma/config/schema_config.go
+++ b/quesma/quesma/config/schema_config.go
@@ -10,28 +10,16 @@ import (
 const TypeAlias = "alias"
 
 type (
-	// not yet in use
 	SchemaConfiguration struct {
-		Fields                    map[FieldName]FieldConfiguration `koanf:"fields"`
-		Ignored                   []string                         `koanf:"ignored"`
-		UnknownPropertiesStrategy UnknownPropertiesConfiguration   `koanf:"unknown-fields"`
+		Fields map[FieldName]FieldConfiguration `koanf:"fields"`
 	}
 	FieldConfiguration struct {
-		Name FieldName `koanf:"name"`
-		// when 'alias' used, other fields are inherited from the aliased field
-		Type         FieldType `koanf:"type"`
-		IsPrimaryKey bool      `koanf:"primary-key"`
-		// target column name, if different than the field name, can point to 'attributes'
-		ColumnName   string `koanf:"column-name"`
-		AliasedField string `koanf:"aliased-field"`
+		Type FieldType `koanf:"type"`
+		//IsTimestampField bool      `koanf:"isTimestampField"`
+		TargetColumnName string `koanf:"targetColumnName"` // if FieldType == TypeAlias then this is the target column name
 	}
-	FieldName                      string
-	FieldType                      string
-	UnknownPropertiesConfiguration struct {
-		Strategy            UnknownPropertiesStrategy `koanf:"strategy"`
-		MatchKeywordAndText bool                      `koanf:"match-keyword-and-text"`
-	}
-	UnknownPropertiesStrategy string
+	FieldName string
+	FieldType string
 )
 
 func (ft FieldType) AsString() string {
@@ -43,14 +31,17 @@ func (fn FieldName) AsString() string {
 }
 
 func (fc FieldConfiguration) String() string {
-	baseString := fmt.Sprintf("FieldConfiguration: Name=%s, Type=%s", fc.Name, fc.Type)
-	if fc.ColumnName != "" {
-		baseString += fmt.Sprintf(", ColumnName=%s", fc.ColumnName)
+	baseString := fmt.Sprintf("FieldConfiguration: Type=%s", fc.Type) //fc.IsTimestampField)
+	if fc.TargetColumnName != "" {
+		baseString += fmt.Sprintf(", TargetColumnName=%s", fc.TargetColumnName)
 	}
 	return baseString
 }
 
 func (sc *SchemaConfiguration) String() string {
+	if sc == nil {
+		return "NO SCHEMA OVERRIDES"
+	}
 	var builder strings.Builder
 
 	builder.WriteString("SchemaConfiguration:\n")
@@ -59,13 +50,6 @@ func (sc *SchemaConfiguration) String() string {
 	for fieldName, fieldConfig := range sc.Fields {
 		builder.WriteString(fmt.Sprintf("\t%s: %+v\n", fieldName, fieldConfig))
 	}
-
-	builder.WriteString("Ignored:\n")
-	for _, ignoredField := range sc.Ignored {
-		builder.WriteString(fmt.Sprintf("\t%s\n", ignoredField))
-	}
-
-	builder.WriteString(fmt.Sprintf("UnknownPropertiesStrategy: %+v\n", sc.UnknownPropertiesStrategy))
 	return builder.String()
 }
 

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -33,7 +33,9 @@ func Test_ipRangeTransform(t *testing.T) {
 			Name:           "kibana_sample_data_logs",
 			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
-			TypeMappings:   map[string]string{IpFieldName: "ip"},
+			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
+				config.FieldName(IpFieldName): {Type: "ip"},
+			}},
 		},
 		// Identical to kibana_sample_data_logs, but with "nested.clientip"
 		// instead of "clientip"
@@ -41,14 +43,18 @@ func Test_ipRangeTransform(t *testing.T) {
 			Name:           "kibana_sample_data_logs_nested",
 			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
-			TypeMappings:   map[string]string{"nested.clientip": "ip"},
+			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
+				"nested.clientip": {Type: "ip"},
+			}},
 		},
 		"kibana_sample_data_flights": {
 			Name:           "kibana_sample_data_flights",
 			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
-			TypeMappings: map[string]string{IpFieldName: "ip",
-				"DestLocation": "geo_point"},
+			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
+				config.FieldName(IpFieldName): {Type: "ip"},
+				"DestLocation":                {Type: "geo_point"},
+			}},
 		},
 	}
 	cfg := config.QuesmaConfiguration{

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -113,29 +113,29 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 				columnMap[k] = c
 			}
 
-			for _, a := range qmc.cfg.AliasFields(table.Name) {
+			for alias, target := range qmc.cfg.AliasFields(table.Name) {
 
 				// check for collisions
-				if field, collide := columnMap[a.SourceFieldName]; collide {
+				if field, collide := columnMap[alias]; collide {
 					field.warning = util.Pointer("alias declared with the same name")
-					columnMap[a.SourceFieldName] = field
+					columnMap[alias] = field
 					continue
 				}
 
 				// check if target exists
 				c := tableColumn{}
-				c.name = a.SourceFieldName
-				if aliasedField, ok := columnMap[a.TargetFieldName]; ok {
-					c.typeName = fmt.Sprintf("alias of '%s', %s", a.TargetFieldName, aliasedField.typeName)
+				c.name = alias
+				if aliasedField, ok := columnMap[target]; ok {
+					c.typeName = fmt.Sprintf("alias of '%s', %s", target, aliasedField.typeName)
 					c.isFullTextSearch = aliasedField.isFullTextSearch
 					c.isAttribute = aliasedField.isAttribute
 				} else {
-					c.warning = util.Pointer("alias points to non-existing field '" + a.TargetFieldName + "'")
+					c.warning = util.Pointer("alias points to non-existing field '" + target + "'")
 					c.typeName = "dangling alias"
 				}
 
-				columnNames = append(columnNames, a.SourceFieldName)
-				columnMap[a.SourceFieldName] = c
+				columnNames = append(columnNames, alias)
+				columnMap[alias] = c
 			}
 
 			// columns added by Quesma, not visible for the user

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -107,6 +107,9 @@ func NewSchemaRegistry(tableProvider TableProvider, configuration config.QuesmaC
 }
 
 func (s *schemaRegistry) populateSchemaFromStaticConfiguration(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field) {
+	if indexConfiguration.SchemaOverrides == nil {
+		return
+	}
 	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
 		if field.Type.AsString() == config.TypeAlias {
 			continue

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -74,10 +74,6 @@ func (s *schemaRegistry) populateSchemaFromDynamicConfiguration(indexName string
 	}
 }
 
-func deprecatedConfigInUse(indexConfig config.IndexConfiguration) bool {
-	return indexConfig.SchemaConfiguration == nil
-}
-
 func (s *schemaRegistry) AllSchemas() map[TableName]Schema {
 	if schemas, err := s.loadSchemas(); err != nil {
 		logger.Error().Msgf("error loading schemas: %v", err)
@@ -111,56 +107,30 @@ func NewSchemaRegistry(tableProvider TableProvider, configuration config.QuesmaC
 }
 
 func (s *schemaRegistry) populateSchemaFromStaticConfiguration(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field) {
-	if deprecatedConfigInUse(indexConfiguration) {
-		for fieldName, fieldType := range indexConfiguration.TypeMappings {
-			if resolvedType, valid := ParseQuesmaType(fieldType); valid {
-				if resolvedType.Equal(TypePoint) {
-					// TODO replace with notion of ephemeral types (see other identical TODOs)
-					fields[FieldName(fieldName)] = Field{PropertyName: FieldName(fieldName), InternalPropertyName: FieldName(strings.Replace(fieldName, ".", "::", -1)), Type: resolvedType}
-				} else {
-					fields[FieldName(fieldName)] = Field{PropertyName: FieldName(fieldName), InternalPropertyName: FieldName(fieldName), Type: resolvedType}
-				}
-			} else {
-				logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", fieldType)
-			}
+	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
+		if field.Type.AsString() == config.TypeAlias {
+			continue
 		}
-	} else {
-		for _, field := range indexConfiguration.SchemaConfiguration.Fields {
-			if field.Type.AsString() == config.TypeAlias {
-				continue
-			}
-			if resolvedType, valid := ParseQuesmaType(field.Type.AsString()); valid {
-				// TODO replace with notion of ephemeral types (see other identical TODOs)
-				if resolvedType.Equal(TypePoint) {
-					fields[FieldName(field.Name.AsString())] = Field{PropertyName: FieldName(field.Name.AsString()), InternalPropertyName: FieldName(strings.Replace(field.Name.AsString(), ".", "::", -1)), Type: resolvedType}
-				} else {
-					fields[FieldName(field.Name.AsString())] = Field{PropertyName: FieldName(field.Name.AsString()), InternalPropertyName: FieldName(field.Name.AsString()), Type: resolvedType}
-				}
+		if resolvedType, valid := ParseQuesmaType(field.Type.AsString()); valid {
+			// TODO replace with notion of ephemeral types (see other identical TODOs)
+			if resolvedType.Equal(TypePoint) {
+				fields[FieldName(fieldName)] = Field{PropertyName: FieldName(fieldName), InternalPropertyName: FieldName(strings.Replace(fieldName.AsString(), ".", "::", -1)), Type: resolvedType}
 			} else {
-				logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type.AsString())
+				fields[FieldName(fieldName)] = Field{PropertyName: FieldName(fieldName), InternalPropertyName: FieldName(fieldName), Type: resolvedType}
 			}
+		} else {
+			logger.Warn().Msgf("invalid configuration: type %s not supported (should have been spotted when validating configuration)", field.Type.AsString())
 		}
 	}
 }
 
-func (s *schemaRegistry) populateAliases(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field, aliases map[FieldName]FieldName) {
-	if deprecatedConfigInUse(indexConfiguration) {
-		for aliasName, aliasConfig := range indexConfiguration.Aliases {
-			if _, exists := fields[FieldName(aliasConfig.TargetFieldName)]; exists {
-				aliases[FieldName(aliasName)] = FieldName(aliasConfig.TargetFieldName)
-			} else {
-				logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", aliasConfig.SourceFieldName)
-			}
-		}
-	} else {
-		for _, field := range indexConfiguration.SchemaConfiguration.Fields {
-			if field.Type.AsString() == config.TypeAlias {
-				if _, exists := fields[FieldName(field.AliasedField)]; exists {
-					aliases[FieldName(field.Name)] = FieldName(field.AliasedField)
-				} else {
-					logger.Debug().Msgf("alias field %s not found, possibly not yet loaded", field.AliasedField)
-				}
-			}
+func (s *schemaRegistry) populateAliases(indexConfiguration config.IndexConfiguration, _ map[FieldName]Field, aliases map[FieldName]FieldName) {
+	if indexConfiguration.SchemaOverrides == nil {
+		return
+	}
+	for fieldName, fieldConf := range indexConfiguration.SchemaOverrides.Fields {
+		if fieldConf.Type.AsString() == config.TypeAlias && fieldConf.TargetColumnName != "" {
+			aliases[FieldName(fieldName)] = FieldName(fieldConf.TargetColumnName)
 		}
 	}
 }

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -194,7 +194,11 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 				IndexConfig: map[string]config.IndexConfiguration{
 					"some_table": {Enabled: true,
 						TypeMappings: map[string]string{"message": "keyword"},
-						Aliases:      map[string]config.FieldAlias{"message_alias": {SourceFieldName: "message_alias", TargetFieldName: "message"}},
+						SchemaOverrides: &config.SchemaConfiguration{
+							Fields: map[config.FieldName]config.FieldConfiguration{
+								"message_alias": {Type: "alias", TargetColumnName: "message"},
+							},
+						},
 					},
 				},
 			},

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -76,7 +76,13 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings not backed by db (deprecated)",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, TypeMappings: map[string]string{"message": "keyword"}},
+					"some_table": {Enabled: true,
+						SchemaOverrides: &config.SchemaConfiguration{
+							Fields: map[config.FieldName]config.FieldConfiguration{
+								"message": {Type: "keyword"},
+							},
+						},
+					},
 				},
 			},
 			tableDiscovery: fixedTableProvider{tables: map[string]schema.Table{
@@ -97,9 +103,9 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings not backed by db",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaConfiguration: &config.SchemaConfiguration{
+					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
-							"message": {Name: "message", Type: "keyword"},
+							"message": {Type: "keyword"},
 						},
 					}},
 				},
@@ -122,9 +128,9 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema explicitly configured, nothing in db",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaConfiguration: &config.SchemaConfiguration{
+					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
-							"message": {Name: "message", Type: "keyword"},
+							"message": {Type: "keyword"},
 						},
 					}},
 				},
@@ -138,9 +144,9 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with mapping overrides",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaConfiguration: &config.SchemaConfiguration{
+					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
-							"message": {Name: "message", Type: "keyword"},
+							"message": {Type: "keyword"},
 						},
 					}},
 				},
@@ -164,10 +170,10 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with aliases",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaConfiguration: &config.SchemaConfiguration{
+					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
-							"message":       {Name: "message", Type: "keyword"},
-							"message_alias": {Name: "message_alias", Type: "alias", AliasedField: "message"},
+							"message":       {Type: "keyword"},
+							"message_alias": {Type: "alias", TargetColumnName: "message"},
 						},
 					}},
 				},

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -54,7 +54,13 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings (deprecated)",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, TypeMappings: map[string]string{"message": "keyword"}},
+					"some_table": {Enabled: true,
+						SchemaOverrides: &config.SchemaConfiguration{
+							Fields: map[config.FieldName]config.FieldConfiguration{
+								"message": {Type: "keyword"},
+							},
+						},
+					},
 				},
 			},
 			tableDiscovery: fixedTableProvider{tables: map[string]schema.Table{
@@ -199,10 +205,10 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
 					"some_table": {Enabled: true,
-						TypeMappings: map[string]string{"message": "keyword"},
 						SchemaOverrides: &config.SchemaConfiguration{
 							Fields: map[config.FieldName]config.FieldConfiguration{
 								"message_alias": {Type: "alias", TargetColumnName: "message"},
+								"message":       {Type: "keyword"},
 							},
 						},
 					},
@@ -228,7 +234,13 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, requesting nonexistent schema",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, TypeMappings: map[string]string{"message": "keyword"}},
+					"some_table": {Enabled: true,
+						SchemaOverrides: &config.SchemaConfiguration{
+							Fields: map[config.FieldName]config.FieldConfiguration{
+								"message": {Type: "keyword"},
+							},
+						},
+					},
 				},
 			},
 			tableDiscovery: fixedTableProvider{tables: map[string]schema.Table{


### PR DESCRIPTION
Highlights:
* Moving `TypeMappings` and `Aliases` form `IndexConfiguration` to `SchemaConfiguration` (what used to be called `static-schema`, I'm also changing that to `schemaOverrides`
* Cleanup all the deprecated code logic
* There's more to come with the deprecated field changes, so you might see few line commented out here and there as I didn't want this PR to grow too much and conflict with some @nablaone's recent work

**This might look like only configuration syntax change on the surface**, but it actually aims to reduce the usage of configuration and make the code refer to schema instead.
![image](https://github.com/user-attachments/assets/99c88acf-32ad-46be-b117-a1a686dc0926)
