### PR TITLE
Nested field encoding, moving encoding into one clearly defined place #1

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -388,7 +388,10 @@ func (lm *LogManager) buildCreateTableQueryNoOurFields(ctx context.Context, tabl
 		// in removeFieldsTransformer's Transform method
 		ignoredFields = indexConfig.SchemaOverrides.IgnoredFields()
 	}
-	columns := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(lm.schemaRegistry, tableName), ignoredFields) + Indexes(jsonData)
+	columnsFromJson, columnsFromSchema := FieldsMapToCreateTableString(jsonData, tableConfig, nameFormatter, findSchemaPointer(lm.schemaRegistry, tableName), ignoredFields)
+
+	columns := columnsToString(columnsFromJson, columnsFromSchema)
+	columns += Indexes(jsonData)
 
 	createTableCmd := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "%s"
 (
@@ -733,7 +736,6 @@ func (lm *LogManager) processInsertQuery(ctx context.Context, tableName string,
 	// TODO this is doing nested field encoding
 	// ----------------------
 	tableConfig, err := lm.GetOrCreateTableConfig(ctx, tableName, jsonData[0], tableFormatter)
-
 	// ----------------------
 	if err != nil {
 		return nil, err

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -730,12 +730,18 @@ func (lm *LogManager) processInsertQuery(ctx context.Context, tableName string,
 		processed = append(processed, result)
 	}
 	jsonData = processed
-
+	// TODO this is doing nested field encoding
+	// ----------------------
 	tableConfig, err := lm.GetOrCreateTableConfig(ctx, tableName, jsonData[0], tableFormatter)
+
+	// ----------------------
 	if err != nil {
 		return nil, err
 	}
+	// TODO this is doing nested field encoding
+	// ----------------------
 	return lm.GenerateSqlStatements(ctx, tableName, jsonData, tableConfig, transformer)
+	// ----------------------
 }
 
 func (lm *LogManager) ProcessInsertQuery(ctx context.Context, tableName string,
@@ -807,7 +813,10 @@ func (lm *LogManager) GenerateSqlStatements(ctx context.Context, tableName strin
 			inValidJson, NestedSeparator)
 		// Remove invalid fields from the input JSON
 		preprocessedJson = subtractInputJson(preprocessedJson, inValidJson)
+		// TODO this is doing nested field encoding
+		// ----------------------
 		insertJson, alter, err := lm.BuildIngestSQLStatements(tableName, preprocessedJson, inValidJson, config)
+		// ----------------------
 		alterCmd = append(alterCmd, alter...)
 		if err != nil {
 			return nil, fmt.Errorf("error BuildInsertJson, tablename: '%s' json: '%s': %v", tableName, PrettyJson(insertJson), err)

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -19,14 +19,10 @@ type CreateTableEntry struct {
 	ClickHouseType       string
 }
 
-// m: unmarshalled json from HTTP request
-// Returns nicely formatted string for CREATE TABLE command
-func FieldsMapToCreateTableString(m SchemaMap, config *ChTableConfig, nameFormatter TableColumNameFormatter, schemaMapping *schema.Schema, ignoredFields []config.FieldName) string {
+func columnsToString(columnsFromJson []CreateTableEntry,
+	columnsFromSchema map[schema.FieldName]CreateTableEntry,
+) string {
 	var result strings.Builder
-
-	columnsFromJson := JsonToColumns("", m, 1, config, nameFormatter, ignoredFields)
-	columnsFromSchema := SchemaToColumns(schemaMapping, nameFormatter)
-
 	first := true
 	for _, columnFromJson := range columnsFromJson {
 		if first {
@@ -56,8 +52,16 @@ func FieldsMapToCreateTableString(m SchemaMap, config *ChTableConfig, nameFormat
 		result.WriteString(util.Indent(1))
 		result.WriteString(fmt.Sprintf("\"%s\" %s", column.ClickHouseColumnName, column.ClickHouseType))
 	}
-
 	return result.String()
+}
+
+// m: unmarshalled json from HTTP request
+// Returns nicely formatted string for CREATE TABLE command
+func FieldsMapToCreateTableString(m SchemaMap, config *ChTableConfig, nameFormatter TableColumNameFormatter, schemaMapping *schema.Schema, ignoredFields []config.FieldName) string {
+	columnsFromJson := JsonToColumns("", m, 1, config, nameFormatter, ignoredFields)
+	columnsFromSchema := SchemaToColumns(schemaMapping, nameFormatter)
+
+	return columnsToString(columnsFromJson, columnsFromSchema)
 }
 
 func JsonToColumns(namespace string, m SchemaMap, indentLvl int, chConfig *ChTableConfig, nameFormatter TableColumNameFormatter, ignoredFields []config.FieldName) []CreateTableEntry {

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -19,6 +19,7 @@ type CreateTableEntry struct {
 	ClickHouseType       string
 }
 
+// Rendering columns to string
 func columnsToString(columnsFromJson []CreateTableEntry,
 	columnsFromSchema map[schema.FieldName]CreateTableEntry,
 ) string {
@@ -55,13 +56,18 @@ func columnsToString(columnsFromJson []CreateTableEntry,
 	return result.String()
 }
 
-// m: unmarshalled json from HTTP request
-// Returns nicely formatted string for CREATE TABLE command
-func FieldsMapToCreateTableString(m SchemaMap, config *ChTableConfig, nameFormatter TableColumNameFormatter, schemaMapping *schema.Schema, ignoredFields []config.FieldName) string {
-	columnsFromJson := JsonToColumns("", m, 1, config, nameFormatter, ignoredFields)
+// Returns typed columns from JSON and schema mapping
+func FieldsMapToCreateTableString(m SchemaMap,
+	config *ChTableConfig,
+	nameFormatter TableColumNameFormatter,
+	schemaMapping *schema.Schema,
+	ignoredFields []config.FieldName,
+) ([]CreateTableEntry, map[schema.FieldName]CreateTableEntry) {
+	columnsFromJson := JsonToColumns("", m, 1,
+		config, nameFormatter, ignoredFields)
 	columnsFromSchema := SchemaToColumns(schemaMapping, nameFormatter)
 
-	return columnsToString(columnsFromJson, columnsFromSchema)
+	return columnsFromJson, columnsFromSchema
 }
 
 func JsonToColumns(namespace string, m SchemaMap, indentLvl int, chConfig *ChTableConfig, nameFormatter TableColumNameFormatter, ignoredFields []config.FieldName) []CreateTableEntry {


### PR DESCRIPTION
The purpose of this PRs is to unify nested field encoding process, by doing this exactly in one place.
For this reason we have to move generation of `Create Table` string and `insert into` into one function. 
