### PR TITLE
Pipeline validation

### DIFF
--- a/ci/quesma/config/ci-config.yaml
+++ b/ci/quesma/config/ci-config.yaml
@@ -1,7 +1,11 @@
 installationId: "just-Quesma-smoke-test-instance"
 frontendConnectors:
-  - name: elasticsearchFakedAPI
-    type: elasticsearch-fe
+  - name: elasticsearch-API-for-kibana
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+  - name: elasticsearch-API-for-filebeat
+    type: elasticsearch-fe-ingest
     config:
       listenPort: 8080
 backendConnectors:
@@ -9,20 +13,37 @@ backendConnectors:
     type: elasticsearch
     config:
       url: "http://elasticsearch:9200"
-  - name: my-clickhouse-cloud-data-source
+  - name: my-clickhouse-data-source
     type: clickhouse-os
     config:
       url: "clickhouse://clickhouse:9000"
 processors:
-  - name: elasticsearch-to-clickhouse-processor
-    type: quesma-v1-processor
+  - name: p1
+    type: quesma-v1-processor-query
     config:
-      mode: "dual-write-query-clickhouse"
-      enableElasticsearchIngest: true
       indexes:
         kibana_sample_data_ecommerce:
         kibana_sample_data_flights:
         kibana_sample_data_logs:
         logs-generic-default:
           fullTextFields: [ "message" ]
-        windows_logs:   # Used for EQL e2e tests
+        windows_logs:
+  - name: p2
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        kibana_sample_data_ecommerce:
+        kibana_sample_data_flights:
+        kibana_sample_data_logs:
+        logs-generic-default:
+          fullTextFields: [ "message" ]
+        windows_logs:
+pipelines:
+  - name: p-query
+    frontendConnectors: [ elasticsearch-API-for-kibana ]
+    processors: [ p1 ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]
+  - name: p-ingest
+    frontendConnectors: [ elasticsearch-API-for-filebeat ]
+    processors: [ p2 ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]

--- a/quesma/config.yaml.template
+++ b/quesma/config.yaml.template
@@ -4,8 +4,12 @@
 #       `config.yaml` is going to be ignored by git.
 #
 frontendConnectors:
-  - name: myElasticsearchAPI
-    type: elasticsearch-fe
+  - name: elasticsearch-fe-query-conn
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+  - name: elasticsearch-fe-ingest-conn
+    type: elasticsearch-fe-ingest
     config:
       listenPort: 8080
 backendConnectors:
@@ -13,7 +17,7 @@ backendConnectors:
     type: elasticsearch
     config:
       url: "http://localhost:9200"
-  - name: my-clickhouse-cloud-data-source
+  - name: my-clickhouse-local-data-source
     type: clickhouse-os
     config:
       url: "clickhouse://localhost:9000"
@@ -22,8 +26,8 @@ logging:
   level: "info"
   disableFileLogging: false
 processors:
-  - name: my-quesma-processor
-    type: quesma-v1-processor
+  - name: query-processor
+    type: quesma-v1-processor-query
     config:
       mode: "dual-write-query-clickhouse"
       enableElasticsearchIngest: true
@@ -41,3 +45,31 @@ processors:
             timestamp:
               source: "timestamp"   # field name in ES Query
               target: "@timestamp"  #  field name in ClickHouse
+  - name: ingest-processor
+    type: quesma-v1-processor-ingest
+    config:
+      mode: "dual-write-query-clickhouse"
+      enableElasticsearchIngest: true
+      indexes:
+        kibana_sample_data_ecommerce:
+          timestampField: "@timestamp"
+        kibana_sample_data_flights:
+          disabled: false  # Just to have example that its possible
+        kibana_sample_data_logs:
+          fullTextFields: [ "message", "agent" ]
+          mappings:
+            message: "text"
+            agent: "text"
+          aliases:
+            timestamp:
+              source: "timestamp"   # field name in ES Query
+              target: "@timestamp"  #  field name in ClickHouse
+pipelines:
+  - name: my-quesma-query-pipeline
+    frontendConnectors: [ elasticsearch-fe-query-conn ]
+    processors: [ query-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-local-data-source ]
+  - name: my-quesma-ingest-pipeline
+    frontendConnectors: [ elasticsearch-fe-ingest-conn ]
+    processors: [ ingest-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-local-data-source ]

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -4,10 +4,12 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/knadh/koanf/providers/env"
 	"log"
 	"quesma/network"
