### PR TITLE
Remove `fullTextFields` from demo config `local-dev.yaml`

### DIFF
--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -60,14 +60,13 @@ processors:
               message:
                 type: text
               "host.name":
-                type: "keyword"
+                type: text
               "service.name":
                 type: "keyword"
               source:
                 type: "keyword"
               severity:
                 type: "keyword"
-          fullTextFields: [ "message", "host.name" ]
   - name: my-ingest-processor
     type: quesma-v1-processor-ingest
     config:
@@ -101,14 +100,13 @@ processors:
               message:
                 type: text
               "host.name":
-                type: "keyword"
+                type: text
               "service.name":
                 type: "keyword"
               source:
                 type: "keyword"
               severity:
                 type: "keyword"
-          fullTextFields: [ "message", "host.name" ]
 pipelines:
   - name: my-pipeline-elasticsearch-query-clickhouse
     frontendConnectors: [ elastic-query ]


### PR DESCRIPTION
After 5f749e8e5e29c9, `fullTextFields` is now removed and configured by setting a type of field to `text`. Fix the demo config `local-dev.yaml` accordingly.