### PR TITLE
Return proper response for `significant_terms`, not default from `terms`

### DIFF
--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -4956,7 +4956,8 @@ var AggregationTests = []AggregationTestCase{
 				},
 				"aggregations": {
 					"2": {
-						"bg_count": 14074,
+						"bg_count": 825,
+						"doc_count": 825,
 						"buckets": [
 							{
 								"bg_count": 619,
@@ -4970,9 +4971,7 @@ var AggregationTests = []AggregationTestCase{
 								"key": "zip",
 								"score": 206
 							}
-						],
-						"sum_other_doc_count": 0,
-						"doc_count_error_upper_bound": 0
+						]
 					}
 				},
 				"hits": {

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -685,6 +685,7 @@ var AggregationTests2 = []AggregationTestCase{
 			"aggregations": {
 				"2": {
 					"bg_count": 2786,
+					"doc_count": 2786,
 					"buckets": [
 						{
 							"1": {
@@ -709,9 +710,7 @@ var AggregationTests2 = []AggregationTestCase{
 							"key": "200",
 							"score": 2570
 						}
-					],
-					"sum_other_doc_count": 2786,
-					"doc_count_error_upper_bound": 0
+					]
 				}
 			},
 			"hits": {

--- a/quesma/testdata/opensearch-visualize/aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/aggregation_requests.go
@@ -803,7 +803,8 @@ var AggregationTests = []testdata.AggregationTestCase{
 							"score": 94
 						}
 					],
-					"sum_other_doc_count": 2336
+					"doc_count": 5000,
+					"bg_count": 5000
 				}
 			},
 			"hits": {
@@ -982,7 +983,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 			},
 			"aggregations": {
 				"2": {
-					"bg_count": 14074,
+					"bg_count": 5300,
 					"buckets": [
 						{
 							"1": {
@@ -1005,8 +1006,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 							"score": 94
 						}
 					],
-					"sum_other_doc_count": 2636,
-					"doc_count_error_upper_bound": 0
+					"doc_count": 5300
 				}
 			},
 			"hits": {
@@ -1188,6 +1188,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 			"aggregations": {
 				"2": {
 					"bg_count": 2786,
+					"doc_count": 2786,
 					"buckets": [
 						{
 							"1": {
@@ -1234,9 +1235,7 @@ var AggregationTests = []testdata.AggregationTestCase{
 							"key": "200",
 							"score": 2570
 						}
-					],
-					"sum_other_doc_count": 216,
-					"doc_count_error_upper_bound": 0
+					]
 				}
 			},
 			"hits": {


### PR DESCRIPTION
`significant_terms` return `doc_count`, not `sum_other_doc_count` like terms.
Fixed here.