### PR TITLE
nested fields encoding, refactoring ddl creation #2

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -379,7 +379,7 @@ func findSchemaPointer(schemaRegistry schema.Registry, tableName string) *schema
 }
 
 func (lm *LogManager) buildCreateTableQueryNoOurFields(ctx context.Context, tableName string,
-	jsonData types.JSON, tableConfig *ChTableConfig, nameFormatter TableColumNameFormatter) (string, error) {
+	jsonData types.JSON, tableConfig *ChTableConfig, nameFormatter TableColumNameFormatter) string {
 
 	var ignoredFields []config.FieldName
 	if indexConfig, found := lm.cfg.IndexConfig[tableName]; found && indexConfig.SchemaOverrides != nil {
@@ -403,7 +403,7 @@ COMMENT 'created by Quesma'`,
 		tableName, columns,
 		tableConfig.CreateTablePostFieldsString())
 
-	return createTableCmd, nil
+	return createTableCmd
 }
 
 func Indexes(m SchemaMap) string {
@@ -423,16 +423,9 @@ func Indexes(m SchemaMap) string {
 func (lm *LogManager) CreateTableFromInsertQuery(ctx context.Context, name string, jsonData types.JSON, config *ChTableConfig, tableFormatter TableColumNameFormatter) error {
 	// TODO fix lm.AddTableIfDoesntExist(name, jsonData)
 
-	query, err := lm.buildCreateTableQueryNoOurFields(ctx, name, jsonData, config, tableFormatter)
-	if err != nil {
-		return err
-	}
+	query := lm.buildCreateTableQueryNoOurFields(ctx, name, jsonData, config, tableFormatter)
 
-	err = lm.ProcessCreateTableQuery(ctx, query, config)
-	if err != nil {
-		return err
-	}
-	return nil
+	return lm.ProcessCreateTableQuery(ctx, query, config)
 }
 
 func deepCopyMapSliceInterface(original map[string][]interface{}) map[string][]interface{} {

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -116,8 +116,7 @@ func TestAddTimestamp(t *testing.T) {
 	nameFormatter := DefaultColumnNameFormatter()
 	lm := NewLogManagerEmpty()
 	lm.schemaRegistry = schema.StaticRegistry{}
-	query, err := lm.buildCreateTableQueryNoOurFields(context.Background(), "tableName", types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`), tableConfig, nameFormatter)
-	assert.NoError(t, err)
+	query := lm.buildCreateTableQueryNoOurFields(context.Background(), "tableName", types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`), tableConfig, nameFormatter)
 	assert.True(t, strings.Contains(query, timestampFieldName))
 }
 

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -116,7 +116,10 @@ func TestAddTimestamp(t *testing.T) {
 	nameFormatter := DefaultColumnNameFormatter()
 	lm := NewLogManagerEmpty()
 	lm.schemaRegistry = schema.StaticRegistry{}
-	query := lm.buildCreateTableQueryNoOurFields(context.Background(), "tableName", types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`), tableConfig, nameFormatter)
+	jsonData := types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`)
+	columnsFromJson, columnsFromSchema := lm.buildCreateTableQueryNoOurFields(context.Background(), "tableName", jsonData, tableConfig, nameFormatter)
+	columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema), Indexes(jsonData))
+	query := createTableQuery(tableName, columns, tableConfig)
 	assert.True(t, strings.Contains(query, timestampFieldName))
 }
 

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -157,7 +157,10 @@ func TestAutomaticTableCreationAtInsert(t *testing.T) {
 			for index3, lm := range logManagers(tableConfig) {
 				t.Run("case insertTest["+strconv.Itoa(index1)+"], config["+strconv.Itoa(index2)+"], logManager["+strconv.Itoa(index3)+"]", func(t *testing.T) {
 					lm.lm.schemaRegistry = schema.StaticRegistry{}
-					query := lm.lm.buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, &columNameFormatter{separator: "::"})
+					columnsFromJson, columnsFromSchema := lm.lm.buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, &columNameFormatter{separator: "::"})
+					columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema), Indexes(types.MustJSON(tt.insertJson)))
+					query := createTableQuery(tableName, columns, tableConfig)
+
 					table, err := NewTable(query, tableConfig)
 					assert.NoError(t, err)
 					query = addOurFieldsToCreateTableQuery(query, tableConfig, table)

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -157,8 +157,7 @@ func TestAutomaticTableCreationAtInsert(t *testing.T) {
 			for index3, lm := range logManagers(tableConfig) {
 				t.Run("case insertTest["+strconv.Itoa(index1)+"], config["+strconv.Itoa(index2)+"], logManager["+strconv.Itoa(index3)+"]", func(t *testing.T) {
 					lm.lm.schemaRegistry = schema.StaticRegistry{}
-					query, err := lm.lm.buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, &columNameFormatter{separator: "::"})
-					assert.NoError(t, err)
+					query := lm.lm.buildCreateTableQueryNoOurFields(context.Background(), tableName, types.MustJSON(tt.insertJson), tableConfig, &columNameFormatter{separator: "::"})
 					table, err := NewTable(query, tableConfig)
 					assert.NoError(t, err)
 					query = addOurFieldsToCreateTableQuery(query, tableConfig, table)


### PR DESCRIPTION
Propagating the return of type-safe columns as []CreateTableEntry and map[schema.FieldName]CreateTableEntry instead of strings.