### PR TITLE
Remove indices `enabled: true` option in favor of explicit disabling

### DIFF
--- a/ci/quesma/config/ci-config.yaml
+++ b/ci/quesma/config/ci-config.yaml
@@ -21,13 +21,8 @@ processors:
       enableElasticsearchIngest: true
       indexes:
         kibana_sample_data_ecommerce:
-          enabled: true
         kibana_sample_data_flights:
-          enabled: true
         kibana_sample_data_logs:
-          enabled: true
         logs-generic-default:
-          enabled: true
           fullTextFields: [ "message" ]
         windows_logs:   # Used for EQL e2e tests
-          enabled: true

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -30,7 +30,6 @@ processors:
       enableElasticsearchIngest: false
       indexes:
         kibana_sample_data_ecommerce:
-          enabled: true
           schemaOverrides:
             fields:
               "geoip.location":
@@ -44,7 +43,6 @@ processors:
               manufacturer:
                 type: text
         kibana_sample_data_flights:
-          enabled: true
           schemaOverrides:
             fields:
               "DestLocation":
@@ -52,7 +50,6 @@ processors:
               "OriginLocation":
                 type: geo_point
         logs-generic-default:
-          enabled: true
           schemaOverrides:
             fields:
               timestamp:

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -155,12 +155,12 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]string, d
 	var explicitlyDisabledTables, notConfiguredTables []string
 	for table, columns := range tables {
 		if indexConfig, found := td.cfg.IndexConfig[table]; found {
-			if indexConfig.Enabled {
+			if indexConfig.Disabled {
+				explicitlyDisabledTables = append(explicitlyDisabledTables, table)
+			} else {
 				comment := td.tableComment(databaseName, table)
 				createTableQuery := td.createTableQuery(databaseName, table)
 				configuredTables[table] = discoveredTable{table, columns, indexConfig, comment, createTableQuery}
-			} else {
-				explicitlyDisabledTables = append(explicitlyDisabledTables, table)
 			}
 		} else {
 			notConfiguredTables = append(notConfiguredTables, table)

--- a/quesma/config.yaml.template
+++ b/quesma/config.yaml.template
@@ -30,11 +30,9 @@ processors:
       indexes:
         kibana_sample_data_ecommerce:
           timestampField: "@timestamp"
-          enabled: true
         kibana_sample_data_flights:
-          enabled: true
+          disabled: false  # Just to have example that its possible
         kibana_sample_data_logs:
-          enabled: true
           fullTextFields: [ "message", "agent" ]
           mappings:
             message: "text"

--- a/quesma/feature/not_supported_test.go
+++ b/quesma/feature/not_supported_test.go
@@ -30,8 +30,7 @@ func TestNewUnsupportedFeature_index(t *testing.T) {
 	cfg := config.QuesmaConfiguration{}
 	cfg.IndexConfig = map[string]config.IndexConfiguration{
 		"foo": {
-			Name:    "foo",
-			Enabled: true,
+			Name: "foo",
 		},
 	}
 

--- a/quesma/proxy/l4_proxy.go
+++ b/quesma/proxy/l4_proxy.go
@@ -57,7 +57,7 @@ func resolveHttpServer(inspect bool) *http.Server {
 
 func configureRouting() *http.ServeMux {
 	router := http.NewServeMux()
-	configuration := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", Enabled: true}}}
+	configuration := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", Disabled: false}}}
 	router.HandleFunc("POST /{index}/_doc", util.BodyHandler(func(body []byte, writer http.ResponseWriter, r *http.Request) {
 		index := r.PathValue("index")
 

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -40,7 +40,6 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 	tsField := "@timestamp"
 	indexConfig := config.IndexConfiguration{
 		Name:           "logs-generic-default",
-		Enabled:        true,
 		FullTextFields: []string{"message"},
 		TimestampField: &tsField,
 	}
@@ -108,8 +107,7 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewTableDiscovery(config.QuesmaConfiguration{}, nil), schema.StaticRegistry{})
 	lm.AddTableIfDoesntExist(&table)
 	indexConfig := config.IndexConfiguration{
-		Name:    "logs-generic-default",
-		Enabled: true,
+		Name: "logs-generic-default",
 	}
 	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{}}
 
@@ -175,8 +173,7 @@ func TestQueryParserNoAttrsConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	indexConfig := config.IndexConfiguration{
-		Name:    "logs-generic-default",
-		Enabled: true,
+		Name: "logs-generic-default",
 	}
 	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{}}
 

--- a/quesma/quesma/config/config_test.go
+++ b/quesma/quesma/config/config_test.go
@@ -15,22 +15,18 @@ func TestIndexConfiguration_FullTextField(t *testing.T) {
 	indexConfig := map[string]IndexConfiguration{
 		"none": {
 			Name:           "none",
-			Enabled:        true,
 			FullTextFields: []string{},
 		},
 		"foo-bar": {
 			Name:           "foo-bar",
-			Enabled:        true,
 			FullTextFields: []string{"sometext"},
 		},
 		"bar-logs": {
 			Name:           "bar-logs",
-			Enabled:        true,
 			FullTextFields: []string{},
 		},
 		"logs-generic-default": {
 			Name:           "logs-generic-default",
-			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
 		},
 	}
@@ -93,15 +89,15 @@ func TestQuesmaConfigurationLoading(t *testing.T) {
 		enabled        bool
 		fullTextFields []string
 	}{
-		{"logs-generic-default", true, []string{"message", "host.name"}},
-		{"device-logs", true, []string{"message"}},
+		{"logs-generic-default", false, []string{"message", "host.name"}},
+		{"device-logs", false, []string{"message"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ic := findIndexConfig(tt.name)
 			assert.NotNil(t, ic)
-			assert.Equal(t, tt.enabled, ic.Enabled)
+			assert.Equal(t, tt.enabled, ic.Disabled)
 			assert.Equal(t, tt.fullTextFields, ic.FullTextFields)
 		})
 	}

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -9,8 +9,8 @@ import (
 )
 
 type IndexConfiguration struct {
-	Name    string `koanf:"name"`
-	Enabled bool   `koanf:"enabled"` // TODO rename to `Disabled` to reduce already polluted config
+	Name     string `koanf:"name"`
+	Disabled bool   `koanf:"disabled"`
 	// TODO to be deprecated
 	FullTextFields []string `koanf:"fullTextFields"`
 	// TODO to be deprecated
@@ -44,9 +44,9 @@ func (c IndexConfiguration) String() string {
 		}
 		extraString += strings.Join(fields, ", ")
 	}
-	var str = fmt.Sprintf("\n\t\t%s, enabled: %t, schema overrides: %s, override: %s",
+	var str = fmt.Sprintf("\n\t\t%s, disabled: %t, schema overrides: %s, override: %s",
 		c.Name,
-		c.Enabled,
+		c.Disabled,
 		c.SchemaOverrides.String(),
 		c.Override,
 	)

--- a/quesma/quesma/config/test_config.yaml
+++ b/quesma/quesma/config/test_config.yaml
@@ -18,32 +18,23 @@ logging:
   level: "info"
 indexes:
   example-index:
-    enabled: true
   kibana_sample_data_ecommerce:
-    enabled: true
   kibana_sample_data_flights:
-    enabled: true
   kibana_sample_data_logs:
-    enabled: true
-    aliases:
-      timestamp:
-        targetfieldname: "timestamp"
-        sourcefieldname: "@timestamp"
+    schemaOverrides:
+      fields:
+        timestamp:
+          type: alias
+          targetColumnName: "@timestamp"
   kafka-example-topic:
-    enabled: true
   logs-generic-default:
-    enabled: true
     fullTextFields: ["message", "host.name"]
   device-logs:
-    enabled: true
     fullTextFields: ["message"]
   phone_home_logs:
-    enabled: true
     fullTextFields: ["message"]
   windows_logs:
-    enabled: true
   phone_home_data:
-    enabled: true
     fullTextFields: ["message"]
 
 

--- a/quesma/quesma/config/util.go
+++ b/quesma/quesma/config/util.go
@@ -24,7 +24,9 @@ func RunConfigured(ctx context.Context, cfg QuesmaConfiguration, indexName strin
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is not configured, skipping", indexName)
 			return
 		}
-		if matchingConfig.Enabled {
+		if matchingConfig.Disabled {
+			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
+		} else {
 			insertCounter.Add(1)
 			if insertCounter.Load()%50 == 1 {
 				logger.DebugWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s, ctr: %d", indexName, body.ShortString(), insertCounter.Load())
@@ -33,8 +35,6 @@ func RunConfigured(ctx context.Context, cfg QuesmaConfiguration, indexName strin
 			if err != nil {
 				logger.ErrorWithCtx(ctx).Msg("Can't write to Clickhouse: " + err.Error())
 			}
-		} else {
-			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
 		}
 	}
 }

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -116,7 +116,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 		}
 
 		indexConfig, found := cfg.IndexConfig[index]
-		if !found || !indexConfig.Enabled {
+		if !found || indexConfig.Disabled {
 			// Bulk entry for Elastic - forward the request as-is
 			opBytes, err := rawOp.Bytes()
 			if err != nil {

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -50,7 +50,7 @@ func handleFieldCapsIndex(cfg config.QuesmaConfiguration, schemaRegistry schema.
 
 		if schemaDefinition, found := schemaRegistry.FindSchema(schema.TableName(resolvedIndex)); found {
 			indexConfig, configured := cfg.IndexConfig[resolvedIndex]
-			if configured && !indexConfig.Enabled {
+			if configured && indexConfig.Disabled {
 				continue
 			}
 

--- a/quesma/quesma/functionality/field_capabilities/field_caps_test.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps_test.go
@@ -79,8 +79,7 @@ func TestFieldCaps(t *testing.T) {
 	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-generic-default": {
-				Name:    "logs-generic-default",
-				Enabled: true,
+				Name: "logs-generic-default",
 			},
 		},
 	}, schema.StaticRegistry{
@@ -142,7 +141,7 @@ func TestFieldCapsWithAliases(t *testing.T) {
   ]
 }`)
 	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
-		IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Name: "logs-generic-default", Enabled: true}},
+		IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Name: "logs-generic-default"}},
 	}, schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -184,12 +183,10 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
-				Name:    "logs-1",
-				Enabled: true,
+				Name: "logs-1",
 			},
 			"logs-2": {
-				Name:    "logs-2",
-				Enabled: true,
+				Name: "logs-2",
 			},
 		},
 	}, schema.StaticRegistry{
@@ -293,16 +290,13 @@ func TestFieldCapsMultipleIndexesConflictingEntries(t *testing.T) {
 	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
-				Name:    "logs-1",
-				Enabled: true,
+				Name: "logs-1",
 			},
 			"logs-2": {
-				Name:    "logs-2",
-				Enabled: true,
+				Name: "logs-2",
 			},
 			"logs-3": {
-				Name:    "logs-3",
-				Enabled: true,
+				Name: "logs-3",
 			},
 		},
 	}, schema.StaticRegistry{

--- a/quesma/quesma/matchers.go
+++ b/quesma/quesma/matchers.go
@@ -32,7 +32,7 @@ func matchedAgainstBulkBody(configuration config.QuesmaConfiguration) mux.Reques
 			}
 			if idx%2 == 0 {
 				indexConfig, found := configuration.IndexConfig[extractIndexName(s)]
-				if found && indexConfig.Enabled {
+				if found && !indexConfig.Disabled {
 					return true
 				}
 			}
@@ -65,7 +65,7 @@ func matchedAgainstPattern(configuration config.QuesmaConfiguration) mux.Request
 			for _, pattern := range indexPatterns {
 				for _, indexName := range configuration.IndexConfig {
 					if config.MatchName(elasticsearch.NormalizePattern(pattern), indexName.Name) {
-						if configuration.IndexConfig[indexName.Name].Enabled {
+						if !configuration.IndexConfig[indexName.Name].Disabled {
 							return true
 						}
 					}
@@ -77,7 +77,7 @@ func matchedAgainstPattern(configuration config.QuesmaConfiguration) mux.Request
 				pattern := elasticsearch.NormalizePattern(indexPattern)
 				if config.MatchName(pattern, index.Name) {
 					if indexConfig, exists := configuration.IndexConfig[index.Name]; exists {
-						return indexConfig.Enabled
+						return !indexConfig.Disabled
 					}
 				}
 			}

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -333,7 +333,7 @@ func matchedExact(config config.QuesmaConfiguration) mux.RequestMatcher {
 			return false
 		}
 		indexConfig, exists := config.IndexConfig[req.Params["index"]]
-		return exists && indexConfig.Enabled
+		return exists && !indexConfig.Disabled
 	})
 }
 

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -20,19 +20,19 @@ func Test_matchedAgainstConfig(t *testing.T) {
 		{
 			name:   "index enabled",
 			index:  "index",
-			config: indexConfig("index", true),
+			config: indexConfig("index", false),
 			want:   true,
 		},
 		{
 			name:   "index disabled",
 			index:  "index",
-			config: indexConfig("index", false),
+			config: indexConfig("index", true),
 			want:   false,
 		},
 		{
 			name:   "index not configured",
 			index:  "index",
-			config: indexConfig("logs", false),
+			config: indexConfig("logs", true),
 			want:   false,
 		},
 	}
@@ -57,61 +57,61 @@ func Test_matchedAgainstPattern(t *testing.T) {
 		{
 			name:          "multiple indexes, one matches configuration",
 			pattern:       "logs-1,logs-2,foo-*,index",
-			configuration: indexConfig("index", true),
+			configuration: indexConfig("index", false),
 			want:          true,
 		},
 		{
 			name:          "multiple indexes, one internal",
 			pattern:       "index,.kibana",
-			configuration: indexConfig("index", true),
+			configuration: indexConfig("index", false),
 			want:          false,
 		},
 		{
 			name:          "index explicitly enabled",
 			pattern:       "index",
-			configuration: indexConfig("index", true),
+			configuration: indexConfig("index", false),
 			want:          true,
 		},
 		{
 			name:          "index explicitly disabled",
 			pattern:       "index",
-			configuration: indexConfig("index", false),
+			configuration: indexConfig("index", true),
 			want:          false,
 		},
 		{
 			name:          "index enabled, * pattern",
 			pattern:       "*",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          true,
 		},
 		{
 			name:          "index enabled, _all pattern",
 			pattern:       "_all",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          true,
 		},
 		{
 			name:          "index enabled, multiple patterns",
 			pattern:       "logs-*-*, logs-*",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          true,
 		},
 		{
 			name:          "index enabled, multiple patterns",
 			pattern:       "logs-*-*, logs-generic-default",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          true,
 		},
 		{
 			name:          "index disabled, wide pattern",
 			pattern:       "logs-*-*",
-			configuration: indexConfig("logs-generic-default", false),
+			configuration: indexConfig("logs-generic-default", true),
 			want:          false,
 		},
 		{
 			name:          "index enabled, narrow pattern",
 			pattern:       "logs-generic-*",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          true,
 		},
 		{
@@ -123,7 +123,7 @@ func Test_matchedAgainstPattern(t *testing.T) {
 		{
 			name:          "traces-apm*, not configured",
 			pattern:       "traces-apm*",
-			configuration: indexConfig("logs-generic-default", true),
+			configuration: indexConfig("logs-generic-default", false),
 			want:          false,
 		},
 	}
@@ -137,8 +137,8 @@ func Test_matchedAgainstPattern(t *testing.T) {
 	}
 }
 
-func indexConfig(name string, enabled bool) config.QuesmaConfiguration {
-	return config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{name: {Name: name, Enabled: enabled}}}
+func indexConfig(name string, disabled bool) config.QuesmaConfiguration {
+	return config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{name: {Name: name, Disabled: disabled}}}
 }
 
 func Test_matchedAgainstBulkBody(t *testing.T) {
@@ -151,31 +151,31 @@ func Test_matchedAgainstBulkBody(t *testing.T) {
 		{
 			name:   "single index, config present",
 			body:   `{"create":{"_index":"logs-generic-default"}}`,
-			config: indexConfig("logs-generic-default", true),
+			config: indexConfig("logs-generic-default", false),
 			want:   true,
 		},
 		{
 			name:   "single index, table not present",
 			body:   `{"create":{"_index":"logs-generic-default"}}`,
-			config: indexConfig("foo", true),
+			config: indexConfig("foo", false),
 			want:   false,
 		},
 		{
 			name:   "multiple indexes, table present",
 			body:   `{"create":{"_index":"logs-generic-default"}}` + "\n{}\n" + `{"create":{"_index":"logs-generic-default"}}`,
-			config: indexConfig("logs-generic-default", true),
+			config: indexConfig("logs-generic-default", false),
 			want:   true,
 		},
 		{
 			name:   "multiple indexes, some tables not present",
 			body:   `{"create":{"_index":"logs-generic-default"}}` + "\n{}\n" + `{"create":{"_index":"non-existent"}}`,
-			config: indexConfig("logs-generic-default", true),
+			config: indexConfig("logs-generic-default", false),
 			want:   true,
 		},
 		{
 			name:   "multiple indexes, all tables not present",
 			body:   `{"create":{"_index":"not-there"}}` + "\n{}\n" + `{"create":{"_index":"non-existent"}}`,
-			config: indexConfig("logs-generic-default", true),
+			config: indexConfig("logs-generic-default", false),
 			want:   false,
 		},
 	}

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -31,7 +31,6 @@ func Test_ipRangeTransform(t *testing.T) {
 	indexConfig := map[string]config.IndexConfiguration{
 		"kibana_sample_data_logs": {
 			Name:           "kibana_sample_data_logs",
-			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				config.FieldName(IpFieldName): {Type: "ip"},
@@ -41,7 +40,6 @@ func Test_ipRangeTransform(t *testing.T) {
 		// instead of "clientip"
 		"kibana_sample_data_logs_nested": {
 			Name:           "kibana_sample_data_logs_nested",
-			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				"nested.clientip": {Type: "ip"},
@@ -49,7 +47,6 @@ func Test_ipRangeTransform(t *testing.T) {
 		},
 		"kibana_sample_data_flights": {
 			Name:           "kibana_sample_data_flights",
-			Enabled:        true,
 			FullTextFields: []string{"message", "content"},
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				config.FieldName(IpFieldName): {Type: "ip"},
@@ -387,8 +384,7 @@ func Test_arrayType(t *testing.T) {
 
 	indexConfig := map[string]config.IndexConfiguration{
 		"kibana_sample_data_ecommerce": {
-			Name:    "kibana_sample_data_ecommerce",
-			Enabled: true,
+			Name: "kibana_sample_data_ecommerce",
 		},
 	}
 	cfg := config.QuesmaConfiguration{
@@ -582,8 +578,7 @@ func TestApplyWildCard(t *testing.T) {
 
 	indexConfig := map[string]config.IndexConfiguration{
 		"kibana_sample_data_ecommerce": {
-			Name:    "kibana_sample_data_ecommerce",
-			Enabled: true,
+			Name: "kibana_sample_data_ecommerce",
 		},
 	}
 	cfg := config.QuesmaConfiguration{

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -41,7 +41,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 			defer db.Close()
 
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
-			cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+			cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 			logChan := logger.InitOnlyChannelLoggerForTests()
 			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 			go managementConsole.RunOnlyChannelProcessor()
@@ -109,7 +109,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 	defer db.Close()
 
 	lm := clickhouse.NewLogManagerWithConnection(db, table)
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	logChan := logger.InitOnlyChannelLoggerForTests()
 	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	go managementConsole.RunOnlyChannelProcessor()

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSearchOpensearch(t *testing.T) {
 
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	table := clickhouse.Table{
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),
@@ -179,7 +179,7 @@ func TestHighlighter(t *testing.T) {
 		],
 		"version": true
 	}`
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	table := clickhouse.Table{
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -35,7 +35,7 @@ var ctx = context.WithValue(context.TODO(), tracing.RequestIdCtxKey, tracing.Get
 
 func TestAsyncSearchHandler(t *testing.T) {
 	// logger.InitSimpleLoggerForTests()
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	table := concurrent.NewMapWith(tableName, &clickhouse.Table{
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),
@@ -112,7 +112,7 @@ func TestAsyncSearchHandler(t *testing.T) {
 }
 
 func TestAsyncSearchHandlerSpecialCharacters(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	table := clickhouse.Table{
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),
@@ -180,7 +180,7 @@ var table = concurrent.NewMapWith(tableName, &clickhouse.Table{
 })
 
 func TestSearchHandler(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -222,7 +222,7 @@ func TestSearchHandler(t *testing.T) {
 
 // TODO this test gives wrong results??
 func TestSearchHandlerNoAttrsConfig(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -262,7 +262,7 @@ func TestSearchHandlerNoAttrsConfig(t *testing.T) {
 }
 
 func TestAsyncSearchFilter(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -305,7 +305,7 @@ func TestAsyncSearchFilter(t *testing.T) {
 // (testing of creating response is lacking), because of `sqlmock` limitation.
 // It can't return uint64, thus creating response code panics because of that.
 func TestHandlingDateTimeFields(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -401,7 +401,7 @@ func TestHandlingDateTimeFields(t *testing.T) {
 // (top 10 values, "other" value, min/max).
 // Both `_search`, and `_async_search` handlers are tested.
 func TestNumericFacetsQueries(t *testing.T) {
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -495,7 +495,7 @@ func TestNumericFacetsQueries(t *testing.T) {
 
 func TestSearchTrackTotalCount(t *testing.T) {
 
-	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {Enabled: true}}}
+	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	s := schema.StaticRegistry{Tables: map[schema.TableName]schema.Schema{}}
 
 	s.Tables[tableName] = schema.Schema{

--- a/quesma/quesma/source_resolver.go
+++ b/quesma/quesma/source_resolver.go
@@ -31,7 +31,7 @@ func ResolveSources(indexPattern string, cfg config.QuesmaConfiguration, im elas
 			}
 
 			for indexName, indexConfig := range cfg.IndexConfig {
-				if elasticsearch.IndexMatches(pattern, indexName) && indexConfig.Enabled {
+				if elasticsearch.IndexMatches(pattern, indexName) && !indexConfig.Disabled {
 					matchesClickhouse = append(matchesClickhouse, indexName)
 				}
 			}
@@ -57,7 +57,7 @@ func ResolveSources(indexPattern string, cfg config.QuesmaConfiguration, im elas
 		}
 	} else {
 		if c, exists := cfg.IndexConfig[indexPattern]; exists {
-			if c.Enabled {
+			if !c.Disabled {
 				return sourceClickhouse, []string{}, []string{indexPattern}
 			} else {
 				return sourceElasticsearch, []string{indexPattern}, []string{}

--- a/quesma/quesma/source_resolver_test.go
+++ b/quesma/quesma/source_resolver_test.go
@@ -24,7 +24,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Index only in Clickhouse,pattern:",
 			args: args{
 				indexPattern: "test",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {Enabled: true}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {}}},
 				im:           NewFixedIndexManagement(),
 			},
 			want: sourceClickhouse,
@@ -33,7 +33,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Index only in Clickhouse,pattern:",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {Enabled: true}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {}}},
 				im:           NewFixedIndexManagement(),
 			},
 			want: sourceClickhouse,
@@ -60,7 +60,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Indexes both in Elasticsearch and Clickhouse",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"kibana-sample-data-logs": {Enabled: true}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"kibana-sample-data-logs": {}}},
 				im:           NewFixedIndexManagement("logs-generic-default"),
 			},
 			want: sourceBoth,
@@ -69,7 +69,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Indexes both in Elasticsearch and Clickhouse, but explicitly disabled",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Enabled: false}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Disabled: true}}},
 				im:           NewFixedIndexManagement("logs-generic-default"),
 			},
 			want: sourceElasticsearch,

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -95,7 +95,7 @@ func TestHtmlSchemaPage(t *testing.T) {
 
 	cfg := config.QuesmaConfiguration{}
 
-	cfg.IndexConfig = map[string]config.IndexConfiguration{xss: {Name: xss, Enabled: true}}
+	cfg.IndexConfig = map[string]config.IndexConfiguration{xss: {Name: xss}}
 
 	tables := concurrent.NewMap[string, *clickhouse.Table]()
 	tables.Store(table.Name, table)

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -261,7 +261,7 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 	buffer.Html(`Name Pattern`)
 	buffer.Html(`</th>`)
 	buffer.Html(`<th>`)
-	buffer.Html(`Enabled?`)
+	buffer.Html(`Disabled?`)
 	buffer.Html(`</th>`)
 	buffer.Html(`<th>`)
 	buffer.Html(`Full Text Search Fields`)
@@ -275,7 +275,7 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 		buffer.Text(cfg.Name)
 		buffer.Html(`</td>`)
 		buffer.Html(`<td>`)
-		if cfg.Enabled {
+		if cfg.Disabled {
 			buffer.Text("true")
 		} else {
 			buffer.Text("false")

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -32,7 +32,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, no mappings",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true},
+					"some_table": {},
 				},
 			},
 			tableDiscovery: fixedTableProvider{tables: map[string]schema.Table{
@@ -54,7 +54,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings (deprecated)",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true,
+					"some_table": {
 						SchemaOverrides: &config.SchemaConfiguration{
 							Fields: map[config.FieldName]config.FieldConfiguration{
 								"message": {Type: "keyword"},
@@ -82,7 +82,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings not backed by db (deprecated)",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true,
+					"some_table": {
 						SchemaOverrides: &config.SchemaConfiguration{
 							Fields: map[config.FieldName]config.FieldConfiguration{
 								"message": {Type: "keyword"},
@@ -109,7 +109,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with type mappings not backed by db",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
+					"some_table": {SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
 							"message": {Type: "keyword"},
 						},
@@ -134,7 +134,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema explicitly configured, nothing in db",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
+					"some_table": {SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
 							"message": {Type: "keyword"},
 						},
@@ -150,7 +150,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with mapping overrides",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
+					"some_table": {SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
 							"message": {Type: "keyword"},
 						},
@@ -176,7 +176,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with aliases",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true, SchemaOverrides: &config.SchemaConfiguration{
+					"some_table": {SchemaOverrides: &config.SchemaConfiguration{
 						Fields: map[config.FieldName]config.FieldConfiguration{
 							"message":       {Type: "keyword"},
 							"message_alias": {Type: "alias", TargetColumnName: "message"},
@@ -204,7 +204,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, with aliases [deprecated config]",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true,
+					"some_table": {
 						SchemaOverrides: &config.SchemaConfiguration{
 							Fields: map[config.FieldName]config.FieldConfiguration{
 								"message_alias": {Type: "alias", TargetColumnName: "message"},
@@ -234,7 +234,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			name: "schema inferred, requesting nonexistent schema",
 			cfg: config.QuesmaConfiguration{
 				IndexConfig: map[string]config.IndexConfiguration{
-					"some_table": {Enabled: true,
+					"some_table": {
 						SchemaOverrides: &config.SchemaConfiguration{
 							Fields: map[config.FieldName]config.FieldConfiguration{
 								"message": {Type: "keyword"},
@@ -275,7 +275,7 @@ func Test_schemaRegistry_UpdateDynamicConfiguration(t *testing.T) {
 	tableName := "some_table"
 	cfg := config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
-			tableName: {Enabled: true},
+			tableName: {Disabled: false},
 		},
 	}
 	tableDiscovery := fixedTableProvider{tables: map[string]schema.Table{


### PR DESCRIPTION
Removes `enabled: true`, from the index configuration. 
Index being just listed in the configuration by name implies that it is managed by Quesma. 
I'm also adding `disabled: <bool>` option just in case one has WIP configuration yet our logic is completely bypassed.
