### PR TITLE
quickfixes to `terms_enum`

### DIFF
--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -503,13 +503,13 @@ func (cw *ClickhouseQueryTranslator) BuildNRowsQuery(fieldName string, query *mo
 	return query_util.BuildHitsQuery(cw.Ctx, model.SingleTableNamePlaceHolder, fieldName, query, limit)
 }
 
-func (cw *ClickhouseQueryTranslator) BuildAutocompleteQuery(fieldName string, whereClause model.Expr, limit int) *model.Query {
+func (cw *ClickhouseQueryTranslator) BuildAutocompleteQuery(fieldName, tableName string, whereClause model.Expr, limit int) *model.Query {
 	return &model.Query{
 		SelectCommand: *model.NewSelectCommand(
 			[]model.Expr{model.NewColumnRef(fieldName)},
 			nil,
 			nil,
-			model.NewTableRef(model.SingleTableNamePlaceHolder),
+			model.NewTableRef(tableName),
 			whereClause,
 			[]model.Expr{},
 			limit,

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -263,7 +263,7 @@ func configureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 				return nil, errors.New("invalid request body, expecting JSON")
 			}
 
-			if responseBody, err := terms_enum.HandleTermsEnum(ctx, req.Params["index"], body, lm, console); err != nil {
+			if responseBody, err := terms_enum.HandleTermsEnum(ctx, req.Params["index"], body, lm, sr, console); err != nil {
 				return nil, err
 			} else {
 				return elasticsearchQueryResult(string(responseBody), http.StatusOK), nil


### PR DESCRIPTION
Fix for https://github.com/QuesmaOrg/quesma/issues/675

`terms_enum`'s SQL was a) missing `ResolveField` b) didn't fill tablename

Both cases from the issue work now:
<img width="1480" alt="Screenshot 2024-09-01 at 12 03 30" src="https://github.com/user-attachments/assets/a141a27a-9884-4b59-8020-5c9615fd7040">
<img width="1449" alt="Screenshot 2024-09-01 at 12 03 06" src="https://github.com/user-attachments/assets/d8348c0b-fc38-4797-9a1a-d10c40a8dc43">

I'll add some test.