### PR TITLE
Properly limit count of ingest requests

### DIFF
--- a/quesma/stats/ingest_statistics.go
+++ b/quesma/stats/ingest_statistics.go
@@ -128,7 +128,7 @@ func (s *Statistics) process(cfg config.QuesmaConfiguration, index string,
 
 func (s *Statistics) Process(cfg config.QuesmaConfiguration, index string, jsonData types.JSON, nestedSeparator string) {
 	s.process(cfg, index, jsonData, false, nestedSeparator)
-	if statistics, ok := (*s)[index]; ok {
+	if statistics, ok := (*s)[index]; ok && statistics.Requests < STATISTICS_LIMIT {
 		statistics.Requests++
 	}
 }


### PR DESCRIPTION
Quesma collects statistics for the first `10000` (`STATISTICS_LIMIT`) requests. However the UI incorrectly showed that the stats were collected for more requests than that.

The issue is that `statistics.Requests++` in `Process()` was executed every time, even though `process()` helper stopped looking at those requests. Fix the issue by adding that `STATISTICS_LIMIT` check also to `Process()`.