### PR TITLE
Implicitly enable optimizers when config is there

### DIFF
--- a/quesma/optimize/materialized_view_replace.go
+++ b/quesma/optimize/materialized_view_replace.go
@@ -180,9 +180,10 @@ func (s *materializedViewReplace) replace(rule materializedViewReplaceRule, quer
 				from = query.FromClause.Accept(v).(model.Expr)
 			}
 		}
-
-		where := query.WhereClause.Accept(v).(model.Expr)
-
+		where := query.WhereClause
+		if query.WhereClause != nil {
+			where = query.WhereClause.Accept(v).(model.Expr)
+		}
 		return model.NewSelectCommand(query.Columns, query.GroupBy, query.OrderBy, from, where, query.LimitBy, query.Limit, query.SampleLimit, query.IsDistinct, ctes, namedCTEs)
 
 	}

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -58,7 +58,7 @@ func (s *OptimizePipeline) getIndexName(queries []*model.Query) string {
 	return res
 }
 
-func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries []*model.Query) (bool, map[string]string) {
+func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries []*model.Query) (disabled bool, props map[string]string) {
 
 	indexName := s.getIndexName(queries)
 
@@ -70,7 +70,7 @@ func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries [
 	}
 
 	// default is not enabled
-	return transformer.IsEnabledByDefault(), make(map[string]string)
+	return !transformer.IsEnabledByDefault(), make(map[string]string)
 }
 
 func (s *OptimizePipeline) Transform(queries []*model.Query) ([]*model.Query, error) {

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -64,8 +64,8 @@ func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries [
 
 	// first we check index specific settings
 	if indexCfg, ok := s.config.IndexConfig[indexName]; ok {
-		if optimizerCfg, ok := indexCfg.EnabledOptimizers[transformer.Name()]; ok {
-			return optimizerCfg.Enabled, optimizerCfg.Properties
+		if optimizerCfg, ok := indexCfg.Optimizers[transformer.Name()]; ok {
+			return optimizerCfg.Disabled, optimizerCfg.Properties
 		}
 	}
 
@@ -85,9 +85,9 @@ func (s *OptimizePipeline) Transform(queries []*model.Query) ([]*model.Query, er
 	// run optimizations on queries
 	for _, optimization := range s.optimizations {
 
-		enabled, properties := s.findConfig(optimization, queries)
+		disabled, properties := s.findConfig(optimization, queries)
 
-		if !enabled {
+		if disabled {
 			continue
 		}
 

--- a/quesma/optimize/pipeline_test.go
+++ b/quesma/optimize/pipeline_test.go
@@ -44,7 +44,7 @@ func Test_cacheQueries(t *testing.T) {
 	cfg := config.QuesmaConfiguration{}
 	cfg.IndexConfig = make(map[string]config.IndexConfiguration)
 	cfg.IndexConfig["foo"] = config.IndexConfiguration{
-		EnabledOptimizers: map[string]config.OptimizerConfiguration{"cache_queries": {Enabled: true}},
+		Optimizers: map[string]config.OptimizerConfiguration{"cache_queries": {}},
 	}
 
 	for _, tt := range tests {
@@ -197,7 +197,7 @@ func Test_dateTrunc(t *testing.T) {
 	cfg := config.QuesmaConfiguration{}
 	cfg.IndexConfig = make(map[string]config.IndexConfiguration)
 	cfg.IndexConfig["foo"] = config.IndexConfiguration{
-		EnabledOptimizers: map[string]config.OptimizerConfiguration{"truncate_date": {Enabled: true}},
+		Optimizers: map[string]config.OptimizerConfiguration{"truncate_date": {}},
 	}
 
 	for _, tt := range tests {
@@ -425,9 +425,8 @@ func Test_materialized_view_replace(t *testing.T) {
 	cfg := config.QuesmaConfiguration{}
 	cfg.IndexConfig = make(map[string]config.IndexConfiguration)
 	cfg.IndexConfig["foo"] = config.IndexConfiguration{
-		EnabledOptimizers: map[string]config.OptimizerConfiguration{
+		Optimizers: map[string]config.OptimizerConfiguration{
 			"materialized_view_replace": {
-				Enabled: true,
 				Properties: map[string]string{
 					"table":     "foo",
 					"condition": `"a">10`,

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -65,8 +65,8 @@ func (cw *ClickhouseQueryTranslator) ParseQuery(body types.JSON) (*model.Executi
 		var pancakeApplied bool
 
 		// this is an alternative implementation
-		pancakeOptimizerProps, enabled := cw.Config.IndexConfig[cw.IncomingIndexName].GetOptimizerConfiguration(PancakeOptimizerName)
-		if enabled && pancakeOptimizerProps["mode"] == "apply" {
+		pancakeOptimizerProps, disabled := cw.Config.IndexConfig[cw.IncomingIndexName].GetOptimizerConfiguration(PancakeOptimizerName)
+		if !disabled && pancakeOptimizerProps["mode"] == "apply" {
 
 			// here we deside if pancake should count rows
 			addCount := countQuery != nil

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -65,7 +65,7 @@ type RelationalDbConfiguration struct {
 }
 
 type OptimizerConfiguration struct {
-	Disabled   bool              `koanf:"enabled"`
+	Disabled   bool              `koanf:"disabled"`
 	Properties map[string]string `koanf:"properties"`
 }
 

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -65,7 +65,7 @@ type RelationalDbConfiguration struct {
 }
 
 type OptimizerConfiguration struct {
-	Enabled    bool              `koanf:"enabled"`
+	Disabled   bool              `koanf:"enabled"`
 	Properties map[string]string `koanf:"properties"`
 }
 
@@ -217,7 +217,13 @@ func (c *QuesmaConfiguration) optimizersConfigAsString(s string, cfg map[string]
 
 	lines = append(lines, fmt.Sprintf("        %s:", s))
 	for k, v := range cfg {
-		lines = append(lines, fmt.Sprintf("            %s: %v", k, v.Enabled))
+		var status string
+		if v.Disabled {
+			status = "<disabled>"
+		} else {
+			status = "enabled"
+		}
+		lines = append(lines, fmt.Sprintf("            %s: %s", k, status))
 		if v.Properties != nil && len(v.Properties) > 0 {
 			lines = append(lines, fmt.Sprintf("                properties: %v", v.Properties))
 		}
@@ -233,8 +239,8 @@ func (c *QuesmaConfiguration) OptimizersConfigAsString() string {
 	lines = append(lines, "\n")
 
 	for indexName, indexConfig := range c.IndexConfig {
-		if indexConfig.EnabledOptimizers != nil && len(indexConfig.EnabledOptimizers) > 0 {
-			lines = append(lines, c.optimizersConfigAsString(indexName, indexConfig.EnabledOptimizers))
+		if indexConfig.Optimizers != nil && len(indexConfig.Optimizers) > 0 {
+			lines = append(lines, c.optimizersConfigAsString(indexName, indexConfig.Optimizers))
 		}
 	}
 

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -38,10 +38,9 @@ func (c IndexConfiguration) String() string {
 	}
 }
 
-func (c IndexConfiguration) GetOptimizerConfiguration(optimizerName string) (map[string]string, bool) {
+func (c IndexConfiguration) GetOptimizerConfiguration(optimizerName string) (props map[string]string, disabled bool) {
 	if optimizer, ok := c.Optimizers[optimizerName]; ok {
 		return optimizer.Properties, optimizer.Disabled
 	}
-
-	return nil, false
+	return nil, true
 }

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -10,10 +10,10 @@ type IndexConfiguration struct {
 	Name     string `koanf:"name"`
 	Disabled bool   `koanf:"disabled"`
 	// TODO to be deprecated
-	TimestampField    *string                           `koanf:"timestampField"`
-	SchemaOverrides   *SchemaConfiguration              `koanf:"schemaOverrides"`
-	EnabledOptimizers map[string]OptimizerConfiguration `koanf:"optimizers"`
-	Override          string                            `koanf:"override"`
+	TimestampField  *string                           `koanf:"timestampField"`
+	SchemaOverrides *SchemaConfiguration              `koanf:"schemaOverrides"`
+	Optimizers      map[string]OptimizerConfiguration `koanf:"optimizers"`
+	Override        string                            `koanf:"override"`
 }
 
 func (c IndexConfiguration) GetTimestampField() (tsField string) {
@@ -39,8 +39,8 @@ func (c IndexConfiguration) String() string {
 }
 
 func (c IndexConfiguration) GetOptimizerConfiguration(optimizerName string) (map[string]string, bool) {
-	if optimizer, ok := c.EnabledOptimizers[optimizerName]; ok {
-		return optimizer.Properties, optimizer.Enabled
+	if optimizer, ok := c.Optimizers[optimizerName]; ok {
+		return optimizer.Properties, optimizer.Disabled
 	}
 
 	return nil, false

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -117,14 +117,14 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 
 func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
 
-	props, enabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
-	if enabled && props["mode"] == "alternative" {
+	props, disabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
+	if !disabled && props["mode"] == "alternative" {
 		return q.maybeCreatePancakeExecutionPlan(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
 	}
 
 	// TODO is should be enabled in a different way. it's not an optimizer
-	_, enabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
-	if enabled {
+	_, disabled = q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration("elastic_ab_testing")
+	if !disabled {
 		return q.askElasticAsAnAlternative(ctx, resolvedTableName, plan, queryTranslator, body, table, isAsync)
 	}
 


### PR DESCRIPTION
Similarly to indices (ref: https://github.com/QuesmaOrg/quesma/pull/682), optimizers are implicitly enabled when their configuration is in place. There's an option to leave config and make them have no effect by using `disabled` boolean flag.

Old reality:
```
optimizers:
  pancake:
    Enabled: true
    properties:
      mode: "apply"
```

Becomes:
```
optimizers:
  pancake:
    properties:
      mode: "apply"
```
 or optionally:
 ```
optimizers:
  pancake:
    disabled: false
    properties:
      mode: "apply"
```
FYSA @nablaone.