### PR TITLE
treewide: Pass QuesmaConfiguration by pointer, not by value

### DIFF
--- a/quesma/ab_testing/sender/coordinator.go
+++ b/quesma/ab_testing/sender/coordinator.go
@@ -22,7 +22,7 @@ type SenderCoordinator struct {
 	enabled bool
 }
 
-func NewSenderCoordinator(cfg config.QuesmaConfiguration) *SenderCoordinator {
+func NewSenderCoordinator(cfg *config.QuesmaConfiguration) *SenderCoordinator {
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -44,7 +44,7 @@ func TestAlterTable(t *testing.T) {
 	}
 	fieldsMap := concurrent.NewMapWith("tableName", table)
 
-	lm := NewLogManager(fieldsMap, config.QuesmaConfiguration{})
+	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 	for i := range rowsToInsert {
 		insert, alter, err := lm.BuildIngestSQLStatements("tableName", types.MustJSON(rowsToInsert[i]), nil, chConfig)
 		assert.Equal(t, expectedInsert[i], insert)
@@ -84,7 +84,7 @@ func TestAlterTableHeuristic(t *testing.T) {
 	}
 	const tableName = "tableName"
 	fieldsMap := concurrent.NewMapWith(tableName, table)
-	lm := NewLogManager(fieldsMap, config.QuesmaConfiguration{})
+	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 
 	rowsToInsert := make([]string, 0)
 	previousRow := ``

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -47,7 +47,7 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	})
 
 	f := func(t1, t2 TableMap) {
-		lm := NewLogManager(fieldsMap, config.QuesmaConfiguration{})
+		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 		j, alter, err := lm.BuildIngestSQLStatements("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))
@@ -800,7 +800,7 @@ func TestLogManager_GetTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var tableDefinitions = atomic.Pointer[TableMap]{}
 			tableDefinitions.Store(&tt.predefinedTables)
-			lm := NewLogManager(&tt.predefinedTables, config.QuesmaConfiguration{})
+			lm := NewLogManager(&tt.predefinedTables, &config.QuesmaConfiguration{})
 			assert.Equalf(t, tt.found, lm.FindTable(tt.tableNamePattern) != nil, "GetTable(%v)", tt.tableNamePattern)
 		})
 	}
@@ -878,7 +878,7 @@ func TestLogManager_ResolveIndexes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var tableDefinitions = atomic.Pointer[TableMap]{}
 			tableDefinitions.Store(tt.tables)
-			lm := &LogManager{tableDiscovery: newTableDiscoveryWith(config.QuesmaConfiguration{}, nil, *tt.tables)}
+			lm := &LogManager{tableDiscovery: newTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tt.tables)}
 			indexes, err := lm.ResolveIndexes(context.Background(), tt.patterns)
 			assert.NoError(t, err)
 			assert.Equalf(t, tt.resolved, indexes, tt.patterns, "ResolveIndexes(%v)", tt.patterns)

