### PR TITLE
Quick fix containsAttributes and rename Attributes* constants

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -439,9 +439,9 @@ func deepCopyMapSliceInterface(original map[string][]interface{}) map[string][]i
 func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalidJson types.JSON) map[string][]interface{} {
 	newAttrsMap := deepCopyMapSliceInterface(attrsMap)
 	for k, v := range invalidJson {
-		newAttrsMap[AttributesKeyColumn] = append(newAttrsMap[AttributesKeyColumn], k)
-		newAttrsMap[AttributesValueColumn] = append(newAttrsMap[AttributesValueColumn], v)
-		newAttrsMap[AttributesValueType] = append(newAttrsMap[AttributesValueType], NewType(v).String())
+		newAttrsMap[DeprecatedAttributesKeyColumn] = append(newAttrsMap[DeprecatedAttributesKeyColumn], k)
+		newAttrsMap[DeprecatedAttributesValueColumn] = append(newAttrsMap[DeprecatedAttributesValueColumn], v)
+		newAttrsMap[DeprecatedAttributesValueType] = append(newAttrsMap[DeprecatedAttributesValueType], NewType(v).String())
 	}
 	return newAttrsMap
 }
@@ -471,8 +471,8 @@ func (lm *LogManager) generateNewColumns(
 	table *Table,
 	alteredAttributesIndexes []int) []string {
 	var alterCmd []string
-	attrKeys := getAttributesByArrayName(AttributesKeyColumn, attrsMap)
-	attrTypes := getAttributesByArrayName(AttributesValueType, attrsMap)
+	attrKeys := getAttributesByArrayName(DeprecatedAttributesKeyColumn, attrsMap)
+	attrTypes := getAttributesByArrayName(DeprecatedAttributesValueType, attrsMap)
 	var deleteIndexes []int
 
 	// HACK Alert:
@@ -505,9 +505,9 @@ func (lm *LogManager) generateNewColumns(
 	table.Cols = newColumns
 
 	for i := len(deleteIndexes) - 1; i >= 0; i-- {
-		attrsMap[AttributesKeyColumn] = append(attrsMap[AttributesKeyColumn][:deleteIndexes[i]], attrsMap[AttributesKeyColumn][deleteIndexes[i]+1:]...)
-		attrsMap[AttributesValueType] = append(attrsMap[AttributesValueType][:deleteIndexes[i]], attrsMap[AttributesValueType][deleteIndexes[i]+1:]...)
-		attrsMap[AttributesValueColumn] = append(attrsMap[AttributesValueColumn][:deleteIndexes[i]], attrsMap[AttributesValueColumn][deleteIndexes[i]+1:]...)
+		attrsMap[DeprecatedAttributesKeyColumn] = append(attrsMap[DeprecatedAttributesKeyColumn][:deleteIndexes[i]], attrsMap[DeprecatedAttributesKeyColumn][deleteIndexes[i]+1:]...)
+		attrsMap[DeprecatedAttributesValueType] = append(attrsMap[DeprecatedAttributesValueType][:deleteIndexes[i]], attrsMap[DeprecatedAttributesValueType][deleteIndexes[i]+1:]...)
+		attrsMap[DeprecatedAttributesValueColumn] = append(attrsMap[DeprecatedAttributesValueColumn][:deleteIndexes[i]], attrsMap[DeprecatedAttributesValueColumn][deleteIndexes[i]+1:]...)
 	}
 	return alterCmd
 }
@@ -517,11 +517,11 @@ func generateNonSchemaFieldsString(attrsMap map[string][]interface{}) (string, e
 	if len(attrsMap) <= 0 {
 		return nonSchemaStr, nil
 	}
-	attrKeys := getAttributesByArrayName(AttributesKeyColumn, attrsMap)
-	attrValues := getAttributesByArrayName(AttributesValueColumn, attrsMap)
-	attrTypes := getAttributesByArrayName(AttributesValueType, attrsMap)
+	attrKeys := getAttributesByArrayName(DeprecatedAttributesKeyColumn, attrsMap)
+	attrValues := getAttributesByArrayName(DeprecatedAttributesValueColumn, attrsMap)
+	attrTypes := getAttributesByArrayName(DeprecatedAttributesValueType, attrsMap)
 
-	attributesColumns := []string{AttributesColumn, AttributesMetadataColumn}
+	attributesColumns := []string{AttributesValuesColumn, AttributesMetadataColumn}
 
 	for columnIndex, column := range attributesColumns {
 		var value string
@@ -552,7 +552,7 @@ func generateNonSchemaFieldsString(attrsMap map[string][]interface{}) (string, e
 
 // This function implements heuristic for deciding if we should add new columns
 func (lm *LogManager) shouldAlterColumns(table *Table, attrsMap map[string][]interface{}) (bool, []int) {
-	attrKeys := getAttributesByArrayName(AttributesKeyColumn, attrsMap)
+	attrKeys := getAttributesByArrayName(DeprecatedAttributesKeyColumn, attrsMap)
 	alterColumnIndexes := make([]int, 0)
 	if len(table.Cols) < alwaysAddColumnLimit {
 		// We promote all non-schema fields to columns

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -13,11 +13,13 @@ import (
 )
 
 const (
-	AttributesKeyColumn      = "attributes_string_key"
-	AttributesValueColumn    = "attributes_string_value"
-	AttributesValueType      = "attributes_string_type"
-	attributesColumnType     = "Map(String, String)"
-	AttributesColumn         = "attributes_values"
+	// FIXME: Remnants of old way of storing attributes
+	DeprecatedAttributesKeyColumn   = "attributes_string_key"
+	DeprecatedAttributesValueColumn = "attributes_string_value"
+	DeprecatedAttributesValueType   = "attributes_string_type"
+
+	attributesColumnType     = "Map(String, String)" // ClickHouse type of AttributesValuesColumn, AttributesMetadataColumn
+	AttributesValuesColumn   = "attributes_values"
 	AttributesMetadataColumn = "attributes_metadata"
 )
 
@@ -324,10 +326,10 @@ func (config *ChTableConfig) CreateTablePostFieldsString() string {
 
 func NewDefaultStringAttribute() Attribute {
 	return Attribute{
-		KeysArrayName:   AttributesKeyColumn,
-		ValuesArrayName: AttributesValueColumn,
-		TypesArrayName:  AttributesValueType,
-		MapValueName:    AttributesColumn,
+		KeysArrayName:   DeprecatedAttributesKeyColumn,
+		ValuesArrayName: DeprecatedAttributesValueColumn,
+		TypesArrayName:  DeprecatedAttributesValueType,
+		MapValueName:    AttributesValuesColumn,
 		MapMetadataName: AttributesMetadataColumn,
 		Type:            NewBaseType("String"),
 	}
@@ -338,7 +340,7 @@ func NewDefaultInt64Attribute() Attribute {
 		KeysArrayName:   "attributes_int64_key",
 		ValuesArrayName: "attributes_int64_value",
 		TypesArrayName:  "attributes_int64_type",
-		MapValueName:    AttributesColumn,
+		MapValueName:    AttributesValuesColumn,
 		MapMetadataName: AttributesMetadataColumn,
 		Type:            NewBaseType("Int64"),
 	}
@@ -349,7 +351,7 @@ func NewDefaultFloat64Attribute() Attribute {
 		KeysArrayName:   "attributes_float64_key",
 		ValuesArrayName: "attributes_float64_value",
 		TypesArrayName:  "attributes_float64_type",
-		MapValueName:    AttributesColumn,
+		MapValueName:    AttributesValuesColumn,
 		MapMetadataName: AttributesMetadataColumn,
 		Type:            NewBaseType("Float64"),
 	}
@@ -360,7 +362,7 @@ func NewDefaultBoolAttribute() Attribute {
 		KeysArrayName:   "attributes_bool_key",
 		ValuesArrayName: "attributes_bool_value",
 		TypesArrayName:  "attributes_bool_type",
-		MapValueName:    AttributesColumn,
+		MapValueName:    AttributesValuesColumn,
 		MapMetadataName: AttributesMetadataColumn,
 		Type:            NewBaseType("Bool"),
 	}

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -16,7 +16,7 @@ const (
 	AttributesKeyColumn      = "attributes_string_key"
 	AttributesValueColumn    = "attributes_string_value"
 	AttributesValueType      = "attributes_string_type"
-	attributesColumnType     = "Array(String)"
+	attributesColumnType     = "Map(String, String)"
 	AttributesColumn         = "attributes_values"
 	AttributesMetadataColumn = "attributes_metadata"
 )

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -213,7 +213,7 @@ func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]d
 				logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
 				continue
 			}
-			if col != AttributesColumn && col != AttributesMetadataColumn {
+			if col != AttributesValuesColumn && col != AttributesMetadataColumn {
 				column := resolveColumn(col, colType)
 				if column != nil {
 					columnsMap[col] = column
@@ -407,17 +407,17 @@ func isNullableType(colType string) bool {
 }
 
 func containsAttributes(cols map[string]string) bool {
-	hasAttributesColumn := false
+	hasAttributesValuesColumn := false
 	hasAttributesMetadataColumn := false
 	for col, colType := range cols {
-		if col == AttributesColumn && colType == attributesColumnType {
-			hasAttributesColumn = true
+		if col == AttributesValuesColumn && colType == attributesColumnType {
+			hasAttributesValuesColumn = true
 		}
 		if col == AttributesMetadataColumn && colType == attributesColumnType {
 			hasAttributesMetadataColumn = true
 		}
 	}
-	return hasAttributesColumn && hasAttributesMetadataColumn
+	return hasAttributesValuesColumn && hasAttributesMetadataColumn
 }
 
 func removePrecision(str string) string {

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -213,7 +213,7 @@ func (td *tableDiscovery) populateTableDefinitions(configuredTables map[string]d
 				logger.Warn().Msgf("table %s, column %s is ignored", tableName, col)
 				continue
 			}
-			if col != AttributesKeyColumn && col != AttributesValueColumn {
+			if col != AttributesColumn && col != AttributesMetadataColumn {
 				column := resolveColumn(col, colType)
 				if column != nil {
 					columnsMap[col] = column
@@ -407,17 +407,17 @@ func isNullableType(colType string) bool {
 }
 
 func containsAttributes(cols map[string]string) bool {
-	hasAttributesKey := false
-	hasAttributesValues := false
+	hasAttributesColumn := false
+	hasAttributesMetadataColumn := false
 	for col, colType := range cols {
-		if col == AttributesKeyColumn && colType == attributesColumnType {
-			hasAttributesKey = true
+		if col == AttributesColumn && colType == attributesColumnType {
+			hasAttributesColumn = true
 		}
-		if col == AttributesValueColumn && colType == attributesColumnType {
-			hasAttributesValues = true
+		if col == AttributesMetadataColumn && colType == attributesColumnType {
+			hasAttributesMetadataColumn = true
 		}
 	}
-	return hasAttributesKey && hasAttributesValues
+	return hasAttributesColumn && hasAttributesMetadataColumn
 }
 
 func removePrecision(str string) string {


### PR DESCRIPTION
The first commit fixes `containsAttributes` method - this method checks if the discovered table has the correct attributes columns. If none are detected, attributes are not updated at all. The method was not updated after 2ea8e07, which changed how the attributes were stored. Fix the problem by referencing correct constants.

The second commit renames a bunch of `Attributes*` constants. After 2ea8e07 attributes are stored in a new way, but constants related to old column names are still there (used internally). This would cause confusion, since the names are very similar. Renaming them to `Deprecated*` makes it more clear (and easier to fix in future PRs).