### PR TITLE
Move IgnoredFields into SchemaOverrides, make it work properly with ingest

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -381,7 +381,14 @@ func findSchemaPointer(schemaRegistry schema.Registry, tableName string) *schema
 func (lm *LogManager) buildCreateTableQueryNoOurFields(ctx context.Context, tableName string,
 	jsonData types.JSON, tableConfig *ChTableConfig, nameFormatter TableColumNameFormatter) (string, error) {
 
-	columns := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(lm.schemaRegistry, tableName)) + Indexes(jsonData)
+	var ignoredFields []config.FieldName
+	if indexConfig, found := lm.cfg.IndexConfig[tableName]; found && indexConfig.SchemaOverrides != nil {
+		// FIXME: don't get ignored fields from schema config, but store
+		// them in the schema registry - that way we don't have to manually replace '.' with '::'
+		// in removeFieldsTransformer's Transform method
+		ignoredFields = indexConfig.SchemaOverrides.IgnoredFields()
+	}
+	columns := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(lm.schemaRegistry, tableName), ignoredFields) + Indexes(jsonData)
 
 	createTableCmd := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s"
 (

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -208,7 +208,7 @@ func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]d
 		var columnsMap = make(map[string]*Column)
 		partiallyResolved := false
 		for col, colType := range resTable.columnTypes {
-			if schemaOverride, found := resTable.config.SchemaOverrides.Fields[config.FieldName(col)]; found && schemaOverride.Type.AsString() == config.TypeIgnored {
+			if schemaOverride, found := resTable.config.SchemaOverrides.Fields[config.FieldName(col)]; found && schemaOverride.Ignored {
 				logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
 				continue
 			}

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -208,8 +208,7 @@ func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]d
 		var columnsMap = make(map[string]*Column)
 		partiallyResolved := false
 		for col, colType := range resTable.columnTypes {
-
-			if _, isIgnored := resTable.config.IgnoredFields[col]; isIgnored {
+			if schemaOverride, found := resTable.config.SchemaOverrides.Fields[config.FieldName(col)]; found && schemaOverride.Type.AsString() == config.TypeIgnored {
 				logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
 				continue
 			}

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -208,9 +208,11 @@ func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]d
 		var columnsMap = make(map[string]*Column)
 		partiallyResolved := false
 		for col, colType := range resTable.columnTypes {
-			if schemaOverride, found := resTable.config.SchemaOverrides.Fields[config.FieldName(col)]; found && schemaOverride.Ignored {
-				logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
-				continue
+			if resTable.config.SchemaOverrides != nil {
+				if schemaOverride, found := resTable.config.SchemaOverrides.Fields[config.FieldName(col)]; found && schemaOverride.Ignored {
+					logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
+					continue
+				}
 			}
 			if col != AttributesValuesColumn && col != AttributesMetadataColumn {
 				column := resolveColumn(col, colType)

--- a/quesma/jsonprocessor/json_processor.go
+++ b/quesma/jsonprocessor/json_processor.go
@@ -4,6 +4,7 @@ package jsonprocessor
 
 import (
 	"fmt"
+	"quesma/quesma/config"
 	"quesma/quesma/types"
 )
 
@@ -106,5 +107,16 @@ func (t *RewriteArrayOfObject) Transform(data types.JSON) (types.JSON, error) {
 		}
 	}
 
+	return data, nil
+}
+
+type RemoveFieldsOfObject struct {
+	RemovedFields []config.FieldName
+}
+
+func (t *RemoveFieldsOfObject) Transform(data types.JSON) (types.JSON, error) {
+	for _, field := range t.RemovedFields {
+		delete(data, field.AsString())
+	}
 	return data, nil
 }

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -181,9 +181,6 @@ func (c *QuesmaConfiguration) Validate() error {
 //
 //lint:ignore U1000 Ignore unused function temporarily for debugging
 func (c *QuesmaConfiguration) validateDeprecated(indexName IndexConfiguration, result error) error {
-	if len(indexName.IgnoredFields) > 0 {
-		fmt.Printf("index configuration %s contains deprecated field 'ignoredFields'", indexName.Name)
-	}
 	if indexName.TimestampField != nil {
 		fmt.Printf("index configuration %s contains deprecated field 'timestampField'", indexName.Name)
 	}
@@ -338,7 +335,7 @@ func (c *QuesmaConfiguration) validateSchemaConfiguration(config IndexConfigurat
 	for fieldName, fieldConfig := range config.SchemaOverrides.Fields {
 		if fieldConfig.Type == "" {
 			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has no type", fieldName, config.Name))
-		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) {
+		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) && fieldConfig.Type != TypeAlias && fieldConfig.Type != TypeIgnored {
 			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has invalid type %s", fieldName, config.Name, fieldConfig.Type))
 		}
 		if fieldConfig.Type == TypeAlias && fieldConfig.TargetColumnName == "" {

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -333,9 +333,9 @@ func (c *QuesmaConfiguration) validateSchemaConfiguration(config IndexConfigurat
 	}
 
 	for fieldName, fieldConfig := range config.SchemaOverrides.Fields {
-		if fieldConfig.Type == "" {
+		if fieldConfig.Type == "" && !fieldConfig.Ignored {
 			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has no type", fieldName, config.Name))
-		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) && fieldConfig.Type != TypeAlias && fieldConfig.Type != TypeIgnored {
+		} else if !elasticsearch_field_types.IsValid(fieldConfig.Type.AsString()) && !fieldConfig.Ignored {
 			err = multierror.Append(err, fmt.Errorf("field [%s] in index [%s] has invalid type %s", fieldName, config.Name, fieldConfig.Type))
 		}
 		if fieldConfig.Type == TypeAlias && fieldConfig.TargetColumnName == "" {

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -13,8 +13,6 @@ type IndexConfiguration struct {
 	// TODO to be deprecated
 	FullTextFields []string `koanf:"fullTextFields"`
 	// TODO to be deprecated
-	IgnoredFields map[string]bool `koanf:"ignoredFields"`
-	// TODO to be deprecated
 	TimestampField    *string                           `koanf:"timestampField"`
 	SchemaOverrides   *SchemaConfiguration              `koanf:"schemaOverrides"`
 	EnabledOptimizers map[string]OptimizerConfiguration `koanf:"optimizers"`
@@ -29,16 +27,6 @@ func (c IndexConfiguration) GetTimestampField() (tsField string) {
 }
 
 func (c IndexConfiguration) String() string {
-	var extraString string
-	extraString = ""
-	if len(c.IgnoredFields) > 0 {
-		extraString += "; ignored fields: "
-		var fields []string
-		for field := range c.IgnoredFields {
-			fields = append(fields, field)
-		}
-		extraString += strings.Join(fields, ", ")
-	}
 	var str = fmt.Sprintf("\n\t\t%s, disabled: %t, schema overrides: %s, override: %s",
 		c.Name,
 		c.Disabled,

--- a/quesma/quesma/config/schema_config.go
+++ b/quesma/quesma/config/schema_config.go
@@ -8,7 +8,6 @@ import (
 )
 
 const TypeAlias = "alias"
-const TypeIgnored = "ignored"
 
 type (
 	SchemaConfiguration struct {
@@ -18,6 +17,7 @@ type (
 		Type FieldType `koanf:"type"`
 		//IsTimestampField bool      `koanf:"isTimestampField"`
 		TargetColumnName string `koanf:"targetColumnName"` // if FieldType == TypeAlias then this is the target column name
+		Ignored          bool   `koanf:"ignored"`
 	}
 	FieldName string
 	FieldType string
@@ -57,7 +57,7 @@ func (sc *SchemaConfiguration) String() string {
 func (sc *SchemaConfiguration) IgnoredFields() []FieldName {
 	var ignoredFields []FieldName
 	for fieldName, fieldConfig := range sc.Fields {
-		if fieldConfig.Type == TypeIgnored {
+		if fieldConfig.Ignored {
 			ignoredFields = append(ignoredFields, fieldName)
 		}
 	}

--- a/quesma/quesma/config/schema_config.go
+++ b/quesma/quesma/config/schema_config.go
@@ -8,6 +8,7 @@ import (
 )
 
 const TypeAlias = "alias"
+const TypeIgnored = "ignored"
 
 type (
 	SchemaConfiguration struct {
@@ -51,6 +52,16 @@ func (sc *SchemaConfiguration) String() string {
 		builder.WriteString(fmt.Sprintf("\t%s: %+v\n", fieldName, fieldConfig))
 	}
 	return builder.String()
+}
+
+func (sc *SchemaConfiguration) IgnoredFields() []FieldName {
+	var ignoredFields []FieldName
+	for fieldName, fieldConfig := range sc.Fields {
+		if fieldConfig.Type == TypeIgnored {
+			ignoredFields = append(ignoredFields, fieldName)
+		}
+	}
+	return ignoredFields
 }
 
 func NewEmptySchemaConfiguration() SchemaConfiguration {

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -112,7 +112,7 @@ func (s *schemaRegistry) populateSchemaFromStaticConfiguration(indexConfiguratio
 		return
 	}
 	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
-		if field.Type.AsString() == config.TypeAlias || field.Type.AsString() == config.TypeIgnored {
+		if field.Type.AsString() == config.TypeAlias || field.Ignored {
 			continue
 		}
 		if resolvedType, valid := ParseQuesmaType(field.Type.AsString()); valid {
@@ -166,7 +166,7 @@ func (s *schemaRegistry) removeIgnoredFields(indexConfiguration config.IndexConf
 		return
 	}
 	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
-		if field.Type.AsString() == config.TypeIgnored {
+		if field.Ignored {
 			delete(fields, FieldName(fieldName))
 			delete(aliases, FieldName(fieldName))
 		}

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -47,6 +47,7 @@ func (s *schemaRegistry) loadSchemas() (map[TableName]Schema, error) {
 		s.populateSchemaFromStaticConfiguration(indexConfiguration, fields)
 		existsInDataSource := s.populateSchemaFromTableDefinition(definitions, indexName, fields)
 		s.populateAliases(indexConfiguration, fields, aliases)
+		s.removeIgnoredFields(indexConfiguration, fields, aliases)
 		schemas[TableName(indexName)] = NewSchemaWithAliases(fields, aliases, existsInDataSource)
 	}
 
@@ -111,7 +112,7 @@ func (s *schemaRegistry) populateSchemaFromStaticConfiguration(indexConfiguratio
 		return
 	}
 	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
-		if field.Type.AsString() == config.TypeAlias {
+		if field.Type.AsString() == config.TypeAlias || field.Type.AsString() == config.TypeIgnored {
 			continue
 		}
 		if resolvedType, valid := ParseQuesmaType(field.Type.AsString()); valid {
@@ -158,4 +159,16 @@ func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[strin
 		}
 	}
 	return found
+}
+
+func (s *schemaRegistry) removeIgnoredFields(indexConfiguration config.IndexConfiguration, fields map[FieldName]Field, aliases map[FieldName]FieldName) {
+	if indexConfiguration.SchemaOverrides == nil {
+		return
+	}
+	for fieldName, field := range indexConfiguration.SchemaOverrides.Fields {
+		if field.Type.AsString() == config.TypeIgnored {
+			delete(fields, FieldName(fieldName))
+			delete(aliases, FieldName(fieldName))
+		}
+	}
 }


### PR DESCRIPTION
This is a part of our recent effort of finalizing a new stable configuration. Previously `IgnoredFields` was a part of `IndexConfiguration`, looking like this:

```yaml
test_index:
  ignoredFields:
    myField: true
    anotherField: true
```

However, with the recent improvements to `SchemaConfiguration`, now it makes more sense to configure it under `schemaOverrides`, like this:

```yaml
test_index:
  schemaOverrides:
    fields:
      myField:
        ignored: true
      anotherField:
        ignored: true
```

This PR moves this configuration from `ignoredFields` (`IndexConfiguration`) to `schemaOverrides` (`SchemaConfiguration`).

Moreover, `ignoredFields` did not work correctly with Quesma's ingest, as ignored fields were only ignored in the query path. This PR adds necessary checks also to the ingest path.

Unfortunately, the code is not very clean with regards to handling of `.` vs `::` - I have tried cleaning up the situation, but that required some larger refactors which would make this PR too big...