### PR TITLE
Remove last remnants of fullTextFields config

### DIFF
--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -4,14 +4,11 @@ package config
 
 import (
 	"fmt"
-	"strings"
 )
 
 type IndexConfiguration struct {
 	Name     string `koanf:"name"`
 	Disabled bool   `koanf:"disabled"`
-	// TODO to be deprecated
-	FullTextFields []string `koanf:"fullTextFields"`
 	// TODO to be deprecated
 	TimestampField    *string                           `koanf:"timestampField"`
 	SchemaOverrides   *SchemaConfiguration              `koanf:"schemaOverrides"`
@@ -33,10 +30,6 @@ func (c IndexConfiguration) String() string {
 		c.SchemaOverrides.String(),
 		c.Override,
 	)
-
-	if len(c.FullTextFields) > 0 {
-		str = fmt.Sprintf("%s, fullTextFields: %s", str, strings.Join(c.FullTextFields, ", "))
-	}
 
 	if c.TimestampField != nil {
 		return fmt.Sprintf("%s, timestampField: %s", str, *c.TimestampField)

--- a/quesma/quesma/config/test_config.yaml
+++ b/quesma/quesma/config/test_config.yaml
@@ -28,13 +28,27 @@ indexes:
           targetColumnName: "@timestamp"
   kafka-example-topic:
   logs-generic-default:
-    fullTextFields: ["message", "host.name"]
+    schemaOverrides:
+      fields:
+        message:
+          type: text
+        "host.name":
+          type: text
   device-logs:
-    fullTextFields: ["message"]
+    schemaOverrides:
+      fields:
+        message:
+          type: text
   phone_home_logs:
-    fullTextFields: ["message"]
+    schemaOverrides:
+      fields:
+        message:
+          type: text
   windows_logs:
   phone_home_data:
-    fullTextFields: ["message"]
+    schemaOverrides:
+      fields:
+        message:
+          type: text
 
 

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -30,27 +30,30 @@ func Test_ipRangeTransform(t *testing.T) {
 
 	indexConfig := map[string]config.IndexConfiguration{
 		"kibana_sample_data_logs": {
-			Name:           "kibana_sample_data_logs",
-			FullTextFields: []string{"message", "content"},
+			Name: "kibana_sample_data_logs",
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				config.FieldName(IpFieldName): {Type: "ip"},
+				"message":                     {Type: "text"},
+				"content":                     {Type: "text"},
 			}},
 		},
 		// Identical to kibana_sample_data_logs, but with "nested.clientip"
 		// instead of "clientip"
 		"kibana_sample_data_logs_nested": {
-			Name:           "kibana_sample_data_logs_nested",
-			FullTextFields: []string{"message", "content"},
+			Name: "kibana_sample_data_logs_nested",
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				"nested.clientip": {Type: "ip"},
+				"message":         {Type: "text"},
+				"content":         {Type: "text"},
 			}},
 		},
 		"kibana_sample_data_flights": {
-			Name:           "kibana_sample_data_flights",
-			FullTextFields: []string{"message", "content"},
+			Name: "kibana_sample_data_flights",
 			SchemaOverrides: &config.SchemaConfiguration{Fields: map[config.FieldName]config.FieldConfiguration{
 				config.FieldName(IpFieldName): {Type: "ip"},
 				"DestLocation":                {Type: "geo_point"},
+				"message":                     {Type: "text"},
+				"content":                     {Type: "text"},
 			}},
 		},
 	}

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -245,7 +245,7 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 
 	buffer.Html("\n<table>")
 	buffer.Html(`<tr class="tableName" id="quesma-config">`)
-	buffer.Html(`<th colspan=3><h2>`)
+	buffer.Html(`<th colspan=2><h2>`)
 	buffer.Html(`Quesma Config`)
 	buffer.Html(`</h2></th>`)
 	buffer.Html(`</tr>`)
@@ -256,9 +256,6 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 	buffer.Html(`</th>`)
 	buffer.Html(`<th>`)
 	buffer.Html(`Disabled?`)
-	buffer.Html(`</th>`)
-	buffer.Html(`<th>`)
-	buffer.Html(`Full Text Search Fields`)
 	buffer.Html(`</th>`)
 
 	buffer.Html(`</tr>`)
@@ -274,10 +271,6 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 		} else {
 			buffer.Text("false")
 		}
-		buffer.Html(`</td>`)
-
-		buffer.Html(`<td>`)
-		buffer.Text(strings.Join(cfg.FullTextFields, ", "))
 		buffer.Html(`</td>`)
 
 		buffer.Html(`</tr>`)


### PR DESCRIPTION
After 5f749e8e5e29c9, `fullTextFields` configuration option is now removed, but we forgot to delete it from `IndexConfiguration`, which made it a bit confusing. This commit deletes it fully.