+	"slices"
 	"strings"
 )
 
@@ -22,7 +24,9 @@ const (
 type ProcessorType string
 
 const (
-	QuesmaV1Processor ProcessorType = "quesma-v1-processor"
+	QuesmaV1ProcessorNoOp   ProcessorType = "quesma-v1-processor-noop"
+	QuesmaV1ProcessorQuery  ProcessorType = "quesma-v1-processor-query"
+	QuesmaV1ProcessorIngest ProcessorType = "quesma-v1-processor-ingest"
 )
 
 type QuesmaNewConfiguration struct {
@@ -34,6 +38,14 @@ type QuesmaNewConfiguration struct {
 	IngestStatistics           bool                 `koanf:"ingestStatistics"`
 	QuesmaInternalTelemetryUrl *Url                 `koanf:"internalTelemetryUrl"`
 	Processors                 []Processor          `koanf:"processors"`
+	Pipelines                  []Pipeline           `koanf:"pipelines"`
+}
+
+type Pipeline struct {
+	Name               string   `koanf:"name"`
+	FrontendConnectors []string `koanf:"frontendConnectors"`
+	Processors         []string `koanf:"processors"`
+	BackendConnectors  []string `koanf:"backendConnectors"`
 }
 
 type FrontendConnector struct {
@@ -76,8 +88,141 @@ func LoadV2Config() QuesmaNewConfiguration {
 	if err := k.Unmarshal("", &v2config); err != nil {
 		log.Fatalf("error unmarshalling config: %v", err)
 	}
-
+	if err := v2config.validate(); err != nil {
+		var multiErr *multierror.Error
+		if errors.As(err, &multiErr) {
+			if len(multiErr.Errors) > 0 {
+				log.Fatalf("Config validation failed: %v", multiErr)
+			}
+		}
+	}
 	return v2config
+}
+
+// validate at this level verifies the basic assumptions behind pipelines/processors/connectors,
+// many of which being just stubs for future impl
+func (c *QuesmaNewConfiguration) validate() error {
+	var _, errAcc error
+	for _, pipeline := range c.Pipelines {
+		errAcc = multierror.Append(errAcc, c.validatePipeline(pipeline))
+	}
+	for _, fc := range c.FrontendConnectors {
+		errAcc = multierror.Append(errAcc, c.validateFrontendConnector(fc))
+	}
+	for _, pr := range c.Processors {
+		errAcc = multierror.Append(errAcc, c.validateProcessor(pr))
+	}
+	errAcc = multierror.Append(errAcc, c.validatePipelines())
+
+	return errAcc
+}
+
+func (c *QuesmaNewConfiguration) validatePipelines() error {
+	if len(c.Pipelines) != 2 {
+		return errors.New("exactly two pipelines (one for query, one for ingest) must be defined at this moment")
+	}
+	return nil
+}
+
+func (c *QuesmaNewConfiguration) validateFrontendConnector(fc FrontendConnector) error {
+	if fc.Type != ElasticsearchFrontedConnectorName {
+		return errors.New(fmt.Sprintf("frontend connector %s - type not recognized, only `elasticsearch-fe` is supported at this moment", fc.Name))
+	}
+	return nil
+}
+
+func (c *QuesmaNewConfiguration) definedFrontedConnectorNames() []string {
+	var names []string
+	for _, fc := range c.FrontendConnectors {
+		names = append(names, fc.Name)
+	}
+	return names
+}
+
+func (c *QuesmaNewConfiguration) definedBackendConnectorNames() []string {
+	var names []string
+	for _, bc := range c.BackendConnectors {
+		names = append(names, bc.Name)
+	}
+	return names
+}
+
+func (c *QuesmaNewConfiguration) definedProcessorNames() []string {
+	var names []string
+	for _, p := range c.Processors {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func (c *QuesmaNewConfiguration) validateProcessor(p Processor) error {
+	if !slices.Contains(getAllowedProcessorTypes(), p.Type) {
+		return errors.New("processor type not recognized, only `quesma-v1-processor-noop`, `quesma-v1-processor-query` and `quesma-v1-processor-ingest` are supported at this moment")
+	}
+	return nil
+}
+
+func (c *QuesmaNewConfiguration) validatePipeline(pipeline Pipeline) error {
+	var _, errAcc error
+	if len(pipeline.FrontendConnectors) != 1 {
+		errAcc = multierror.Append(errAcc, errors.New("pipeline must have exactly one frontend connector"))
+	} else if len(pipeline.FrontendConnectors) == 0 {
+		return multierror.Append(errAcc, errors.New("pipeline must have exactly one frontend connector, none defined"))
+	}
+	if !slices.Contains(c.definedFrontedConnectorNames(), pipeline.FrontendConnectors[0]) {
+		errAcc = multierror.Append(errAcc, errors.New(fmt.Sprintf("frontend connector named %s referenced in %s not found in configuration", pipeline.FrontendConnectors[0], pipeline.Name)))
+	}
+	if len(pipeline.BackendConnectors) != 0 && len(pipeline.BackendConnectors) > 2 {
+		return multierror.Append(errAcc, errors.New(fmt.Sprintf("pipeline must define exactly one or two backend connectors, %d defined", len(pipeline.BackendConnectors))))
+	}
+	if !slices.Contains(c.definedBackendConnectorNames(), pipeline.BackendConnectors[0]) {
+		errAcc = multierror.Append(errAcc, errors.New(fmt.Sprintf("backend connector named %s referenced in %s not found in configuration", pipeline.BackendConnectors[0], pipeline.Name)))
+	}
+	if len(pipeline.BackendConnectors) == 2 {
+		if !slices.Contains(c.definedBackendConnectorNames(), pipeline.BackendConnectors[1]) {
+			errAcc = multierror.Append(errAcc, errors.New(fmt.Sprintf("backend connector named %s referenced in %s not found in configuration", pipeline.BackendConnectors[1], pipeline.Name)))
+		}
+	}
+	if len(pipeline.Processors) != 1 {
+		return multierror.Append(errAcc, errors.New(fmt.Sprintf("pipeline must have exactly one processor, [%s] has %d defined", pipeline.Name, len(pipeline.Processors))))
+	}
+	if !slices.Contains(c.definedProcessorNames(), pipeline.Processors[0]) {
+		errAcc = multierror.Append(errAcc, errors.New(fmt.Sprintf("processor named %s referenced in %s not found in configuration", pipeline.Processors[0], pipeline.Name)))
+	} else {
+		onlyProcessorInPipeline := c.getProcessorByName(pipeline.Processors[0])
+		if onlyProcessorInPipeline.Type == QuesmaV1ProcessorNoOp {
+			if len(pipeline.BackendConnectors) != 1 {
+				return multierror.Append(errAcc, errors.New(fmt.Sprintf("pipeline %s has a noop processor supports only one backend connector", pipeline.Name)))
+			}
+			if conn := c.getBackendConnectorByName(pipeline.BackendConnectors[0]); conn.Type != ElasticsearchBackendConnectorName {
+				return multierror.Append(errAcc, errors.New(fmt.Sprintf("pipeline %s has a noop processor which can be connected only to elasticsearch backend connector", pipeline.Name)))
+			}
+		}
+	}
+
+	return errAcc
+}
+
+func (c *QuesmaNewConfiguration) getBackendConnectors() []BackendConnector {
+	return c.BackendConnectors
+}
+
+func (c *QuesmaNewConfiguration) getBackendConnectorByName(name string) *BackendConnector {
+	for _, b := range c.BackendConnectors {
+		if b.Name == name {
+			return &b
+		}
+	}
+	return nil
+}
+
+func (c *QuesmaNewConfiguration) getProcessorByName(name string) *Processor {
+	for _, p := range c.Processors {
+		if p.Name == name {
+			return &p
+		}
+	}
+	return nil
 }
 
 func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
@@ -107,6 +252,12 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			conf.ClickHouse = *relDBConn
 		}
 	}
+	// Now determine Quesma final state with following heuristic
+	// if 2 pipelines with noop processor -> switch to proxy mode, ditch the whole config
+	// if one query, one ingest pipeline with noop processor -> switch to "dual-write-query-clickhouse" mode
+	// * just ingest processor -
+	//
+
 	if v1processor, err := c.getProcessorConfig(); err == nil {
 		conf.Mode = v1processor.Config.Mode
 		conf.IndexConfig = v1processor.Config.IndexConfig
@@ -175,9 +326,13 @@ func (c *QuesmaNewConfiguration) getProcessorConfig() (*Processor, error) {
 	if len(c.Processors) != 1 {
 		return nil, errors.New("exactly one processor must be defined at this moment")
 	}
-	if c.Processors[0].Type == QuesmaV1Processor {
+	if slices.Contains(getAllowedProcessorTypes(), c.Processors[0].Type) {
 		return &c.Processors[0], nil
 	} else {
-		return nil, errors.New("processor type not recognized, only `quesma-v1-processor` is supported at this moment")
+		return nil, errors.New("processor type not recognized")
 	}
+}
+
+func getAllowedProcessorTypes() []ProcessorType {
+	return []ProcessorType{QuesmaV1ProcessorNoOp, QuesmaV1ProcessorQuery, QuesmaV1ProcessorIngest}
 }

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -408,6 +408,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 	if len(procList) == 1 {
 		if procList[0].Type == QuesmaV1ProcessorNoOp {
 			conf.Mode = ProxyInspect
+		} else {
+			conf.Mode = DualWriteQueryClickhouse
 		}
 	} else if len(procList) == 2 {
 		if procList[0].Type == QuesmaV1ProcessorNoOp && procList[1].Type == QuesmaV1ProcessorNoOp {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -214,6 +214,12 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 	}
 	if isDualPipeline {
 		fc1, fc2 := c.getFrontendConnectorByName(c.Pipelines[0].FrontendConnectors[0]), c.getFrontendConnectorByName(c.Pipelines[1].FrontendConnectors[0])
+		if fc1 == nil {
+			return fmt.Errorf(fmt.Sprintf("frontend connector named [%s] not found in configuration", c.Pipelines[0].FrontendConnectors[0]))
+		}
+		if fc2 == nil {
+			return fmt.Errorf(fmt.Sprintf("frontend connector named [%s] not found in configuration", c.Pipelines[1].FrontendConnectors[0]))
+		}
 		if !((fc1.Type == ElasticsearchFrontendQueryConnectorName && fc2.Type == ElasticsearchFrontendIngestConnectorName) ||
 			(fc2.Type == ElasticsearchFrontendQueryConnectorName && fc1.Type == ElasticsearchFrontendIngestConnectorName)) {
 			return fmt.Errorf("when declaring two fronted connector types, one must be of query type and the other of ingest type")

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -173,7 +173,7 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 		fcName := c.Pipelines[0].FrontendConnectors[0]
 		if fc := c.getFrontendConnectorByName(fcName); fc != nil {
 			if fc.Type != ElasticsearchFrontendQueryConnectorName {
-				return fmt.Errorf("single pipeline Quesma can only be used for querying, but the frontend connector is not of query type")
+				return fmt.Errorf("single-pipeline Quesma can only be used for querying, but the frontend connector is not of query type")
 			}
 			proc := c.getProcessorByName(c.Pipelines[0].Processors[0])
 			if proc == nil {
@@ -209,7 +209,7 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 				}
 			}
 		} else {
-			return fmt.Errorf(fmt.Sprintf("frontend connector named [%s] referred in piepeline[%s] not found in configuration", fcName, c.Pipelines[0].Name))
+			return fmt.Errorf(fmt.Sprintf("frontend connector named [%s] referred in pipeline [%s] not found in configuration", fcName, c.Pipelines[0].Name))
 		}
 	}
 	if isDualPipeline {
@@ -235,7 +235,7 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 			return fmt.Errorf(fmt.Sprintf("ingest processor named [%s] not found in configuration", ingestPipeline.Processors[0]))
 		}
 		if ingestProcessor.Type != QuesmaV1ProcessorIngest {
-			return fmt.Errorf("ingest pipeline must have ingest processor")
+			return fmt.Errorf("ingest pipeline must have ingest-type processor")
 		}
 		queryProcessor := c.getProcessorByName(queryPipeline.Processors[0])
 		if queryProcessor == nil {
@@ -256,7 +256,7 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 
 func (c *QuesmaNewConfiguration) validateFrontendConnector(fc FrontendConnector) error {
 	if fc.Type != ElasticsearchFrontendIngestConnectorName && fc.Type != ElasticsearchFrontendQueryConnectorName {
-		return fmt.Errorf(fmt.Sprintf("frontend connector's %s type not recognized, only `%s` and `%s` are supported at this moment", fc.Name, ElasticsearchFrontendIngestConnectorName, ElasticsearchFrontendQueryConnectorName))
+		return fmt.Errorf(fmt.Sprintf("frontend connector's [%s] type not recognized, only `%s` and `%s` are supported at this moment", fc.Name, ElasticsearchFrontendIngestConnectorName, ElasticsearchFrontendQueryConnectorName))
 	}
 	return nil
 }
@@ -429,7 +429,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 }
 
 func (c *QuesmaNewConfiguration) getPublicTcpPort() (network.Port, error) {
-	// per validation, there's always at least one frontend connector, and even if there's a second one, it must listen on the same port
+	// per validation, there's always at least one frontend connector,
+	// even if there's a second one, it has to listen on the same port
 	return c.FrontendConnectors[0].Config.ListenPort, nil
 }
 

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -234,8 +234,8 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 		if ingestProcessor == nil {
 			return fmt.Errorf(fmt.Sprintf("ingest processor named [%s] not found in configuration", ingestPipeline.Processors[0]))
 		}
-		if ingestProcessor.Type != QuesmaV1ProcessorIngest {
-			return fmt.Errorf("ingest pipeline must have ingest-type processor")
+		if ingestProcessor.Type != QuesmaV1ProcessorIngest && ingestProcessor.Type != QuesmaV1ProcessorNoOp {
+			return fmt.Errorf("ingest pipeline must have ingest-type or noop processor")
 		}
 		queryProcessor := c.getProcessorByName(queryPipeline.Processors[0])
 		if queryProcessor == nil {
@@ -405,8 +405,13 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		if procList[0].Type == QuesmaV1ProcessorNoOp {
 			conf.Mode = ProxyInspect
 		}
+	} else if len(procList) == 2 {
+		if procList[0].Type == QuesmaV1ProcessorNoOp && procList[1].Type == QuesmaV1ProcessorNoOp {
+			conf.Mode = ProxyInspect
+		} else {
+			conf.Mode = DualWriteQueryClickhouse
+		}
 	}
-	conf.Mode = DualWriteQueryClickhouse
 	if v1processor := procList[0]; v1processor != nil {
 		conf.IndexConfig = v1processor.Config.IndexConfig
 		for indexName, indexConfig := range v1processor.Config.IndexConfig {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -241,6 +241,10 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 		if queryProcessor == nil {
 			return fmt.Errorf(fmt.Sprintf("query processor named [%s] not found in configuration", ingestPipeline.Processors[0]))
 		}
+		if (queryProcessor.Type == QuesmaV1ProcessorNoOp && ingestProcessor.Type != QuesmaV1ProcessorNoOp) ||
+			(ingestProcessor.Type == QuesmaV1ProcessorNoOp && queryProcessor.Type != QuesmaV1ProcessorNoOp) {
+			return fmt.Errorf("at this moment, noop processor is allowed only if used in both pipelines")
+		}
 		if queryProcessor.Type != QuesmaV1ProcessorQuery &&
 			queryProcessor.Type != QuesmaV1ProcessorNoOp {
 			return fmt.Errorf("query pipeline must have query or noop processor")


### PR DESCRIPTION
This PR introduces `pipelines` to the configuration:
```yaml
pipelines:
  - name: p-query
    frontendConnectors: [ elasticsearch-API-for-kibana ]
    processors: [ my-query-processor ]
    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]
  - name: p-ingest
    frontendConnectors: [ elasticsearch-API-for-filebeat ]
    processors: [ my-ingest-processor ]
    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]
```

This is pretty hairy code, most of it being stubs for future implementation. However, it gets the job done and allows us configuring currently viable deployment scenarios.