### PR TITLE
Send proper error response in `/_doc` endpoint

### DIFF
--- a/quesma/quesma/config/util.go
+++ b/quesma/quesma/config/util.go
@@ -11,21 +11,23 @@ import (
 
 var insertCounter = atomic.Int32{}
 
-func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName string, body types.JSON, action func() error) {
+func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName string, body types.JSON, action func() error) error {
 	if len(cfg.IndexConfig) == 0 {
 		logger.InfoWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s", indexName, body.ShortString())
 		err := action()
 		if err != nil {
 			logger.ErrorWithCtx(ctx).Msg("Can't write to index: " + err.Error())
 		}
+		return err
 	} else {
 		matchingConfig, ok := findMatchingConfig(indexName, cfg)
 		if !ok {
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is not configured, skipping", indexName)
-			return
+			return nil
 		}
 		if matchingConfig.Disabled {
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
+			return nil
 		} else {
 			insertCounter.Add(1)
 			if insertCounter.Load()%50 == 1 {
@@ -35,6 +37,7 @@ func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName stri
 			if err != nil {
 				logger.ErrorWithCtx(ctx).Msg("Can't write to Clickhouse: " + err.Error())
 			}
+			return err
 		}
 	}
 }

--- a/quesma/quesma/functionality/doc/doc.go
+++ b/quesma/quesma/functionality/doc/doc.go
@@ -20,7 +20,7 @@ func Write(ctx context.Context, tableName string, body types.JSON, lm *clickhous
 		return nil
 	}
 
-	config.RunConfigured(ctx, cfg, tableName, body, func() error {
+	return config.RunConfigured(ctx, cfg, tableName, body, func() error {
 		if len(cfg.IndexConfig[tableName].Override) > 0 {
 			tableName = cfg.IndexConfig[tableName].Override
 		}
@@ -28,5 +28,4 @@ func Write(ctx context.Context, tableName string, body types.JSON, lm *clickhous
 		transformer := jsonprocessor.IngestTransformerFor(tableName, cfg)
 		return lm.ProcessInsertQuery(ctx, tableName, types.NDJSON{body}, transformer, nameFormatter)
 	})
-	return nil
 }

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -60,12 +60,18 @@ func configureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 
 		body, err := types.ExpectJSON(req.ParsedBody)
 		if err != nil {
-			return nil, err
+			return &mux.Result{
+				Body:       string(queryparser.BadRequestParseError(err)),
+				StatusCode: http.StatusBadRequest,
+			}, nil
 		}
 
 		err = doc.Write(ctx, req.Params["index"], body, lm, cfg)
 		if err != nil {
-			return nil, err
+			return &mux.Result{
+				Body:       string(queryparser.BadRequestParseError(err)),
+				StatusCode: http.StatusBadRequest,
+			}, nil
 		}
 
 		return indexDocResult(req.Params["index"], http.StatusOK)


### PR DESCRIPTION
Before this change, the `_doc` endpoint would always report that the insert has succeeded, even if an error occurred and couldn't be handled by Quesma (meaning the insert failed!).

The `RunConfigured` function previously knew about the error, logged it, but did not pass it up to the caller.  Change that and return a properly formatted error response in `doc.go` (`bulk.go` already handled it correctly).