### PR TITLE
Moving field encoding from JsonToColumns to processInsertQuery

### DIFF
--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -90,22 +90,14 @@ func JsonToColumns(namespace string, m SchemaMap, indentLvl int, chConfig *ChTab
 			if indentLvl == 1 && name == timestampFieldName && chConfig.timestampDefaultsNow {
 				fTypeString += " DEFAULT now64()"
 			}
-
 			// We still may have name like:
 			// "service.name": { "very.name": "value" }
 			// Before that code it would be transformed to:
 			// "service.name::very.name"
 			// So I convert it to:
 			// "service::name::very::name"
+
 			internalName := nameFormatter.Format(namespace, name)
-			// We should never have dots in the field names, see 4 ADR
-			internalName = strings.Replace(internalName, ".", "::", -1)
-
-			// FIXME: linear search, converting back '::' to '.'
-			if slices.Contains(ignoredFields, config.FieldName(strings.Replace(internalName, "::", ".", -1))) {
-				continue
-			}
-
 			resultColumns = append(resultColumns, CreateTableEntry{ClickHouseColumnName: internalName, ClickHouseType: fTypeString})
 		}
 	}


### PR DESCRIPTION
This PR implements a major step moving one of nested field encoding functionality to common `processInsertQuery`.
Next,`BuildIngestSQLStatements` will be refactored to extract the same functionality and move it to `processInsertQuery` as well