--- a/quesma/clickhouse/connection.go
+++ b/quesma/clickhouse/connection.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-func initDBConnection(c config.QuesmaConfiguration, tlsConfig *tls.Config) *sql.DB {
+func initDBConnection(c *config.QuesmaConfiguration, tlsConfig *tls.Config) *sql.DB {
 
 	options := clickhouse.Options{Addr: []string{c.ClickHouse.Url.Host}}
 	if c.ClickHouse.User != "" || c.ClickHouse.Password != "" || c.ClickHouse.Database != "" {
@@ -51,7 +51,7 @@ func initDBConnection(c config.QuesmaConfiguration, tlsConfig *tls.Config) *sql.
 
 }
 
-func InitDBConnectionPool(c config.QuesmaConfiguration) *sql.DB {
+func InitDBConnectionPool(c *config.QuesmaConfiguration) *sql.DB {
 
 	db := initDBConnection(c, &tls.Config{})
 
@@ -95,7 +95,7 @@ func InitDBConnectionPool(c config.QuesmaConfiguration) *sql.DB {
 // RunClickHouseConnectionDoctor is very blunt and verbose function which aims to print some helpful information
 // in case of misconfigured ClickHouse connection. In the future, we might rethink how do we manage this and perhaps
 // move some parts to InitDBConnectionPool, but for now this should already provide some useful feedback.
-func RunClickHouseConnectionDoctor(c config.QuesmaConfiguration) {
+func RunClickHouseConnectionDoctor(c *config.QuesmaConfiguration) {
 	timeout := 1 * time.Second
 	defaultNativeProtocolPort := "9000"
 	defaultNativeProtocolPortEncrypted := "9440"

--- a/quesma/clickhouse/ingest_validator_test.go
+++ b/quesma/clickhouse/ingest_validator_test.go
@@ -167,7 +167,7 @@ func TestIngestValidation(t *testing.T) {
 		db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 		lm := NewLogManagerEmpty()
 		lm.chDb = db
-		lm.tableDiscovery = newTableDiscoveryWith(config.QuesmaConfiguration{}, nil, *tableMap)
+		lm.tableDiscovery = newTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tableMap)
 
 		defer db.Close()
 

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -152,7 +152,7 @@ func logManagersNonEmpty(cfg *ChTableConfig) []logManagerHelper {
 			},
 			Created: created,
 		})
-		lms = append(lms, logManagerHelper{NewLogManager(full, config.QuesmaConfiguration{}), created})
+		lms = append(lms, logManagerHelper{NewLogManager(full, &config.QuesmaConfiguration{}), created})
 	}
 	return lms
 }
@@ -303,7 +303,7 @@ func TestInsertVeryBigIntegers(t *testing.T) {
 			db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 			lm := NewLogManagerEmpty()
 			lm.chDb = db
-			lm.tableDiscovery = newTableDiscoveryWith(config.QuesmaConfiguration{}, nil, *tableMapNoSchemaFields)
+			lm.tableDiscovery = newTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tableMapNoSchemaFields)
 			defer db.Close()
 
 			mock.ExpectExec(`CREATE TABLE IF NOT EXISTS "` + tableName).WillReturnResult(sqlmock.NewResult(0, 0))

--- a/quesma/clickhouse/table.go
+++ b/quesma/clickhouse/table.go
@@ -118,7 +118,7 @@ func (t *Table) GetDateTimeTypeFromExpr(ctx context.Context, expr model.Expr) Da
 }
 
 // applyIndexConfig applies full text search and alias configuration to the table
-func (t *Table) applyIndexConfig(configuration config.QuesmaConfiguration) {
+func (t *Table) applyIndexConfig(configuration *config.QuesmaConfiguration) {
 	for _, c := range t.Cols {
 		c.IsFullTextMatch = configuration.IsFullTextMatchField(t.Name, c.Name)
 	}

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -39,7 +39,7 @@ type TableDiscovery interface {
 }
 
 type tableDiscovery struct {
-	cfg                               config.QuesmaConfiguration
+	cfg                               *config.QuesmaConfiguration
 	dbConnPool                        *sql.DB
 	tableVerifier                     tableVerifier
 	tableDefinitions                  *atomic.Pointer[TableMap]
@@ -49,7 +49,7 @@ type tableDiscovery struct {
 	ReloadTablesError                 error
 }
 
-func NewTableDiscovery(cfg config.QuesmaConfiguration, dbConnPool *sql.DB) TableDiscovery {
+func NewTableDiscovery(cfg *config.QuesmaConfiguration, dbConnPool *sql.DB) TableDiscovery {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(NewTableMap())
 	result := &tableDiscovery{
@@ -83,7 +83,7 @@ func (t TableDiscoveryTableProviderAdapter) TableDefinitions() map[string]schema
 	return tables
 }
 
-func newTableDiscoveryWith(cfg config.QuesmaConfiguration, dbConnPool *sql.DB, tables TableMap) TableDiscovery {
+func newTableDiscoveryWith(cfg *config.QuesmaConfiguration, dbConnPool *sql.DB, tables TableMap) TableDiscovery {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(&tables)
 	result := &tableDiscovery{
@@ -202,7 +202,7 @@ func (td *tableDiscovery) autoConfigureTables(tables map[string]map[string]strin
 	return
 }
 
-func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]discoveredTable, databaseName string, cfg config.QuesmaConfiguration) {
+func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]discoveredTable, databaseName string, cfg *config.QuesmaConfiguration) {
 	tableMap := NewTableMap()
 	for tableName, resTable := range configuredTables {
 		var columnsMap = make(map[string]*Column)

--- a/quesma/connectors/connector.go
+++ b/quesma/connectors/connector.go
@@ -37,13 +37,13 @@ func (c *ConnectorManager) GetConnector() *clickhouse.LogManager {
 	return c.connectors[0].GetConnector()
 }
 
-func NewConnectorManager(cfg config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery, registry schema.Registry) *ConnectorManager {
+func NewConnectorManager(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery, registry schema.Registry) *ConnectorManager {
 	return &ConnectorManager{
 		connectors: registerConnectors(cfg, chDb, phoneHomeAgent, loader, registry),
 	}
 }
 
-func registerConnectors(cfg config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery, registry schema.Registry) (conns []Connector) {
+func registerConnectors(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery, registry schema.Registry) (conns []Connector) {
 	for connName, conn := range cfg.Connectors {
 		logger.Info().Msgf("Registering connector named [%s] of type [%s]", connName, conn.ConnectorType)
 		switch conn.ConnectorType {

--- a/quesma/health/elastic.go
+++ b/quesma/health/elastic.go
@@ -13,10 +13,10 @@ import (
 )
 
 type ElasticHealthChecker struct {
-	cfg config.QuesmaConfiguration
+	cfg *config.QuesmaConfiguration
 }
 
-func NewElasticHealthChecker(cfg config.QuesmaConfiguration) Checker {
+func NewElasticHealthChecker(cfg *config.QuesmaConfiguration) Checker {
 	return &ElasticHealthChecker{cfg: cfg}
 }
 

--- a/quesma/jsonprocessor/ingest.go
+++ b/quesma/jsonprocessor/ingest.go
@@ -20,7 +20,7 @@ func (t *ingestTransformer) Transform(document types.JSON) (types.JSON, error) {
 }
 
 // right now all transformers are the same, but we can add more in the future
-func IngestTransformerFor(table string, cfg config.QuesmaConfiguration) IngestTransformer {
+func IngestTransformerFor(table string, cfg *config.QuesmaConfiguration) IngestTransformer {
 
 	var transformers []IngestTransformer
 

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -19,11 +19,11 @@ type OptimizeTransformer interface {
 
 // OptimizePipeline - a transformer that optimizes queries
 type OptimizePipeline struct {
-	config        config.QuesmaConfiguration
+	config        *config.QuesmaConfiguration
 	optimizations []OptimizeTransformer
 }
 
-func NewOptimizePipeline(config config.QuesmaConfiguration) model.QueryTransformer {
+func NewOptimizePipeline(config *config.QuesmaConfiguration) model.QueryTransformer {
 
 	return &OptimizePipeline{
 		config: config,

--- a/quesma/optimize/pipeline_test.go
+++ b/quesma/optimize/pipeline_test.go
@@ -57,7 +57,7 @@ func Test_cacheQueries(t *testing.T) {
 					TableName:     tt.tableName,
 				},
 			}
-			pipeline := NewOptimizePipeline(cfg)
+			pipeline := NewOptimizePipeline(&cfg)
 			optimized, err := pipeline.Transform(queries)
 			if err != nil {
 				t.Fatalf("error optimizing query: %v", err)
@@ -210,7 +210,7 @@ func Test_dateTrunc(t *testing.T) {
 					SelectCommand: tt.query,
 				},
 			}
-			pipeline := NewOptimizePipeline(cfg)
+			pipeline := NewOptimizePipeline(&cfg)
 			optimized, err := pipeline.Transform(queries)
 
 			if err != nil {
@@ -447,7 +447,7 @@ func Test_materialized_view_replace(t *testing.T) {
 					SelectCommand: tt.query,
 				},
 			}
-			pipeline := NewOptimizePipeline(cfg)
+			pipeline := NewOptimizePipeline(&cfg)
 			optimized, err := pipeline.Transform(queries)
 
 			if err != nil {

--- a/quesma/proxy/l4_proxy.go
+++ b/quesma/proxy/l4_proxy.go
@@ -57,7 +57,7 @@ func resolveHttpServer(inspect bool) *http.Server {
 
 func configureRouting() *http.ServeMux {
 	router := http.NewServeMux()
-	configuration := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", Disabled: false}}}
+	configuration := &config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", Disabled: false}}}
 	router.HandleFunc("POST /{index}/_doc", util.BodyHandler(func(body []byte, writer http.ResponseWriter, r *http.Request) {
 		index := r.PathValue("index")
 

--- a/quesma/queryparser/aggregation_parser_new_logic_test.go
+++ b/quesma/queryparser/aggregation_parser_new_logic_test.go
@@ -35,7 +35,7 @@ func Test3AggregationParserNewLogic(t *testing.T) {
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
 
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -668,7 +668,7 @@ func TestAggregationParser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -767,7 +767,8 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 		Name:   tableName,
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), config.QuesmaConfiguration{})
+	cfg := &config.QuesmaConfiguration{}
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), cfg)
 
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
@@ -788,7 +789,7 @@ func Test2AggregationParserExternalTestcases(t *testing.T) {
 		},
 	}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s, Config: cfg}
 	for i, test := range allAggregationTests() {
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {
 			if test.TestName == "Max/Sum bucket with some null buckets. Reproduce: Visualize -> Vertical Bar: Metrics: Max (Sum) Bucket (Aggregation: Date Histogram, Metric: Min)" {

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -36,7 +36,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
 
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
 	schemaRegistry := schema.StaticRegistry{}
 
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: schemaRegistry}
@@ -227,7 +227,7 @@ func TestPancakeQueryGeneration_halfpancake(t *testing.T) {
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
 
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
 	schemaRegistry := schema.StaticRegistry{}
 
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: schemaRegistry}

--- a/quesma/queryparser/query_parser_async_search_test.go
+++ b/quesma/queryparser/query_parser_async_search_test.go
@@ -26,7 +26,7 @@ func TestQueryParserAsyncSearch(t *testing.T) {
 		},
 		Created: true,
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -58,7 +58,7 @@ func TestQueryParserAsyncSearch(t *testing.T) {
 // TODO this test doesn't work for now, as it's left for next (last) PR
 func TestQueryParserAggregation(t *testing.T) {
 	table := clickhouse.NewEmptyTable("tablename")
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith("tablename", table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith("tablename", table), &config.QuesmaConfiguration{})
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"tablename": {

--- a/quesma/queryparser/query_parser_range_test.go
+++ b/quesma/queryparser/query_parser_range_test.go
@@ -102,7 +102,7 @@ func Test_parseRange(t *testing.T) {
 				t.Fatal(err)
 			}
 			assert.NoError(t, err)
-			lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
+			lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
 			cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
 
 			simpleQuery := cw.parseRange(test.rangePartOfQuery)

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -46,7 +46,7 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 
 	cfg.IndexConfig[indexConfig.Name] = indexConfig
 
-	lm := clickhouse.NewEmptyLogManager(cfg, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewTableDiscovery(config.QuesmaConfiguration{}, nil), schema.StaticRegistry{})
+	lm := clickhouse.NewEmptyLogManager(&cfg, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewTableDiscovery(&config.QuesmaConfiguration{}, nil), schema.StaticRegistry{})
 	lm.AddTableIfDoesntExist(table)
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
@@ -66,7 +66,7 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
 
 	for i, tt := range testdata.TestsSearch {
 		t.Run(fmt.Sprintf("%s(%d)", tt.Name, i), func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 		},
 		Created: true,
 	}
-	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewTableDiscovery(config.QuesmaConfiguration{}, nil), schema.StaticRegistry{})
+	lm := clickhouse.NewEmptyLogManager(&config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), clickhouse.NewTableDiscovery(&config.QuesmaConfiguration{}, nil), schema.StaticRegistry{})
 	lm.AddTableIfDoesntExist(&table)
 	indexConfig := config.IndexConfiguration{
 		Name: "logs-generic-default",
@@ -130,7 +130,7 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
 
 	for i, tt := range testdata.TestsSearchNoFullTextFields {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -196,8 +196,8 @@ func TestQueryParserNoAttrsConfig(t *testing.T) {
 			},
 		},
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
 	for _, tt := range testdata.TestsSearchNoAttrs {
 		t.Run(tt.Name, func(t *testing.T) {
 			body, parseErr := types.ParseJSON(tt.QueryJson)
@@ -401,7 +401,7 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -486,7 +486,7 @@ func Test_parseSortFields(t *testing.T) {
 		ENGINE = Memory`,
 		clickhouse.NewChTableConfigNoAttrs(),
 	)
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background()}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -30,7 +30,7 @@ type ClickhouseQueryTranslator struct {
 
 	SchemaRegistry    schema.Registry
 	IncomingIndexName string
-	Config            config.QuesmaConfiguration
+	Config            *config.QuesmaConfiguration
 }
 
 var completionStatusOK = func() *int { value := 200; return &value }()

--- a/quesma/queryparser/query_translator_test.go
+++ b/quesma/queryparser/query_translator_test.go
@@ -533,7 +533,7 @@ func TestMakeResponseAsyncSearchQueryIsProperJson(t *testing.T) {
 		ENGINE = Memory`,
 		clickhouse.NewNoTimestampOnlyStringAttrCHConfig(),
 	)
-	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), config.QuesmaConfiguration{})
+	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
 	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background()}
 	queries := []*model.Query{
 		cw.BuildAutocompleteSuggestionsQuery("@", "", 0),

--- a/quesma/quesma/config/util.go
+++ b/quesma/quesma/config/util.go
@@ -11,7 +11,7 @@ import (
 
 var insertCounter = atomic.Int32{}
 
-func RunConfigured(ctx context.Context, cfg QuesmaConfiguration, indexName string, body types.JSON, action func() error) {
+func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName string, body types.JSON, action func() error) {
 	if len(cfg.IndexConfig) == 0 {
 		logger.InfoWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s", indexName, body.ShortString())
 		err := action()
@@ -41,7 +41,7 @@ func RunConfigured(ctx context.Context, cfg QuesmaConfiguration, indexName strin
 
 var matchCounter = atomic.Int32{}
 
-func findMatchingConfig(indexPattern string, cfg QuesmaConfiguration) (IndexConfiguration, bool) {
+func findMatchingConfig(indexPattern string, cfg *QuesmaConfiguration) (IndexConfiguration, bool) {
 	matchCounter.Add(1)
 	for _, indexConfig := range cfg.IndexConfig {
 		if matchCounter.Load()%100 == 1 {

--- a/quesma/quesma/dual_write_proxy.go
+++ b/quesma/quesma/dual_write_proxy.go
@@ -67,7 +67,7 @@ func (q *dualWriteHttpProxy) Stop(ctx context.Context) {
 	q.Close(ctx)
 }
 
-func newDualWriteProxy(schemaLoader clickhouse.TableDiscovery, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, registry schema.Registry, config config.QuesmaConfiguration, pathRouter *mux.PathRouter, quesmaManagementConsole *ui.QuesmaManagementConsole, agent telemetry.PhoneHomeAgent, queryRunner *QueryRunner) *dualWriteHttpProxy {
+func newDualWriteProxy(schemaLoader clickhouse.TableDiscovery, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, registry schema.Registry, config *config.QuesmaConfiguration, pathRouter *mux.PathRouter, quesmaManagementConsole *ui.QuesmaManagementConsole, agent telemetry.PhoneHomeAgent, queryRunner *QueryRunner) *dualWriteHttpProxy {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -64,7 +64,7 @@ type (
 )
 
 func Write(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *clickhouse.LogManager,
-	cfg config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []BulkItem, err error) {
+	cfg *config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (results []BulkItem, err error) {
 	defer recovery.LogPanic()
 
 	bulkSize := len(bulk) / 2 // we divided payload by 2 so that we don't take into account the `action_and_meta_data` line, ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
@@ -87,7 +87,7 @@ func Write(ctx context.Context, defaultIndex *string, bulk types.NDJSON, lm *cli
 	return results, nil
 }
 
-func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bulkSize int, cfg config.QuesmaConfiguration) ([]BulkItem, map[string][]BulkRequestEntry, []byte, []BulkRequestEntry, error) {
+func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bulkSize int, cfg *config.QuesmaConfiguration) ([]BulkItem, map[string][]BulkRequestEntry, []byte, []BulkRequestEntry, error) {
 	results := make([]BulkItem, bulkSize)
 
 	clickhouseDocumentsToInsert := make(map[string][]BulkRequestEntry, bulkSize)
@@ -149,7 +149,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 	return results, clickhouseDocumentsToInsert, elasticRequestBody, elasticBulkEntries, err
 }
 
-func sendToElastic(elasticRequestBody []byte, cfg config.QuesmaConfiguration, elasticBulkEntries []BulkRequestEntry) error {
+func sendToElastic(elasticRequestBody []byte, cfg *config.QuesmaConfiguration, elasticBulkEntries []BulkRequestEntry) error {
 	if len(elasticRequestBody) == 0 {
 		// Fast path - no need to contact Elastic!
 		return nil
@@ -186,7 +186,7 @@ func sendToElastic(elasticRequestBody []byte, cfg config.QuesmaConfiguration, el
 	return nil
 }
 
-func sendToClickhouse(ctx context.Context, clickhouseDocumentsToInsert map[string][]BulkRequestEntry, phoneHomeAgent telemetry.PhoneHomeAgent, cfg config.QuesmaConfiguration, lm *clickhouse.LogManager) {
+func sendToClickhouse(ctx context.Context, clickhouseDocumentsToInsert map[string][]BulkRequestEntry, phoneHomeAgent telemetry.PhoneHomeAgent, cfg *config.QuesmaConfiguration, lm *clickhouse.LogManager) {
 	for indexName, documents := range clickhouseDocumentsToInsert {
 		phoneHomeAgent.IngestCounters().Add(indexName, int64(len(documents)))
 

--- a/quesma/quesma/functionality/doc/doc.go
+++ b/quesma/quesma/functionality/doc/doc.go
@@ -12,7 +12,7 @@ import (
 	"quesma/stats"
 )
 
-func Write(ctx context.Context, tableName string, body types.JSON, lm *clickhouse.LogManager, cfg config.QuesmaConfiguration) error {
+func Write(ctx context.Context, tableName string, body types.JSON, lm *clickhouse.LogManager, cfg *config.QuesmaConfiguration) error {
 	stats.GlobalStatistics.Process(cfg, tableName, body, clickhouse.NestedSeparator)
 
 	defer recovery.LogPanic()

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -41,7 +41,7 @@ func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.Fie
 		fields[colName][fieldTypeName] = fieldCapability
 	}
 }
-func handleFieldCapsIndex(cfg config.QuesmaConfiguration, schemaRegistry schema.Registry, indexes []string) ([]byte, error) {
+func handleFieldCapsIndex(cfg *config.QuesmaConfiguration, schemaRegistry schema.Registry, indexes []string) ([]byte, error) {
 	fields := make(map[string]map[string]model.FieldCapability)
 	for _, resolvedIndex := range indexes {
 		if len(resolvedIndex) == 0 {
@@ -100,7 +100,7 @@ func EmptyFieldCapsResponse() []byte {
 	}
 }
 
-func HandleFieldCaps(ctx context.Context, cfg config.QuesmaConfiguration, schemaRegistry schema.Registry, index string, lm *clickhouse.LogManager) ([]byte, error) {
+func HandleFieldCaps(ctx context.Context, cfg *config.QuesmaConfiguration, schemaRegistry schema.Registry, index string, lm *clickhouse.LogManager) ([]byte, error) {
 	if len(cfg.IndexConfig[index].Override) > 0 {
 		index = cfg.IndexConfig[index].Override
 	}

--- a/quesma/quesma/functionality/field_capabilities/field_caps_test.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps_test.go
@@ -76,7 +76,7 @@ func TestFieldCaps(t *testing.T) {
   ]
 }
 `)
-	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
+	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-generic-default": {
 				Name: "logs-generic-default",
@@ -140,7 +140,7 @@ func TestFieldCapsWithAliases(t *testing.T) {
     "logs-generic-default"
   ]
 }`)
-	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
+	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Name: "logs-generic-default"}},
 	}, schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
@@ -180,7 +180,7 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 			"foo.bar2": {Name: "foo.bar2", Type: clickhouse.BaseType{Name: "String"}},
 		},
 	})
-	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
+	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
 				Name: "logs-1",
@@ -287,7 +287,7 @@ func TestFieldCapsMultipleIndexesConflictingEntries(t *testing.T) {
 			"foo.bar": {Name: "foo.bar", Type: clickhouse.BaseType{Name: "Boolean"}},
 		},
 	})
-	resp, err := handleFieldCapsIndex(config.QuesmaConfiguration{
+	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
 				Name: "logs-1",

--- a/quesma/quesma/functionality/resolve/resolve.go
+++ b/quesma/quesma/functionality/resolve/resolve.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 )
 
-func HandleResolve(pattern string, sr schema.Registry, cfg config.QuesmaConfiguration) (elasticsearch.Sources, error) {
+func HandleResolve(pattern string, sr schema.Registry, cfg *config.QuesmaConfiguration) (elasticsearch.Sources, error) {
 	// In the _resolve endpoint we want to combine the results from both schema.Registry and Elasticsearch
 
 	normalizedPattern := elasticsearch.NormalizePattern(pattern)

--- a/quesma/quesma/functionality/terms_enum/terms_enum_test.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum_test.go
@@ -80,7 +80,7 @@ func TestHandleTermsEnumRequest(t *testing.T) {
 		Created: true,
 	}
 
-	managementConsole := ui.NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(testTableName, table))

--- a/quesma/quesma/highlight_test.go
+++ b/quesma/quesma/highlight_test.go
@@ -110,7 +110,7 @@ func TestParseHighLight(t *testing.T) {
 		Config: clickhouse.NewDefaultCHConfig(),
 	}
 
-	lm := clickhouse.NewEmptyLogManager(config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), nil, schema.StaticRegistry{})
+	lm := clickhouse.NewEmptyLogManager(&config.QuesmaConfiguration{}, nil, telemetry.NewPhoneHomeEmptyAgent(), nil, schema.StaticRegistry{})
 
 	cw := queryparser.ClickhouseQueryTranslator{
 		ClickhouseLM: lm,

--- a/quesma/quesma/matchers.go
+++ b/quesma/quesma/matchers.go
@@ -22,7 +22,7 @@ func matchedAgainstAsyncId() mux.RequestMatcher {
 	})
 }
 
-func matchedAgainstBulkBody(configuration config.QuesmaConfiguration) mux.RequestMatcher {
+func matchedAgainstBulkBody(configuration *config.QuesmaConfiguration) mux.RequestMatcher {
 	return mux.RequestMatcherFunc(func(req *mux.Request) bool {
 		idx := 0
 		for _, s := range strings.Split(req.Body, "\n") {
@@ -44,7 +44,7 @@ func matchedAgainstBulkBody(configuration config.QuesmaConfiguration) mux.Reques
 	})
 }
 
-func matchedAgainstPattern(configuration config.QuesmaConfiguration) mux.RequestMatcher {
+func matchedAgainstPattern(configuration *config.QuesmaConfiguration) mux.RequestMatcher {
 	return mux.RequestMatcherFunc(func(req *mux.Request) bool {
 		indexPattern := elasticsearch.NormalizePattern(req.Params["index"])
 		if elasticsearch.IsInternalIndex(indexPattern) {

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -33,7 +33,7 @@ const (
 	QueryLanguageEQL     = "eql"
 )
 
-func NewQueryTranslator(ctx context.Context, language QueryLanguage, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, schemaRegistry schema.Registry, incomingIndexName string, configuration config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
+func NewQueryTranslator(ctx context.Context, language QueryLanguage, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, schemaRegistry schema.Registry, incomingIndexName string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
 	switch language {
 	case QueryLanguageEQL:
 		return &eql.ClickhouseEQLQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx}

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -38,7 +38,7 @@ type (
 		processor               engine
 		publicTcpPort           network.Port
 		quesmaManagementConsole *ui.QuesmaManagementConsole
-		config                  config.QuesmaConfiguration
+		config                  *config.QuesmaConfiguration
 		telemetryAgent          telemetry.PhoneHomeAgent
 	}
 	engine interface {
@@ -108,7 +108,7 @@ func sendElkResponseToQuesmaConsole(ctx context.Context, elkResponse elasticResu
 	console.PushPrimaryInfo(&ui.QueryDebugPrimarySource{Id: id, QueryResp: body, PrimaryTook: elkResponse.took})
 }
 
-func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.QuesmaConfiguration, quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, inspect bool) *Quesma {
+func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config *config.QuesmaConfiguration, quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, inspect bool) *Quesma {
 	return &Quesma{
 		processor:               proxy.NewTcpProxy(config.PublicTcpPort, config.Elasticsearch.Url.Host, inspect),
 		publicTcpPort:           config.PublicTcpPort,
@@ -118,7 +118,7 @@ func NewQuesmaTcpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, config config.Qu
 }
 
 func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhouse.LogManager, schemaLoader clickhouse.TableDiscovery,
-	indexManager elasticsearch.IndexManagement, schemaRegistry schema.Registry, config config.QuesmaConfiguration,
+	indexManager elasticsearch.IndexManagement, schemaRegistry schema.Registry, config *config.QuesmaConfiguration,
 	quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, abResultsRepository ab_testing.Sender) *Quesma {
 	queryRunner := NewQueryRunner(logManager, config, indexManager, quesmaManagementConsole, schemaRegistry, abResultsRepository)
 
@@ -141,7 +141,7 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent, logManager *clickhous
 }
 
 type router struct {
-	config                  config.QuesmaConfiguration
+	config                  *config.QuesmaConfiguration
 	requestPreprocessors    processorChain
 	quesmaManagementConsole *ui.QuesmaManagementConsole
 	phoneHomeAgent          telemetry.PhoneHomeAgent

--- a/quesma/quesma/quesma_test.go
+++ b/quesma/quesma/quesma_test.go
@@ -18,7 +18,7 @@ func TestShouldExposePprof(t *testing.T) {
 
 	t.Skip("FIXME @pivovarit: this test is flaky, it should be fixed")
 
-	quesma := NewQuesmaTcpProxy(telemetry.NoopPhoneHomeAgent(), config.QuesmaConfiguration{
+	quesma := NewQuesmaTcpProxy(telemetry.NoopPhoneHomeAgent(), &config.QuesmaConfiguration{
 		PublicTcpPort: 8080,
 		Elasticsearch: config.ElasticsearchConfiguration{Url: &config.Url{}},
 	}, nil, make(<-chan logger.LogWithLevel), false)

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -30,7 +30,7 @@ import (
 	"time"
 )
 
-func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *clickhouse.LogManager, console *ui.QuesmaManagementConsole, phoneHomeAgent telemetry.PhoneHomeAgent, queryRunner *QueryRunner) *mux.PathRouter {
+func configureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *clickhouse.LogManager, console *ui.QuesmaManagementConsole, phoneHomeAgent telemetry.PhoneHomeAgent, queryRunner *QueryRunner) *mux.PathRouter {
 
 	// some syntactic sugar
 	method := mux.IsHTTPMethod
@@ -326,7 +326,7 @@ func configureRouter(cfg config.QuesmaConfiguration, sr schema.Registry, lm *cli
 }
 
 // check whether exact index name is enabled
-func matchedExact(config config.QuesmaConfiguration) mux.RequestMatcher {
+func matchedExact(config *config.QuesmaConfiguration) mux.RequestMatcher {
 	return mux.RequestMatcherFunc(func(req *mux.Request) bool {
 		if elasticsearch.IsInternalIndex(req.Params["index"]) {
 			logger.Debug().Msgf("index %s is an internal Elasticsearch index, skipping", req.Params["index"])

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -41,7 +41,7 @@ func Test_matchedAgainstConfig(t *testing.T) {
 
 			req := &mux.Request{Params: map[string]string{"index": tt.index}, Body: tt.body}
 
-			assert.Equalf(t, tt.want, matchedExact(tt.config).Matches(req), "matchedAgainstConfig(%v), index: %s", tt.config, tt.index)
+			assert.Equalf(t, tt.want, matchedExact(&tt.config).Matches(req), "matchedAgainstConfig(%v), index: %s", tt.config, tt.index)
 		})
 	}
 }
@@ -132,7 +132,7 @@ func Test_matchedAgainstPattern(t *testing.T) {
 
 			req := &mux.Request{Params: map[string]string{"index": tt.pattern}, Body: tt.body}
 
-			assert.Equalf(t, tt.want, matchedAgainstPattern(tt.configuration).Matches(req), "matchedAgainstPattern(%v)", tt.configuration)
+			assert.Equalf(t, tt.want, matchedAgainstPattern(&tt.configuration).Matches(req), "matchedAgainstPattern(%v)", tt.configuration)
 		})
 	}
 }
@@ -183,7 +183,7 @@ func Test_matchedAgainstBulkBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			req := &mux.Request{Body: tt.body}
-			assert.Equalf(t, tt.want, matchedAgainstBulkBody(tt.config).Matches(req), "matchedAgainstBulkBody(%+v)", tt.config)
+			assert.Equalf(t, tt.want, matchedAgainstBulkBody(&tt.config).Matches(req), "matchedAgainstBulkBody(%+v)", tt.config)
 		})
 	}
 }

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -69,7 +69,7 @@ func Test_ipRangeTransform(t *testing.T) {
 				"nested::clientip": {Name: "nested::clientip", Type: "ip"},
 			}},
 		}}
-	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{})
+	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
 	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s, logManager: clickhouse.NewLogManagerEmpty()}
 
 	expectedQueries := []*model.Query{
@@ -420,7 +420,7 @@ func Test_arrayType(t *testing.T) {
 	}
 	td.Store("kibana_sample_data_ecommerce", &tableDefinition)
 
-	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{})
+	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
 	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s, logManager: lm}
 
 	tests := []struct {
@@ -612,7 +612,7 @@ func TestApplyWildCard(t *testing.T) {
 	}
 	td.Store(tableDefinition.Name, &tableDefinition)
 
-	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{})
+	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
 	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s, logManager: lm}
 
 	tests := []struct {

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -55,7 +55,7 @@ type QueryRunner struct {
 	AsyncRequestStorage     *concurrent.Map[string, AsyncRequestResult]
 	AsyncQueriesContexts    *concurrent.Map[string, *AsyncQueryContext]
 	logManager              *clickhouse.LogManager
-	cfg                     config.QuesmaConfiguration
+	cfg                     *config.QuesmaConfiguration
 	im                      elasticsearch.IndexManagement
 	quesmaManagementConsole *ui.QuesmaManagementConsole
 
@@ -69,11 +69,11 @@ type QueryRunner struct {
 	ABResultsSender          ab_testing.Sender
 }
 
-func (q *QueryRunner) EnableQueryOptimization(cfg config.QuesmaConfiguration) {
+func (q *QueryRunner) EnableQueryOptimization(cfg *config.QuesmaConfiguration) {
 	q.transformationPipeline.transformers = append(q.transformationPipeline.transformers, optimize.NewOptimizePipeline(cfg))
 }
 
-func NewQueryRunner(lm *clickhouse.LogManager, cfg config.QuesmaConfiguration, im elasticsearch.IndexManagement, qmc *ui.QuesmaManagementConsole, schemaRegistry schema.Registry, abResultsRepository ab_testing.Sender) *QueryRunner {
+func NewQueryRunner(lm *clickhouse.LogManager, cfg *config.QuesmaConfiguration, im elasticsearch.IndexManagement, qmc *ui.QuesmaManagementConsole, schemaRegistry schema.Registry, abResultsRepository ab_testing.Sender) *QueryRunner {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &QueryRunner{logManager: lm, cfg: cfg, im: im, quesmaManagementConsole: qmc,

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -43,7 +43,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 			lm := clickhouse.NewLogManagerWithConnection(db, table)
 			cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 			logChan := logger.InitOnlyChannelLoggerForTests()
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
+			managementConsole := ui.NewQuesmaManagementConsole(&cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 			go managementConsole.RunOnlyChannelProcessor()
 			s := schema.StaticRegistry{
 				Tables: map[schema.TableName]schema.Schema{
@@ -63,7 +63,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 				},
 			}
 
-			queryRunner := NewQueryRunner(lm, cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
+			queryRunner := NewQueryRunner(lm, &cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
 			newCtx := context.WithValue(ctx, tracing.RequestIdCtxKey, tracing.GetRequestId())
 			_, _ = queryRunner.handleSearch(newCtx, tableName, types.MustJSON(tt.QueryRequestJson))
 
@@ -111,7 +111,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 	lm := clickhouse.NewLogManagerWithConnection(db, table)
 	cfg := config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
 	logChan := logger.InitOnlyChannelLoggerForTests()
-	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(&cfg, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	go managementConsole.RunOnlyChannelProcessor()
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
@@ -132,7 +132,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 		},
 	}
 
-	queryRunner := NewQueryRunner(lm, cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
+	queryRunner := NewQueryRunner(lm, &cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
 	for _, testNr := range testNrs {
 		newCtx := context.WithValue(ctx, tracing.RequestIdCtxKey, tracing.GetRequestId())
 		_, _ = queryRunner.handleSearch(newCtx, tableName, types.MustJSON(testdata.UnsupportedQueriesTests[testNr].QueryRequestJson))

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -59,8 +59,8 @@ func TestSearchOpensearch(t *testing.T) {
 			db, mock := util.InitSqlMockWithPrettyPrint(t, false)
 			defer db.Close()
 			lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-			managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
-			cw := queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s}
+			managementConsole := ui.NewQuesmaManagementConsole(&cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+			cw := queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
 
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)
@@ -74,7 +74,7 @@ func TestSearchOpensearch(t *testing.T) {
 			for _, wantedRegex := range tt.WantedRegexes {
 				mock.ExpectQuery(testdata.EscapeBrackets(wantedRegex)).WillReturnRows(sqlmock.NewRows([]string{"@timestamp", "host.name"}))
 			}
-			queryRunner := NewQueryRunner(lm, cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
+			queryRunner := NewQueryRunner(lm, &cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
 			_, err2 := queryRunner.handleSearch(ctx, tableName, types.MustJSON(tt.QueryJson))
 			assert.NoError(t, err2)
 
@@ -211,7 +211,7 @@ func TestHighlighter(t *testing.T) {
 	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
-	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
+	managementConsole := ui.NewQuesmaManagementConsole(&cfg, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 	mock.ExpectQuery("").WillReturnRows(sqlmock.NewRows([]string{"message$*%:;", "host.name", "@timestamp"}). // careful, it's not always in this order, order is nondeterministic
 															AddRow("abcd", "abcd", "abcd").
@@ -220,7 +220,7 @@ func TestHighlighter(t *testing.T) {
 															AddRow("text-to-highlight", "text-to-highlight", "text-to-highlight").
 															AddRow("text", "text", "text"))
 
-	queryRunner := NewQueryRunner(lm, cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
+	queryRunner := NewQueryRunner(lm, &cfg, nil, managementConsole, s, ab_testing.NewEmptySender())
 	response, err := queryRunner.handleSearch(ctx, tableName, types.MustJSON(query))
 	assert.NoError(t, err)
 	if err != nil {

--- a/quesma/quesma/source_resolver.go
+++ b/quesma/quesma/source_resolver.go
@@ -18,7 +18,7 @@ const (
 	sourceNone          = "none"
 )
 
-func ResolveSources(indexPattern string, cfg config.QuesmaConfiguration, im elasticsearch.IndexManagement) (string, []string, []string) {
+func ResolveSources(indexPattern string, cfg *config.QuesmaConfiguration, im elasticsearch.IndexManagement) (string, []string, []string) {
 	if elasticsearch.IsIndexPattern(indexPattern) {
 		matchesElastic := []string{}
 		matchesClickhouse := []string{}

--- a/quesma/quesma/source_resolver_test.go
+++ b/quesma/quesma/source_resolver_test.go
@@ -86,7 +86,7 @@ func TestResolveSources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+tt.args.indexPattern, func(t *testing.T) {
-			got, _, _ := ResolveSources(tt.args.indexPattern, tt.args.cfg, tt.args.im)
+			got, _, _ := ResolveSources(tt.args.indexPattern, &tt.args.cfg, tt.args.im)
 			assert.Equalf(t, tt.want, got, "ResolveSources(%v, %v, %v)", tt.args.indexPattern, tt.args.cfg, tt.args.im)
 		})
 	}

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -21,7 +21,7 @@ func TestHtmlPages(t *testing.T) {
 	xssBytes := []byte(xss)
 	id := "b1c4a89e-4905-5e3c-b57f-dc92627d011e"
 	logChan := make(chan logger.LogWithLevel, 5)
-	qmc := NewQuesmaManagementConsole(config.QuesmaConfiguration{}, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
+	qmc := NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 	qmc.PushPrimaryInfo(&QueryDebugPrimarySource{Id: id, QueryResp: xssBytes})
 	qmc.PushSecondaryInfo(&QueryDebugSecondarySource{Id: id,
 		Path:                   xss,
@@ -57,8 +57,7 @@ func TestHtmlPages(t *testing.T) {
 	})
 
 	t.Run("statistics got no XSS", func(t *testing.T) {
-		cfg := config.QuesmaConfiguration{}
-		stats.GlobalStatistics.Process(cfg, xss, types.MustJSON("{}"), clickhouse.NestedSeparator)
+		stats.GlobalStatistics.Process(&config.QuesmaConfiguration{}, xss, types.MustJSON("{}"), clickhouse.NestedSeparator)
 		response := string(qmc.generateStatistics())
 		assert.NotContains(t, response, xss)
 	})
@@ -100,9 +99,9 @@ func TestHtmlSchemaPage(t *testing.T) {
 	tables := concurrent.NewMap[string, *clickhouse.Table]()
 	tables.Store(table.Name, table)
 
-	logManager := clickhouse.NewLogManager(tables, cfg)
+	logManager := clickhouse.NewLogManager(tables, &cfg)
 
-	qmc := NewQuesmaManagementConsole(cfg, logManager, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
+	qmc := NewQuesmaManagementConsole(&cfg, logManager, nil, logChan, telemetry.NewPhoneHomeEmptyAgent(), nil)
 
 	t.Run("schema got no XSS and no panic", func(t *testing.T) {
 		response := string(qmc.generateTables())

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -89,7 +89,7 @@ type (
 		debugInfoMessages         map[string]queryDebugInfo
 		debugLastMessages         []string
 		responseMatcherChannel    chan queryDebugInfo
-		cfg                       config.QuesmaConfiguration
+		cfg                       *config.QuesmaConfiguration
 		requestsStore             *stats.RequestStatisticStore
 		requestsSource            chan *recordRequests
 		startedAt                 time.Time
@@ -106,7 +106,7 @@ type (
 	}
 )
 
-func NewQuesmaManagementConsole(config config.QuesmaConfiguration, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, logChan <-chan logger.LogWithLevel, phoneHomeAgent telemetry.PhoneHomeAgent, schemasProvider SchemasProvider) *QuesmaManagementConsole {
+func NewQuesmaManagementConsole(cfg *config.QuesmaConfiguration, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, logChan <-chan logger.LogWithLevel, phoneHomeAgent telemetry.PhoneHomeAgent, schemasProvider SchemasProvider) *QuesmaManagementConsole {
 	return &QuesmaManagementConsole{
 		queryDebugPrimarySource:   make(chan *QueryDebugPrimarySource, 10),
 		queryDebugSecondarySource: make(chan *QueryDebugSecondarySource, 10),
@@ -114,7 +114,7 @@ func NewQuesmaManagementConsole(config config.QuesmaConfiguration, logManager *c
 		debugInfoMessages:         make(map[string]queryDebugInfo),
 		debugLastMessages:         make([]string, 0),
 		responseMatcherChannel:    make(chan queryDebugInfo, 5),
-		cfg:                       config,
+		cfg:                       cfg,
 		requestsStore:             stats.NewRequestStatisticStore(),
 		requestsSource:            make(chan *recordRequests, 100),
 		startedAt:                 time.Now(),

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -15,7 +15,7 @@ type (
 		UpdateDynamicConfiguration(name TableName, table Table)
 	}
 	schemaRegistry struct {
-		configuration           config.QuesmaConfiguration
+		configuration           *config.QuesmaConfiguration
 		dataSourceTableProvider TableProvider
 		dataSourceTypeAdapter   typeAdapter
 		dynamicConfiguration    map[string]Table
@@ -97,7 +97,7 @@ func (s *schemaRegistry) UpdateDynamicConfiguration(name TableName, table Table)
 	s.dynamicConfiguration[name.AsString()] = table
 }
 
-func NewSchemaRegistry(tableProvider TableProvider, configuration config.QuesmaConfiguration, dataSourceTypeAdapter typeAdapter) Registry {
+func NewSchemaRegistry(tableProvider TableProvider, configuration *config.QuesmaConfiguration, dataSourceTypeAdapter typeAdapter) Registry {
 	return &schemaRegistry{
 		configuration:           configuration,
 		dataSourceTableProvider: tableProvider,

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -257,7 +257,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := schema.NewSchemaRegistry(tt.tableDiscovery, tt.cfg, clickhouse.SchemaTypeAdapter{})
+			s := schema.NewSchemaRegistry(tt.tableDiscovery, &tt.cfg, clickhouse.SchemaTypeAdapter{})
 			resultSchema, resultFound := s.FindSchema(tt.tableName)
 			if resultFound != tt.found {
 				t.Errorf("FindSchema() got1 = %v, want %v", resultFound, tt.found)
@@ -286,7 +286,7 @@ func Test_schemaRegistry_UpdateDynamicConfiguration(t *testing.T) {
 		}},
 	}}
 
-	s := schema.NewSchemaRegistry(tableDiscovery, cfg, clickhouse.SchemaTypeAdapter{})
+	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
 
 	expectedSchema := schema.NewSchema(map[schema.FieldName]schema.Field{
 		"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.TypeKeyword},

--- a/quesma/stats/ingest_statistics.go
+++ b/quesma/stats/ingest_statistics.go
@@ -99,7 +99,6 @@ func (s *Statistics) process(cfg *config.QuesmaConfiguration, index string,
 	// TODO as proper eviction strategy requires some time
 	// to be implemented, we limit the number of requests for now
 	if statistics.Requests >= STATISTICS_LIMIT {
-		cfg.IngestStatistics = false
 		return
 	}
 

--- a/quesma/stats/ingest_statistics.go
+++ b/quesma/stats/ingest_statistics.go
@@ -79,7 +79,7 @@ func (s *Statistics) getValueStatisticsPtr(keyStatistics *KeyStatistics, nonSche
 	}
 }
 
-func (s *Statistics) process(cfg config.QuesmaConfiguration, index string,
+func (s *Statistics) process(cfg *config.QuesmaConfiguration, index string,
 	jsonData types.JSON, nonSchemaFields bool, nestedSeparator string) {
 	// TODO reading cfg.IngestStatistics is not thread safe
 	if !cfg.IngestStatistics {
@@ -126,14 +126,14 @@ func (s *Statistics) process(cfg config.QuesmaConfiguration, index string,
 	}
 }
 
-func (s *Statistics) Process(cfg config.QuesmaConfiguration, index string, jsonData types.JSON, nestedSeparator string) {
+func (s *Statistics) Process(cfg *config.QuesmaConfiguration, index string, jsonData types.JSON, nestedSeparator string) {
 	s.process(cfg, index, jsonData, false, nestedSeparator)
 	if statistics, ok := (*s)[index]; ok {
 		statistics.Requests++
 	}
 }
 
-func (s *Statistics) UpdateNonSchemaValues(cfg config.QuesmaConfiguration, index string, jsonData types.JSON, nestedSeparator string) {
+func (s *Statistics) UpdateNonSchemaValues(cfg *config.QuesmaConfiguration, index string, jsonData types.JSON, nestedSeparator string) {
 	s.process(cfg, index, jsonData, true, nestedSeparator)
 }
 

--- a/quesma/stats/ingest_statistics_test.go
+++ b/quesma/stats/ingest_statistics_test.go
@@ -45,10 +45,10 @@ func TestStatistics_process(t *testing.T) {
 	cfg := config.QuesmaConfiguration{
 		IngestStatistics: true,
 	}
-	stats.Process(cfg, "index1", types.MustJSON(string(marshal1)), "::")
-	stats.Process(cfg, "index1", types.MustJSON(string(marshal2)), "::")
-	stats.Process(cfg, "index1", types.MustJSON(string(marshal3)), "::")
-	stats.Process(cfg, "index1", types.MustJSON(string(marshal3)), "::")
+	stats.Process(&cfg, "index1", types.MustJSON(string(marshal1)), "::")
+	stats.Process(&cfg, "index1", types.MustJSON(string(marshal2)), "::")
+	stats.Process(&cfg, "index1", types.MustJSON(string(marshal3)), "::")
+	stats.Process(&cfg, "index1", types.MustJSON(string(marshal3)), "::")
 
 	ingestStats := (*stats)["index1"]
 

--- a/quesma/telemetry/phone_home.go
+++ b/quesma/telemetry/phone_home.go
@@ -130,7 +130,7 @@ type agent struct {
 	cancel context.CancelFunc
 
 	clickHouseDb *sql.DB
-	config       config.QuesmaConfiguration
+	config       *config.QuesmaConfiguration
 	clientId     string
 
 	instanceId string
@@ -175,7 +175,7 @@ func hostname() string {
 	return name
 }
 
-func NewPhoneHomeAgent(configuration config.QuesmaConfiguration, clickHouseDb *sql.DB, clientId string) PhoneHomeAgent {
+func NewPhoneHomeAgent(configuration *config.QuesmaConfiguration, clickHouseDb *sql.DB, clientId string) PhoneHomeAgent {
 
 	// TODO
 	// this is a question, maybe we should inherit context from the caller


### PR DESCRIPTION
While working on #683, I noticed that the code in `process()` in `Statistics` modified `QuesmaConfiguration` struct. However, since `QuesmaConfiguration` was passed by value, not by pointer, this modification essentially did nothing.

That (attempted) modification of global state is not that clean (fixed in the second commit), but **this highlighted an issue**: the entire codebase always passes `QuesmaConfiguration` by value (and this is quite a big struct!), not by pointer. Apart from potential performance penalty (but did not profile it), this also makes it not possible to change the configuration in the runtime (since everyone is using their own copy).

Fix the issue by modifying all uses of `QuesmaConfiguration` to pass it as a pointer.