### PR TITLE
Introducing internal Quesma type

### DIFF
--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -133,7 +133,7 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter TableColumNameF
 		default:
 			logger.Warn().Msgf("Unsupported field type '%s' for field '%s' when trying to create a table. Ignoring that field.", field.Type.Name, field.PropertyName.AsString())
 			continue
-		case schema.TypePoint.Name:
+		case schema.QuesmaTypePoint.Name:
 			lat := nameFormatter.Format(internalPropertyName, "lat")
 			lon := nameFormatter.Format(internalPropertyName, "lon")
 			resultColumns[schema.FieldName(lat)] = CreateTableEntry{ClickHouseColumnName: lat, ClickHouseType: "Nullable(String)"}
@@ -141,25 +141,25 @@ func SchemaToColumns(schemaMapping *schema.Schema, nameFormatter TableColumNameF
 			continue
 
 		// Simple types:
-		case schema.TypeText.Name:
+		case schema.QuesmaTypeText.Name:
 			fType = "Nullable(String)"
-		case schema.TypeKeyword.Name:
+		case schema.QuesmaTypeKeyword.Name:
 			fType = "Nullable(String)"
-		case schema.TypeLong.Name:
+		case schema.QuesmaTypeLong.Name:
 			fType = "Nullable(Int64)"
-		case schema.TypeUnsignedLong.Name:
+		case schema.QuesmaTypeUnsignedLong.Name:
 			fType = "Nullable(Uint64)"
-		case schema.TypeTimestamp.Name:
+		case schema.QuesmaTypeTimestamp.Name:
 			fType = "Nullable(DateTime64)"
-		case schema.TypeDate.Name:
+		case schema.QuesmaTypeDate.Name:
 			fType = "Nullable(Date)"
 			// TODO: This (and Nullable(DateTime64) above) can be problematic for ingest when when set by user explicitly. We should either not use Nullable in this case
 			// or add some validation logic so that its handled properly.
 			// Example if someone sets `type: date` to a field in schemaOverrides AND this is a timestamp field for which we have dedicated logic (use DateTime64 + add DEFAULT now64())
 			// Ingest will FAIL creating table with "Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled"
-		case schema.TypeFloat.Name:
+		case schema.QuesmaTypeFloat.Name:
 			fType = "Nullable(Float64)"
-		case schema.TypeBoolean.Name:
+		case schema.QuesmaTypeBoolean.Name:
 			fType = "Nullable(Bool)"
 		}
 		resultColumns[schema.FieldName(internalPropertyName)] = CreateTableEntry{ClickHouseColumnName: internalPropertyName, ClickHouseType: fType}

