### PR TITLE
Refactoring - moving ingest field name encoding into one function

### DIFF
--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -31,8 +31,8 @@ func TestAlterTable(t *testing.T) {
 		`{"Test1":1,"Test2":2}`,
 	}
 	expectedInsert := []string{
-		"{\"attributes_values\":{},\"attributes_metadata\":{},\"Test1\":1}",
-		"{\"attributes_values\":{},\"attributes_metadata\":{},\"Test1\":1,\"Test2\":2}",
+		"{\"Test1\":1}",
+		"{\"Test1\":1,\"Test2\":2}",
 	}
 	alters := []string{
 		"ALTER TABLE \"tableName\" ADD COLUMN IF NOT EXISTS \"Test1\" Nullable(Int64)",

--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -47,7 +47,8 @@ func TestAlterTable(t *testing.T) {
 
 	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 	for i := range rowsToInsert {
-		insert, alter, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+		_, alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+		insert := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.Equal(t, expectedInsert[i], insert)
 		assert.Equal(t, alters[i], alter[0])
 		// Table will grow with each iteration
@@ -121,7 +122,7 @@ func TestAlterTableHeuristic(t *testing.T) {
 
 		assert.Equal(t, int64(0), lm.ingestCounter)
 		for i := range rowsToInsert {
-			_, _, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+			_, _, _, _, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, tc.expected, len(table.Cols))

--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -47,7 +47,7 @@ func TestAlterTable(t *testing.T) {
 
 	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 	for i := range rowsToInsert {
-		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+		alter, onlySchemaFields, nonSchemaFields, err := lm.GenerateIngestContent(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
 		assert.NoError(t, err)
 		insert, err := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.Equal(t, expectedInsert[i], insert)
@@ -123,7 +123,7 @@ func TestAlterTableHeuristic(t *testing.T) {
 
 		assert.Equal(t, int64(0), lm.ingestCounter)
 		for i := range rowsToInsert {
-			_, _, _, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+			_, _, _, err := lm.GenerateIngestContent(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, tc.expected, len(table.Cols))

--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -47,7 +47,7 @@ func TestAlterTable(t *testing.T) {
 
 	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 	for i := range rowsToInsert {
-		_, alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
 		insert := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.Equal(t, expectedInsert[i], insert)
 		assert.Equal(t, alters[i], alter[0])
@@ -122,7 +122,7 @@ func TestAlterTableHeuristic(t *testing.T) {
 
 		assert.Equal(t, int64(0), lm.ingestCounter)
 		for i := range rowsToInsert {
-			_, _, _, _, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
+			_, _, _, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
 			assert.NoError(t, err)
 		}
 		assert.Equal(t, tc.expected, len(table.Cols))

--- a/quesma/clickhouse/alter_table_test.go
+++ b/quesma/clickhouse/alter_table_test.go
@@ -48,7 +48,8 @@ func TestAlterTable(t *testing.T) {
 	lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 	for i := range rowsToInsert {
 		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, types.MustJSON(rowsToInsert[i]), nil, chConfig)
-		insert := generateInsertJson(nonSchemaFields, onlySchemaFields)
+		assert.NoError(t, err)
+		insert, err := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.Equal(t, expectedInsert[i], insert)
 		assert.Equal(t, alters[i], alter[0])
 		// Table will grow with each iteration

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -524,7 +524,7 @@ type NonSchemaField struct {
 	Type  string
 }
 
-func generateNonSchemaStr(nonSchemaFields []NonSchemaField) string {
+func convertNonSchemaFieldsToString(nonSchemaFields []NonSchemaField) string {
 	if len(nonSchemaFields) <= 0 {
 		return ""
 	}
@@ -552,7 +552,7 @@ func generateNonSchemaStr(nonSchemaFields []NonSchemaField) string {
 	return nonSchemaStr
 }
 
-func generateNonSchemaFieldsString(attrsMap map[string][]interface{}) ([]NonSchemaField, error) {
+func generateNonSchemaFields(attrsMap map[string][]interface{}) ([]NonSchemaField, error) {
 	var nonSchemaFields []NonSchemaField
 	if len(attrsMap) <= 0 {
 		return nonSchemaFields, nil
@@ -693,7 +693,7 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 	// addInvalidJsonFieldsToAttributes returns a new map with invalid fields added
 	// this map is then used to generate non-schema fields string
 	attrsMapWithInvalidFields := addInvalidJsonFieldsToAttributes(attrsMap, inValidJson)
-	nonSchemaFields, err := generateNonSchemaFieldsString(attrsMapWithInvalidFields)
+	nonSchemaFields, err := generateNonSchemaFields(attrsMapWithInvalidFields)
 
 	if err != nil {
 		return nil, nil, nil, err
@@ -705,7 +705,7 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 }
 
 func generateInsertJson(nonSchemaFields []NonSchemaField, onlySchemaFields types.JSON) (string, error) {
-	nonSchemaStr := generateNonSchemaStr(nonSchemaFields)
+	nonSchemaStr := convertNonSchemaFieldsToString(nonSchemaFields)
 	schemaFieldsJson, err := json.Marshal(onlySchemaFields)
 	if err != nil {
 		return "", err

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -525,6 +525,9 @@ type NonSchemaField struct {
 }
 
 func generateNonSchemaStr(nonSchemaFields []NonSchemaField) string {
+	if len(nonSchemaFields) <= 0 {
+		return ""
+	}
 	attributesColumns := []string{AttributesValuesColumn, AttributesMetadataColumn}
 	var nonSchemaStr string
 	for columnIndex, column := range attributesColumns {
@@ -535,11 +538,7 @@ func generateNonSchemaStr(nonSchemaFields []NonSchemaField) string {
 		nonSchemaStr += "\"" + column + "\":{"
 		for i := 0; i < len(nonSchemaFields); i++ {
 			if columnIndex > 0 {
-				// We are versioning metadata fields
-				// At the moment we store only types
-				// but that might change in the future
-				const metadataVersionPrefix = "v1"
-				value = metadataVersionPrefix + ";" + nonSchemaFields[i].Type
+				value = nonSchemaFields[i].Type
 			} else {
 				value = nonSchemaFields[i].Value
 			}
@@ -573,10 +572,20 @@ func generateNonSchemaFieldsString(attrsMap map[string][]interface{}) ([]NonSche
 				// but that might change in the future
 				const metadataVersionPrefix = "v1"
 				value = metadataVersionPrefix + ";" + attrTypes[i]
+				if i > len(nonSchemaFields)-1 {
+					nonSchemaFields = append(nonSchemaFields, NonSchemaField{Key: attrKeys[i], Value: "", Type: value})
+				} else {
+					nonSchemaFields[i].Type = value
+				}
 			} else {
 				value = attrValues[i]
+				if i > len(nonSchemaFields)-1 {
+					nonSchemaFields = append(nonSchemaFields, NonSchemaField{Key: attrKeys[i], Value: value, Type: ""})
+				} else {
+					nonSchemaFields[i].Value = value
+				}
+
 			}
-			nonSchemaFields = append(nonSchemaFields, NonSchemaField{Key: attrKeys[i], Value: value, Type: attrTypes[i]})
 		}
 	}
 	return nonSchemaFields, nil

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -783,7 +783,9 @@ func (lm *LogManager) processInsertQuery(ctx context.Context,
 	for i, preprocessedJson := range preprocessedJsons {
 		// TODO this is doing nested field encoding
 		// ----------------------
-		replaceDotsWithSeparator(preprocessedJson)
+		transformFieldName(preprocessedJson, func(field string) string {
+			return strings.Replace(field, ".", "::", -1)
+		})
 		// ----------------------
 		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, preprocessedJson,
 			invalidJsons[i], tableConfig)

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -655,8 +655,6 @@ func (lm *LogManager) BuildIngestSQLStatements(table *Table,
 		return nil, nil, nil, err
 	}
 
-	replaceDotsWithSeparator(jsonMap)
-
 	if len(config.attributes) == 0 {
 		return nil, jsonMap, nil, nil
 	}
@@ -785,6 +783,8 @@ func (lm *LogManager) processInsertQuery(ctx context.Context,
 	for i, preprocessedJson := range preprocessedJsons {
 		// TODO this is doing nested field encoding
 		// ----------------------
+		replaceDotsWithSeparator(preprocessedJson)
+		// ----------------------
 		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(table, preprocessedJson,
 			invalidJsons[i], tableConfig)
 		if err != nil {
@@ -794,7 +794,6 @@ func (lm *LogManager) processInsertQuery(ctx context.Context,
 		if err != nil {
 			return nil, fmt.Errorf("error generatateInsertJson, tablename: '%s' json: '%s': %v", table.Name, PrettyJson(insertJson), err)
 		}
-		// ----------------------
 		alterCmd = append(alterCmd, alter...)
 		if err != nil {
 			return nil, fmt.Errorf("error BuildInsertJson, tablename: '%s' json: '%s': %v", table.Name, PrettyJson(insertJson), err)

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -518,10 +518,12 @@ func (lm *LogManager) generateNewColumns(
 	return alterCmd
 }
 
+// This struct contains the information about the columns that are part of the schema
+// and will go into attributes map
 type NonSchemaField struct {
 	Key   string
 	Value string
-	Type  string
+	Type  string // inferred from incoming json
 }
 
 func convertNonSchemaFieldsToString(nonSchemaFields []NonSchemaField) string {

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -518,7 +518,7 @@ func (lm *LogManager) generateNewColumns(
 	return alterCmd
 }
 
-// This struct contains the information about the columns that are part of the schema
+// This struct contains the information about the columns that aren't part of the schema
 // and will go into attributes map
 type NonSchemaField struct {
 	Key   string

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -50,7 +50,7 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	assert.True(t, exists)
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
-		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		alter, onlySchemaFields, nonSchemaFields, err := lm.GenerateIngestContent(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
 		assert.NoError(t, err)
 		j, err := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.NoError(t, err)

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -50,7 +50,8 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	assert.True(t, exists)
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
-		j, alter, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		_, alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		j := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))
 		m := make(SchemaMap)

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -50,7 +50,7 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	assert.True(t, exists)
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
-		_, alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
+		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
 		j := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))

--- a/quesma/clickhouse/clickhouse_test.go
+++ b/quesma/clickhouse/clickhouse_test.go
@@ -51,7 +51,8 @@ func TestInsertNonSchemaFieldsToOthers_1(t *testing.T) {
 	f := func(t1, t2 TableMap) {
 		lm := NewLogManager(fieldsMap, &config.QuesmaConfiguration{})
 		alter, onlySchemaFields, nonSchemaFields, err := lm.BuildIngestSQLStatements(tableName, types.MustJSON(rowToInsert), nil, hasOthersConfig)
-		j := generateInsertJson(nonSchemaFields, onlySchemaFields)
+		assert.NoError(t, err)
+		j, err := generateInsertJson(nonSchemaFields, onlySchemaFields)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, len(alter))
 		m := make(SchemaMap)

--- a/quesma/clickhouse/dots.go
+++ b/quesma/clickhouse/dots.go
@@ -4,13 +4,12 @@ package clickhouse
 
 import (
 	"quesma/quesma/types"
-	"strings"
 )
 
-func replaceDotsWithSeparator(jsonInsert types.JSON) bool {
+func transformFieldName(jsonInsert types.JSON, transformer func(field string) string) bool {
 	gotDots := false
 	for fieldName, v := range jsonInsert {
-		withoutDotsFieldName := strings.Replace(fieldName, ".", "::", -1)
+		withoutDotsFieldName := transformer(fieldName)
 		if fieldName != withoutDotsFieldName {
 			gotDots = true
 			jsonInsert[withoutDotsFieldName] = v
@@ -18,7 +17,7 @@ func replaceDotsWithSeparator(jsonInsert types.JSON) bool {
 			fieldName = withoutDotsFieldName
 		}
 		if nestedJson, isNested := v.(map[string]interface{}); isNested {
-			nestedGotDots := replaceDotsWithSeparator(nestedJson)
+			nestedGotDots := transformFieldName(nestedJson, transformer)
 			gotDots = gotDots || nestedGotDots
 		}
 	}

--- a/quesma/clickhouse/dots_test.go
+++ b/quesma/clickhouse/dots_test.go
@@ -5,25 +5,31 @@ package clickhouse
 import (
 	"github.com/stretchr/testify/assert"
 	"quesma/quesma/types"
+	"strings"
 	"testing"
 )
 
 func Test_removeDotsFromJsons(t *testing.T) {
 	hostNameStr := `{"host.name": "alpha"}`
 	hostNameJson, _ := types.ParseJSON(hostNameStr)
-	assert.True(t, replaceDotsWithSeparator(hostNameJson))
+
+	fieldTransform := func(field string) string {
+		return strings.ReplaceAll(field, ".", "::")
+	}
+
+	assert.True(t, transformFieldName(hostNameJson, fieldTransform))
 	newBytes, _ := hostNameJson.Bytes()
 	assert.Equal(t, `{"host::name":"alpha"}`, string(newBytes))
 
 	nestedStr := `{"cloud": {"host.name":"alpha"}}`
 	nestedJson, _ := types.ParseJSON(nestedStr)
-	assert.True(t, replaceDotsWithSeparator(nestedJson))
+	assert.True(t, transformFieldName(nestedJson, fieldTransform))
 	newNested, _ := nestedJson.Bytes()
 	assert.Equal(t, `{"cloud":{"host::name":"alpha"}}`, string(newNested))
 
 	noChange := `{"host_name": "alpha"}`
 	noChangeJson, _ := types.ParseJSON(noChange)
-	assert.False(t, replaceDotsWithSeparator(noChangeJson))
+	assert.False(t, transformFieldName(noChangeJson, fieldTransform))
 	newNoChange, _ := noChangeJson.Bytes()
 	assert.Equal(t, `{"host_name":"alpha"}`, string(newNoChange))
 }

--- a/quesma/clickhouse/insert_test.go
+++ b/quesma/clickhouse/insert_test.go
@@ -101,7 +101,7 @@ var expectedInserts = [][]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "service::name" Nullable(String)`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "source" Nullable(String)`),
-		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_values":{},"attributes_metadata":{},"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","service::name":"frontend","severity":"debug","source":"rhel"}`),
+		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","service::name":"frontend","severity":"debug","source":"rhel"}`),
 	},
 	[]string{
 		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
@@ -110,7 +110,7 @@ var expectedInserts = [][]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random1" Array(String)`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random2" Nullable(String)`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
-		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"attributes_values":{},"attributes_metadata":{},"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
+		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host::name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
 	},
 }
 


### PR DESCRIPTION
This PR refactor ingest workflow and unifies ingest field encoding inside `processInsertQuery` function.
That's not finish, it's just a step forward