### PR TITLE
Push Elastic's response from A/B testing to management console

### DIFF
--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -766,6 +766,14 @@ func (q *QueryRunner) postProcessResults(table *clickhouse.Table, results [][]mo
 	return geoIpTransformer.Transform(res)
 }
 
+func pushPrimaryInfo(qmc *ui.QuesmaManagementConsole, Id string, QueryResp []byte, startTime time.Time) {
+	qmc.PushPrimaryInfo(&ui.QueryDebugPrimarySource{
+		Id:          Id,
+		QueryResp:   QueryResp,
+		PrimaryTook: time.Since(startTime),
+	})
+}
+
 func pushSecondaryInfo(qmc *ui.QuesmaManagementConsole, Id, AsyncId, Path string, IncomingQueryBody []byte, QueryBodyTranslated []types.TranslatedSQLQuery, QueryTranslatedResults []byte, startTime time.Time) {
 	qmc.PushSecondaryInfo(&ui.QueryDebugSecondarySource{
 		Id:                     Id,

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -170,6 +170,9 @@ func (q *QueryRunner) askElasticAsAnAlternative(ctx context.Context, resolvedTab
 			return nil, fmt.Errorf("error calling elastic. got error code: %d", resp.StatusCode)
 		}
 
+		contextValues := tracing.ExtractValues(ctx)
+		pushPrimaryInfo(q.quesmaManagementConsole, contextValues.RequestId, responseBody, plan.StartTime)
+
 		return responseBody, nil
 	}
 }

--- a/quesma/quesma/ui/live_tail.go
+++ b/quesma/quesma/ui/live_tail.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"quesma/buildinfo"
-	"quesma/quesma/config"
 	"quesma/quesma/types"
 	"quesma/quesma/ui/internal/builder"
 	"quesma/util"
@@ -217,32 +216,30 @@ func (qmc *QuesmaManagementConsole) populateQueries(debugKeyValueSlice []queryDe
 	buffer.Html("\n</div>\n")
 
 	buffer.Html(`<div class="right" id="query-right">` + "\n")
-	// TODO revisit after modes are redone
-	if qmc.cfg.Mode == config.DualWriteQueryClickhouse && qmc.cfg.EnableElasticsearchIngest {
-		buffer.Html(`<div class="title-bar">Elasticsearch response` + "\n" + `</div>`)
-		buffer.Html(`<div class="debug-body">`)
-		for _, v := range debugKeyValueSlice {
-			if withLinks {
-				buffer.Html(`<a href="/request-id/`).Text(v.id).Html(`">`)
-			}
-			tookStr := fmt.Sprintf(" took %d ms", v.query.PrimaryTook.Milliseconds())
-			buffer.Html("<p>UUID:").Text(v.id).Text(tookStr).Html("</p>\n")
-			buffer.Html(`<pre Id="response`).Text(v.id).Html(`">`)
-			if len(v.query.QueryResp) > 0 {
-				buffer.Text(string(v.query.QueryResp))
-			} else {
-				buffer.Text("(empty, request was not sent to Elasticsearch)")
-			}
-			buffer.Html("\n</pre>")
-			if withLinks {
-				buffer.Html("\n</a>")
-			}
-		}
-	} else {
-		buffer.Html(`<div class="title-bar">Elasticsearch response (not applicable)` + "\n" + `</div>`)
-	}
 
+	// TODO: if no A/B testing with Elastic is enabled in the configuration, then add "(not applicable)" to the title
+	buffer.Html(`<div class="title-bar">Elasticsearch response` + "\n" + `</div>`)
+
+	buffer.Html(`<div class="debug-body">`)
+	for _, v := range debugKeyValueSlice {
+		if withLinks {
+			buffer.Html(`<a href="/request-id/`).Text(v.id).Html(`">`)
+		}
+		tookStr := fmt.Sprintf(" took %d ms", v.query.PrimaryTook.Milliseconds())
+		buffer.Html("<p>UUID:").Text(v.id).Text(tookStr).Html("</p>\n")
+		buffer.Html(`<pre Id="response`).Text(v.id).Html(`">`)
+		if len(v.query.QueryResp) > 0 {
+			buffer.Text(string(v.query.QueryResp))
+		} else {
+			buffer.Text("(empty, request was not sent to Elasticsearch)")
+		}
+		buffer.Html("\n</pre>")
+		if withLinks {
+			buffer.Html("\n</a>")
+		}
+	}
 	buffer.Html("\n</div>")
+
 	buffer.Html("\n</div>\n")
 
 	buffer.Html(`<div class="bottom_left" id="query-bottom-left">` + "\n")


### PR DESCRIPTION
In the Quesma Managment Console we have "Elastic response" panel in the "Live tail" page and similar on the drilldown page. Those panels were filled in by the "EnableElasticsearchIngest: true" mode, which resends all requests to Elastic (even non-ingest!).

However in the upcoming PRs we will effectively remove "EnableElasticsearchIngest" mode. For the query path, it's now obsoleted by A/B testing with Elastic (see #631). But A/B testing with Elastic did not fill in the Quesma Management Console with responses from Elastic.

This PR improves A/B testing with Elastic to also send Elastic's response to the Quesma Management Console.

This is how the relevant panels look like now (previously they were empty):
<img width="2249" alt="Zrzut ekranu 2024-09-6 o 12 27 00" src="https://github.com/user-attachments/assets/32800274-3ade-4fe8-8a13-9d6feaa0d678">
<img width="2249" alt="Zrzut ekranu 2024-09-6 o 12 26 21" src="https://github.com/user-attachments/assets/5f4f15ea-2fea-42a5-8729-27013b301893">

