### PR TITLE
nested fields encoding #4

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -608,14 +608,14 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 	config *ChTableConfig,
 ) (string, []string, error) {
 
-	jsonData, err := json.Marshal(data)
+	jsonAsBytesSlice, err := json.Marshal(data)
 
 	if err != nil {
 		return "", nil, err
 	}
 
 	// we find all non-schema fields
-	jsonMap, err := types.ParseJSON(string(jsonData))
+	jsonMap, err := types.ParseJSON(string(jsonAsBytesSlice))
 	if err != nil {
 		return "", nil, err
 	}
@@ -626,7 +626,7 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 		// if we don't have any attributes, and it wasn't replaced,
 		// we don't need to modify the json
 		if !wasReplaced {
-			return string(jsonData), nil, nil
+			return string(jsonAsBytesSlice), nil, nil
 		}
 		rawBytes, err := jsonMap.Bytes()
 		if err != nil {
@@ -643,8 +643,8 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 
 	mDiff := DifferenceMap(jsonMap, table) // TODO change to DifferenceMap(m, t)
 
-	if len(mDiff) == 0 && string(schemaFieldsJson) == string(jsonData) && len(inValidJson) == 0 { // no need to modify, just insert 'js'
-		return string(jsonData), nil, nil
+	if len(mDiff) == 0 && string(schemaFieldsJson) == string(jsonAsBytesSlice) && len(inValidJson) == 0 { // no need to modify, just insert 'js'
+		return string(jsonAsBytesSlice), nil, nil
 	}
 
 	// check attributes precondition

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -610,10 +610,9 @@ func (lm *LogManager) BuildIngestSQLStatements(tableName string, data types.JSON
 	if err != nil {
 		return "", nil, err
 	}
-	jsonDataAsString := string(jsonData)
 
 	// we find all non-schema fields
-	jsonMap, err := types.ParseJSON(jsonDataAsString)
+	jsonMap, err := types.ParseJSON(string(jsonData))
 	if err != nil {
 		return "", nil, err
 	}
@@ -624,7 +623,7 @@ func (lm *LogManager) BuildIngestSQLStatements(tableName string, data types.JSON
 		// if we don't have any attributes, and it wasn't replaced,
 		// we don't need to modify the json
 		if !wasReplaced {
-			return jsonDataAsString, nil, nil
+			return string(jsonData), nil, nil
 		}
 		rawBytes, err := jsonMap.Bytes()
 		if err != nil {
@@ -642,8 +641,8 @@ func (lm *LogManager) BuildIngestSQLStatements(tableName string, data types.JSON
 
 	mDiff := DifferenceMap(jsonMap, table) // TODO change to DifferenceMap(m, t)
 
-	if len(mDiff) == 0 && string(schemaFieldsJson) == jsonDataAsString && len(inValidJson) == 0 { // no need to modify, just insert 'js'
-		return jsonDataAsString, nil, nil
+	if len(mDiff) == 0 && string(schemaFieldsJson) == string(jsonData) && len(inValidJson) == 0 { // no need to modify, just insert 'js'
+		return string(jsonData), nil, nil
 	}
 
 	// check attributes precondition

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -46,9 +46,11 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 		},
 	})
 
+	tableName, exists := fieldsMap.Load("tableName")
+	assert.True(t, exists)
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
-		j, alter, err := lm.BuildIngestSQLStatements("tableName", types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		j, alter, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))
 		m := make(SchemaMap)

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -244,7 +244,6 @@ func TestProcessInsertQuery(t *testing.T) {
 							mock.ExpectExec(expectedInserts[2*index1+1][i]).WillReturnResult(sqlmock.NewResult(545, 54))
 						}
 					}
-
 					err := lm.lm.ProcessInsertQuery(ctx, tableName, []types.JSON{types.MustJSON(tt.insertJson)}, &IngestTransformer{}, &columNameFormatter{separator: "::"})
 					assert.NoError(t, err)
 					if err := mock.ExpectationsWereMet(); err != nil {

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -244,6 +244,7 @@ func TestProcessInsertQuery(t *testing.T) {
 							mock.ExpectExec(expectedInserts[2*index1+1][i]).WillReturnResult(sqlmock.NewResult(545, 54))
 						}
 					}
+
 					err := lm.lm.ProcessInsertQuery(ctx, tableName, []types.JSON{types.MustJSON(tt.insertJson)}, &IngestTransformer{}, &columNameFormatter{separator: "::"})
 					assert.NoError(t, err)
 					if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
This PR:
- changes signature of `BuildIngestSQLStatements` to pass `*table` consequently
- moves body of `GenerateSqlStatements` to `processInsertQuery` to assemble whole workflow in one place and open a way for new arrangement.