--- a/quesma/clickhouse/type_adapter.go
+++ b/quesma/clickhouse/type_adapter.go
@@ -10,38 +10,38 @@ import (
 type SchemaTypeAdapter struct {
 }
 
-func (c SchemaTypeAdapter) Convert(s string) (schema.Type, bool) {
+func (c SchemaTypeAdapter) Convert(s string) (schema.QuesmaType, bool) {
 	for isArray(s) {
 		s = arrayType(s)
 	}
 	switch {
 	case strings.HasPrefix(s, "Unknown"):
-		return schema.TypeUnknown, true
+		return schema.QuesmaTypeUnknown, true
 	case strings.HasPrefix(s, "Tuple"):
-		return schema.TypeObject, true
+		return schema.QuesmaTypeObject, true
 	}
 
 	switch s {
 	case "String", "LowCardinality(String)":
-		return schema.TypeKeyword, true
+		return schema.QuesmaTypeKeyword, true
 	case "Int", "Int8", "Int16", "Int32", "Int64":
-		return schema.TypeLong, true
+		return schema.QuesmaTypeLong, true
 	case "UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UInt256":
-		return schema.TypeInteger, true
+		return schema.QuesmaTypeInteger, true
 	case "Bool":
-		return schema.TypeBoolean, true
+		return schema.QuesmaTypeBoolean, true
 	case "Float32", "Float64":
-		return schema.TypeFloat, true
+		return schema.QuesmaTypeFloat, true
 	case "DateTime", "DateTime64":
-		return schema.TypeTimestamp, true
+		return schema.QuesmaTypeTimestamp, true
 	case "Date":
-		return schema.TypeDate, true
+		return schema.QuesmaTypeDate, true
 	case "Point":
-		return schema.TypePoint, true
+		return schema.QuesmaTypePoint, true
 	case "Map(String, Nullable(String))", "Map(String, String)":
-		return schema.TypeMap, true
+		return schema.QuesmaTypeMap, true
 	default:
-		return schema.TypeUnknown, false
+		return schema.QuesmaTypeUnknown, false
 	}
 }
 

--- a/quesma/elasticsearch/mappings.go
+++ b/quesma/elasticsearch/mappings.go
@@ -30,7 +30,7 @@ func ParseMappings(namespace string, mappings map[string]interface{}) map[string
 
 		if typeMapping := fieldMappingAsMap["type"]; typeMapping != nil {
 			parsedType, _ := ParseElasticType(typeMapping.(string))
-			if parsedType.Name == schema.TypeUnknown.Name {
+			if parsedType.Name == schema.QuesmaTypeUnknown.Name {
 				logger.Warn().Msgf("unknown type '%v' of field %s", typeMapping, fieldName)
 			}
 			result[fieldName] = schema.Column{Name: fieldName, Type: parsedType.Name}
@@ -47,7 +47,7 @@ func ParseMappings(namespace string, mappings map[string]interface{}) map[string
 func GenerateMappings(schemaNode *schema.SchemaTreeNode) map[string]any {
 	if schemaNode.Field != nil {
 		result := map[string]any{"type": schemaTypeToElasticType(schemaNode.Field.Type)}
-		if schemaNode.Field.Type.Name == schema.TypeText.Name {
+		if schemaNode.Field.Type.Name == schema.QuesmaTypeText.Name {
 			result["fields"] = map[string]any{
 				"keyword": map[string]any{"type": "keyword"},
 			}
@@ -63,57 +63,57 @@ func GenerateMappings(schemaNode *schema.SchemaTreeNode) map[string]any {
 }
 
 // FIXME: should be in elasticsearch_field_types, but this causes import cycle
-func ParseElasticType(t string) (schema.Type, bool) {
+func ParseElasticType(t string) (schema.QuesmaType, bool) {
 	switch t {
 	case elasticsearch_field_types.FieldTypeText:
-		return schema.TypeText, true
+		return schema.QuesmaTypeText, true
 	case elasticsearch_field_types.FieldTypeKeyword:
-		return schema.TypeKeyword, true
+		return schema.QuesmaTypeKeyword, true
 	case elasticsearch_field_types.FieldTypeLong, elasticsearch_field_types.FieldTypeInteger, elasticsearch_field_types.FieldTypeShort, elasticsearch_field_types.FieldTypeByte:
-		return schema.TypeLong, true
+		return schema.QuesmaTypeLong, true
 	case elasticsearch_field_types.FieldTypeDate:
-		return schema.TypeTimestamp, true
+		return schema.QuesmaTypeTimestamp, true
 	case elasticsearch_field_types.FieldTypeFloat, elasticsearch_field_types.FieldTypeHalfFloat, elasticsearch_field_types.FieldTypeDouble:
-		return schema.TypeFloat, true
+		return schema.QuesmaTypeFloat, true
 	case elasticsearch_field_types.FieldTypeBoolean:
-		return schema.TypeBoolean, true
+		return schema.QuesmaTypeBoolean, true
 	case elasticsearch_field_types.FieldTypeIp:
-		return schema.TypeIp, true
+		return schema.QuesmaTypeIp, true
 	case elasticsearch_field_types.FieldTypeGeoPoint:
-		return schema.TypePoint, true
+		return schema.QuesmaTypePoint, true
 	default:
-		return schema.TypeUnknown, false
+		return schema.QuesmaTypeUnknown, false
 	}
 }
 
-func schemaTypeToElasticType(t schema.Type) string {
+func schemaTypeToElasticType(t schema.QuesmaType) string {
 	switch t.Name {
-	case schema.TypeText.Name:
+	case schema.QuesmaTypeText.Name:
 		return elasticsearch_field_types.FieldTypeText
-	case schema.TypeKeyword.Name:
+	case schema.QuesmaTypeKeyword.Name:
 		return elasticsearch_field_types.FieldTypeKeyword
-	case schema.TypeInteger.Name:
+	case schema.QuesmaTypeInteger.Name:
 		return elasticsearch_field_types.FieldTypeInteger
-	case schema.TypeLong.Name:
+	case schema.QuesmaTypeLong.Name:
 		return elasticsearch_field_types.FieldTypeLong
-	case schema.TypeUnsignedLong.Name:
+	case schema.QuesmaTypeUnsignedLong.Name:
 		return elasticsearch_field_types.FieldTypeUnsignedLong
-	case schema.TypeTimestamp.Name:
+	case schema.QuesmaTypeTimestamp.Name:
 		return elasticsearch_field_types.FieldTypeDate
-	case schema.TypeDate.Name:
+	case schema.QuesmaTypeDate.Name:
 		return elasticsearch_field_types.FieldTypeDate
-	case schema.TypeFloat.Name:
+	case schema.QuesmaTypeFloat.Name:
 		return elasticsearch_field_types.FieldTypeDouble
-	case schema.TypeBoolean.Name:
+	case schema.QuesmaTypeBoolean.Name:
 		return elasticsearch_field_types.FieldTypeBoolean
-	case schema.TypeObject.Name:
+	case schema.QuesmaTypeObject.Name:
 		return elasticsearch_field_types.FieldTypeObject
-	case schema.TypeIp.Name:
+	case schema.QuesmaTypeIp.Name:
 		return elasticsearch_field_types.FieldTypeIp
-	case schema.TypePoint.Name:
+	case schema.QuesmaTypePoint.Name:
 		return elasticsearch_field_types.FieldTypeGeoPoint
 	default:
-		logger.Error().Msgf("Unknown type '%s', defaulting to 'text' type", t.Name)
+		logger.Error().Msgf("Unknown Quesma type '%s', defaulting to 'text' type", t.Name)
 		return elasticsearch_field_types.FieldTypeText
 	}
 }

--- a/quesma/elasticsearch/type_adapter.go
+++ b/quesma/elasticsearch/type_adapter.go
@@ -10,27 +10,27 @@ import (
 type SchemaTypeAdapter struct {
 }
 
-func (e SchemaTypeAdapter) Convert(s string) (schema.Type, bool) {
+func (e SchemaTypeAdapter) Convert(s string) (schema.QuesmaType, bool) {
 	switch s {
 	case elasticsearch_field_types.FieldTypeText:
-		return schema.TypeText, true
+		return schema.QuesmaTypeText, true
 	case elasticsearch_field_types.FieldTypeKeyword:
-		return schema.TypeKeyword, true
+		return schema.QuesmaTypeKeyword, true
 	case elasticsearch_field_types.FieldTypeLong:
-		return schema.TypeLong, true
+		return schema.QuesmaTypeLong, true
 	case elasticsearch_field_types.FieldTypeDate:
-		return schema.TypeDate, true
+		return schema.QuesmaTypeDate, true
 	case elasticsearch_field_types.FieldTypeDateNanos:
-		return schema.TypeDate, true
+		return schema.QuesmaTypeDate, true
 	case elasticsearch_field_types.FieldTypeDouble:
-		return schema.TypeFloat, true
+		return schema.QuesmaTypeFloat, true
 	case elasticsearch_field_types.FieldTypeBoolean:
-		return schema.TypeBoolean, true
+		return schema.QuesmaTypeBoolean, true
 	case elasticsearch_field_types.FieldTypeIp:
-		return schema.TypeIp, true
+		return schema.QuesmaTypeIp, true
 	case elasticsearch_field_types.FieldTypeGeoPoint:
-		return schema.TypePoint, true
+		return schema.QuesmaTypePoint, true
 	default:
-		return schema.TypeUnknown, false
+		return schema.QuesmaTypeUnknown, false
 	}
 }

--- a/quesma/model/metrics_aggregations/top_hits.go
+++ b/quesma/model/metrics_aggregations/top_hits.go
@@ -51,7 +51,7 @@ func (query TopHits) TranslateSqlResponseToJson(rows []model.QueryResultRow, lev
 			}
 			colName, _ := strings.CutPrefix(withoutQuotes, `windowed_`)
 
-			if col.ColType.Name == schema.TypePoint.Name {
+			if col.ColType.Name == schema.QuesmaTypePoint.Name {
 				hits := make(model.JsonMap)
 				// TODO suffixes (::lat, ::lon) hardcoded for now
 				// due to insufficient information in the schema

--- a/quesma/model/query_result.go
+++ b/quesma/model/query_result.go
@@ -19,7 +19,7 @@ type FieldAtIndex = int // for facets/histogram what Cols[i] means
 type QueryResultCol struct {
 	ColName string // quoted, e.g. `"message"`
 	Value   interface{}
-	ColType schema.Type
+	ColType schema.QuesmaType
 }
 
 func NewQueryResultCol(colName string, value interface{}) QueryResultCol {

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -991,7 +991,7 @@ func (cw *ClickhouseQueryTranslator) parseExists(queryMap QueryMap) model.Simple
 		case clickhouse.NotExists:
 			// TODO this is a workaround for the case when the field is a point
 			if schemaInstance, exists := cw.SchemaRegistry.FindSchema(schema.TableName(cw.Table.Name)); exists {
-				if value, ok := schemaInstance.ResolveFieldByInternalName(fieldName); ok && value.Type.Equal(schema.TypePoint) {
+				if value, ok := schemaInstance.ResolveFieldByInternalName(fieldName); ok && value.Type.Equal(schema.QuesmaTypePoint) {
 					return model.NewSimpleQuery(sql, true)
 				}
 			}

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -18,7 +18,7 @@ import (
 	"quesma/util"
 )
 
-func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.FieldCapability, colName string, fieldType schema.Type, index string) {
+func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.FieldCapability, colName string, fieldType schema.QuesmaType, index string) {
 	fieldTypeName := asElasticType(fieldType)
 	fieldCapability := model.FieldCapability{
 		Type:          asElasticType(fieldType),
@@ -67,13 +67,13 @@ func handleFieldCapsIndex(cfg *config.QuesmaConfiguration, schemaRegistry schema
 				addFieldCapabilityFromSchemaRegistry(fields, fieldName.AsString(), field.Type, resolvedIndex)
 				switch field.Type.Name {
 				case "text":
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.TypeKeyword, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.QuesmaTypeKeyword, resolvedIndex)
 				case "keyword":
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.TypeText, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
 				case "map":
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.TypeText, resolvedIndex)
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapKeysSuffix), schema.TypeText, resolvedIndex)
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapValuesSuffix), schema.TypeText, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapKeysSuffix), schema.QuesmaTypeText, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapValuesSuffix), schema.QuesmaTypeText, resolvedIndex)
 				}
 			}
 
@@ -118,29 +118,29 @@ func HandleFieldCaps(ctx context.Context, cfg *config.QuesmaConfiguration, schem
 	return handleFieldCapsIndex(cfg, schemaRegistry, indexes)
 }
 
-func asElasticType(t schema.Type) string {
+func asElasticType(t schema.QuesmaType) string {
 	switch t.Name {
-	case schema.TypeText.Name:
+	case schema.QuesmaTypeText.Name:
 		return elasticsearch_field_types.FieldTypeText
-	case schema.TypeTimestamp.Name:
+	case schema.QuesmaTypeTimestamp.Name:
 		return elasticsearch_field_types.FieldTypeDate
-	case schema.TypeKeyword.Name:
+	case schema.QuesmaTypeKeyword.Name:
 		return elasticsearch_field_types.FieldTypeKeyword
-	case schema.TypeLong.Name:
+	case schema.QuesmaTypeLong.Name:
 		return elasticsearch_field_types.FieldTypeLong
-	case schema.TypeDate.Name:
+	case schema.QuesmaTypeDate.Name:
 		return elasticsearch_field_types.FieldTypeDate
-	case schema.TypeFloat.Name:
+	case schema.QuesmaTypeFloat.Name:
 		return elasticsearch_field_types.FieldTypeDouble
-	case schema.TypeBoolean.Name:
+	case schema.QuesmaTypeBoolean.Name:
 		return elasticsearch_field_types.FieldTypeBoolean
-	case schema.TypeIp.Name:
+	case schema.QuesmaTypeIp.Name:
 		return elasticsearch_field_types.FieldTypeIp
-	case schema.TypeObject.Name:
+	case schema.QuesmaTypeObject.Name:
 		return elasticsearch_field_types.FieldTypeObject
-	case schema.TypePoint.Name:
+	case schema.QuesmaTypePoint.Name:
 		return elasticsearch_field_types.FieldTypeGeoPoint
-	case schema.TypeInteger.Name:
+	case schema.QuesmaTypeInteger.Name:
 		return elasticsearch_field_types.FieldTypeInteger
 	default:
 		return elasticsearch_field_types.FieldTypeText

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -118,7 +118,7 @@ func (s *SchemaCheckPass) applyIpTransformations(query *model.Query) (*model.Que
 		if !found {
 			logger.Error().Msgf("Field %s not found in schema for table %s, should never happen here", lhsValue, fromTable)
 		}
-		if !field.Type.Equal(schema.TypeIp) {
+		if !field.Type.Equal(schema.QuesmaTypeIp) {
 			return model.NewInfixExpr(lhs.(model.Expr), e.Op, rhs.(model.Expr))
 		}
 		if len(lhsValue) == 0 || len(rhsValue) == 0 {
@@ -188,7 +188,7 @@ func (s *SchemaCheckPass) applyGeoTransformations(query *model.Query) (*model.Qu
 				// This checks if the column is of type point
 				// and if it is, it appends the lat and lon columns to the group by clause
 				field := schemaInstance.Fields[schema.FieldName(col.ColumnName)]
-				if field.Type.Name == schema.TypePoint.Name {
+				if field.Type.Name == schema.QuesmaTypePoint.Name {
 					// TODO suffixes ::lat, ::lon are hardcoded for now
 					groupBy = append(groupBy, model.NewColumnRef(field.InternalPropertyName.AsString()+"::lat"))
 					groupBy = append(groupBy, model.NewColumnRef(field.InternalPropertyName.AsString()+"::lon"))
@@ -205,7 +205,7 @@ func (s *SchemaCheckPass) applyGeoTransformations(query *model.Query) (*model.Qu
 				// This checks if the column is of type point
 				// and if it is, it appends the lat and lon columns to the select clause
 				field := schemaInstance.Fields[schema.FieldName(col.ColumnName)]
-				if field.Type.Name == schema.TypePoint.Name {
+				if field.Type.Name == schema.QuesmaTypePoint.Name {
 					// TODO suffixes ::lat, ::lon are hardcoded for now
 					columns = append(columns, model.NewColumnRef(field.InternalPropertyName.AsString()+"::lat"))
 					columns = append(columns, model.NewColumnRef(field.InternalPropertyName.AsString()+"::lon"))

--- a/quesma/schema/schema.go
+++ b/quesma/schema/schema.go
@@ -16,7 +16,7 @@ type (
 		PropertyName FieldName
 		// InternalPropertyName is how the field is represented in the data source
 		InternalPropertyName FieldName
-		Type                 Type
+		Type                 QuesmaType
 	}
 	TableName string
 	FieldName string

--- a/quesma/schema/types.go
+++ b/quesma/schema/types.go
@@ -4,86 +4,85 @@ package schema
 
 import "slices"
 
+type (
+	QuesmaType struct {
+		Name       string
+		Properties []QuesmaTypeProperty
+	}
+	QuesmaTypeProperty string
+)
+
 var (
-	// TODO add more and review existing
-	TypeText         = Type{Name: "text", Properties: []TypeProperty{Searchable, FullText}}
-	TypeKeyword      = Type{Name: "keyword", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeInteger      = Type{Name: "integer", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeLong         = Type{Name: "long", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeUnsignedLong = Type{Name: "unsigned_long", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeTimestamp    = Type{Name: "timestamp", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeDate         = Type{Name: "date", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeFloat        = Type{Name: "float", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeBoolean      = Type{Name: "boolean", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeObject       = Type{Name: "object", Properties: []TypeProperty{Searchable}}
-	TypeArray        = Type{Name: "array", Properties: []TypeProperty{Searchable}}
-	TypeMap          = Type{Name: "map", Properties: []TypeProperty{Searchable}}
-	TypeIp           = Type{Name: "ip", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypePoint        = Type{Name: "point", Properties: []TypeProperty{Searchable, Aggregatable}}
-	TypeUnknown      = Type{Name: "unknown", Properties: []TypeProperty{Searchable}}
+	QuesmaTypeText         = QuesmaType{Name: "text", Properties: []QuesmaTypeProperty{Searchable, FullText}}
+	QuesmaTypeKeyword      = QuesmaType{Name: "keyword", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeInteger      = QuesmaType{Name: "integer", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeLong         = QuesmaType{Name: "long", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeUnsignedLong = QuesmaType{Name: "unsigned_long", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeTimestamp    = QuesmaType{Name: "timestamp", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeDate         = QuesmaType{Name: "date", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeFloat        = QuesmaType{Name: "float", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeBoolean      = QuesmaType{Name: "boolean", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeObject       = QuesmaType{Name: "object", Properties: []QuesmaTypeProperty{Searchable}}
+	QuesmaTypeArray        = QuesmaType{Name: "array", Properties: []QuesmaTypeProperty{Searchable}}
+	QuesmaTypeMap          = QuesmaType{Name: "map", Properties: []QuesmaTypeProperty{Searchable}}
+	QuesmaTypeIp           = QuesmaType{Name: "ip", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypePoint        = QuesmaType{Name: "point", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
+	QuesmaTypeUnknown      = QuesmaType{Name: "unknown", Properties: []QuesmaTypeProperty{Searchable}}
 )
 
 const (
-	Aggregatable TypeProperty = "aggregatable"
-	Searchable   TypeProperty = "searchable"
-	FullText     TypeProperty = "full_text"
+	Aggregatable QuesmaTypeProperty = "aggregatable"
+	Searchable   QuesmaTypeProperty = "searchable"
+	FullText     QuesmaTypeProperty = "full_text"
 )
 
-func (t Type) Equal(t2 Type) bool {
+func (t QuesmaType) Equal(t2 QuesmaType) bool {
 	return t.Name == t2.Name
 }
 
-func (t Type) IsAggregatable() bool {
+func (t QuesmaType) IsAggregatable() bool {
 	return slices.Contains(t.Properties, Aggregatable)
 }
 
-func (t Type) IsSearchable() bool {
+func (t QuesmaType) IsSearchable() bool {
 	return slices.Contains(t.Properties, Searchable)
 }
 
-func (t Type) IsFullText() bool {
+func (t QuesmaType) IsFullText() bool {
 	return slices.Contains(t.Properties, FullText)
 }
 
-type (
-	Type struct {
-		Name       string
-		Properties []TypeProperty
-	}
-	TypeProperty string
-)
-
-func (t Type) String() string {
+func (t QuesmaType) String() string {
 	return t.Name
 }
 
-func ParseQuesmaType(t string) (Type, bool) {
+func ParseQuesmaType(t string) (QuesmaType, bool) {
 	switch t {
-	case TypeText.Name:
-		return TypeText, true
-	case TypeKeyword.Name:
-		return TypeKeyword, true
-	case TypeLong.Name:
-		return TypeLong, true
-	case TypeTimestamp.Name:
-		return TypeTimestamp, true
-	case TypeDate.Name:
-		return TypeDate, true
-	case TypeFloat.Name:
-		return TypeFloat, true
-	case TypeBoolean.Name, "bool":
-		return TypeBoolean, true
-	case TypeObject.Name, "json":
-		return TypeObject, true
-	case TypeArray.Name:
-		return TypeArray, true
-	case TypeMap.Name:
-		return TypeMap, true
-	case TypeIp.Name:
-		return TypeIp, true
-	case TypePoint.Name, "geo_point":
-		return TypePoint, true
+	case QuesmaTypeText.Name:
+		return QuesmaTypeText, true
+	case QuesmaTypeKeyword.Name:
+		return QuesmaTypeKeyword, true
+	case QuesmaTypeLong.Name:
+		return QuesmaTypeLong, true
+	case QuesmaTypeTimestamp.Name:
+		return QuesmaTypeTimestamp, true
+	case QuesmaTypeDate.Name:
+		return QuesmaTypeDate, true
+	case QuesmaTypeFloat.Name:
+		return QuesmaTypeFloat, true
+	case QuesmaTypeBoolean.Name, "bool":
+		return QuesmaTypeBoolean, true
+	case QuesmaTypeObject.Name, "json":
+		return QuesmaTypeObject, true
+	case QuesmaTypeArray.Name:
+		return QuesmaTypeArray, true
+	case QuesmaTypeMap.Name:
+		return QuesmaTypeMap, true
+	case QuesmaTypeIp.Name:
+		return QuesmaTypeIp, true
+	case QuesmaTypePoint.Name, "geo_point":
+		return QuesmaTypePoint, true
 	default:
-		return TypeUnknown, false
+		return QuesmaTypeUnknown, false
 	}
 }


### PR DESCRIPTION
We've found the `Type` name being very elusive in our codebase when working on schema persistence with @nablaone. 

This PR introduces `QuesmaType*` so that it becomes very clear in our codebase when we're referring to ClickHouse/Elastic types.

Additionally, `config.QuesmaConfiguration` is no longer used in SchemaRegistry  in favor of just index configuration. 