### PR TITLE
Top metrics

### DIFF
--- a/quesma/model/bucket_aggregations/combinator_aggregation_interface.go
+++ b/quesma/model/bucket_aggregations/combinator_aggregation_interface.go
@@ -17,7 +17,8 @@ import "quesma/model"
 type CombinatorAggregationInterface interface {
 	CombinatorGroups() []CombinatorGroup
 	CombinatorTranslateSqlResponseToJson(subGroup CombinatorGroup, rows []model.QueryResultRow) model.JsonMap
-	DoesNotHaveGroupBy() bool // defined is NoGroupByInterface which is broader group
+	DoesNotHaveGroupBy() bool           // defined is NoGroupByInterface which is broader group
+	CombinatorSplit() []model.QueryType // split into new aggregations, each for one group
 }
 
 type CombinatorGroup struct {

--- a/quesma/model/bucket_aggregations/dateRange.go
+++ b/quesma/model/bucket_aggregations/dateRange.go
@@ -196,6 +196,9 @@ func (query DateRange) DoesNotHaveGroupBy() bool {
 func (query DateRange) CombinatorGroups() (result []CombinatorGroup) {
 	for intervalIdx, interval := range query.Intervals {
 		prefix := fmt.Sprintf("range_%d__", intervalIdx)
+		if len(query.Intervals) == 1 {
+			prefix = ""
+		}
 		result = append(result, CombinatorGroup{
 			idx:         intervalIdx,
 			Prefix:      prefix,
@@ -228,4 +231,12 @@ func (query DateRange) CombinatorTranslateSqlResponseToJson(subGroup CombinatorG
 	}
 
 	return response
+}
+
+func (query DateRange) CombinatorSplit() []model.QueryType {
+	result := make([]model.QueryType, 0, len(query.Intervals))
+	for _, interval := range query.Intervals {
+		result = append(result, NewDateRange(query.ctx, query.FieldName, query.Format, []DateTimeInterval{interval}, query.SelectColumnsNr))
+	}
+	return result
 }

--- a/quesma/model/bucket_aggregations/filter.go
+++ b/quesma/model/bucket_aggregations/filter.go
@@ -49,3 +49,7 @@ func (query FilterAgg) CombinatorGroups() (result []CombinatorGroup) {
 func (query FilterAgg) CombinatorTranslateSqlResponseToJson(subGroup CombinatorGroup, rows []model.QueryResultRow) model.JsonMap {
 	return query.TranslateSqlResponseToJson(rows, 0)
 }
+
+func (query FilterAgg) CombinatorSplit() []model.QueryType {
+	return []model.QueryType{query}
+}

--- a/quesma/model/bucket_aggregations/filters.go
+++ b/quesma/model/bucket_aggregations/filters.go
@@ -59,9 +59,13 @@ func (query Filters) DoesNotHaveGroupBy() bool {
 
 func (query Filters) CombinatorGroups() (result []CombinatorGroup) {
 	for filterIdx, filter := range query.Filters {
+		prefix := fmt.Sprintf("filter_%d__", filterIdx)
+		if len(query.Filters) == 1 {
+			prefix = ""
+		}
 		result = append(result, CombinatorGroup{
 			idx:         filterIdx,
-			Prefix:      fmt.Sprintf("filter_%d__", filterIdx),
+			Prefix:      prefix,
 			Key:         filter.Name,
 			WhereClause: filter.Sql.WhereClause,
 		})
@@ -71,4 +75,12 @@ func (query Filters) CombinatorGroups() (result []CombinatorGroup) {
 
 func (query Filters) CombinatorTranslateSqlResponseToJson(subGroup CombinatorGroup, rows []model.QueryResultRow) model.JsonMap {
 	return query.TranslateSqlResponseToJson(rows, 0)
+}
+
+func (query Filters) CombinatorSplit() []model.QueryType {
+	result := make([]model.QueryType, 0, len(query.Filters))
+	for _, filter := range query.Filters {
+		result = append(result, NewFilters(query.ctx, []Filter{filter}))
+	}
+	return result
 }

--- a/quesma/model/metrics_aggregations/top_metrics.go
+++ b/quesma/model/metrics_aggregations/top_metrics.go
@@ -11,12 +11,24 @@ import (
 )
 
 type TopMetrics struct {
-	ctx                context.Context
-	isSortFieldPresent bool
+	ctx       context.Context
+	Size      int
+	SortBy    string
+	SortOrder model.OrderByDirection
 }
 
-func NewTopMetrics(ctx context.Context, isSortFieldPresent bool) TopMetrics {
-	return TopMetrics{ctx: ctx, isSortFieldPresent: isSortFieldPresent}
+func NewTopMetrics(ctx context.Context, size int, sortBy string, sortOrder string) TopMetrics {
+	var order model.OrderByDirection
+	switch sortOrder {
+	case "asc":
+		order = model.AscOrder
+	case "desc":
+		order = model.DescOrder
+	default:
+		logger.WarnWithCtx(ctx).Msgf("invalid sort order: %s, defaulting to desc", sortOrder)
+		order = model.DescOrder
+	}
+	return TopMetrics{ctx: ctx, Size: size, SortBy: sortBy, SortOrder: order}
 }
 
 func (query TopMetrics) AggregationType() model.AggregationType {
@@ -40,7 +52,7 @@ func (query TopMetrics) TranslateSqlResponseToJson(rows []model.QueryResultRow, 
 
 		var sortVal []any
 		var valuesForMetrics []model.QueryResultCol
-		if query.isSortFieldPresent {
+		if len(query.SortBy) > 0 {
 			// per convention, we know that value we sorted by is in the last column (if it exists)
 			lastIndex := len(row.Cols) - 1 // last column is the sort column, we don't return it
 			sortVal = append(sortVal, row.Cols[lastIndex].Value)

--- a/quesma/queryparser/aggregation_parser.go
+++ b/quesma/queryparser/aggregation_parser.go
@@ -287,7 +287,7 @@ func (b *aggrQueryBuilder) buildMetricsAggregation(metricsAggr metricsAggregatio
 	case "top_hits":
 		query.Type = metrics_aggregations.NewTopHits(b.ctx, metricsAggr.Size)
 	case "top_metrics":
-		query.Type = metrics_aggregations.NewTopMetrics(b.ctx, metricsAggr.sortByExists())
+		query.Type = metrics_aggregations.NewTopMetrics(b.ctx, metricsAggr.Size, metricsAggr.SortBy, metricsAggr.Order)
 	case "value_count":
 		query.Type = metrics_aggregations.NewValueCount(b.ctx)
 	case "percentile_ranks":

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -40,7 +40,9 @@ func (p *pancakeJSONRenderer) selectMetricRows(metricName string, rows []model.Q
 	return
 }
 
-func (p *pancakeJSONRenderer) selectTopRows(topAggr *pancakeModelMetricAggregation, rows []model.QueryResultRow) (result []model.QueryResultRow) {
+// selectTopHitsRows: select columns for top_hits/top_metrics and rename them to original column names.
+// There is refactoring opportunity once we move completely to pancakes and remove re-name logic from this method.
+func (p *pancakeJSONRenderer) selectTopHitsRows(topAggr *pancakeModelMetricAggregation, rows []model.QueryResultRow) (result []model.QueryResultRow) {
 	for _, row := range rows {
 		var newCols []model.QueryResultCol
 		for _, col := range row.Cols {
@@ -231,7 +233,7 @@ func (p *pancakeJSONRenderer) layerToJSON(remainingLayers []*pancakeModelLayer, 
 		var metricRows []model.QueryResultRow
 		switch metric.queryType.(type) {
 		case metrics_aggregations.TopMetrics, metrics_aggregations.TopHits:
-			metricRows = p.selectTopRows(metric, rows)
+			metricRows = p.selectTopHitsRows(metric, rows)
 		default:
 			metricRows = p.selectMetricRows(metric.InternalNamePrefix(), rows)
 		}

--- a/quesma/queryparser/pancake_json_rendering.go
+++ b/quesma/queryparser/pancake_json_rendering.go
@@ -40,18 +40,18 @@ func (p *pancakeJSONRenderer) selectMetricRows(metricName string, rows []model.Q
 	return
 }
 
-func (p *pancakeJSONRenderer) selectTopHitsRows(topHits *pancakeModelMetricAggregation, rows []model.QueryResultRow) (result []model.QueryResultRow) {
+func (p *pancakeJSONRenderer) selectTopRows(topAggr *pancakeModelMetricAggregation, rows []model.QueryResultRow) (result []model.QueryResultRow) {
 	for _, row := range rows {
 		var newCols []model.QueryResultCol
 		for _, col := range row.Cols {
-			if strings.HasPrefix(col.ColName, topHits.InternalNamePrefix()) {
-				numStr := strings.TrimPrefix(col.ColName, topHits.InternalNamePrefix())
+			if strings.HasPrefix(col.ColName, topAggr.InternalNamePrefix()) {
+				numStr := strings.TrimPrefix(col.ColName, topAggr.InternalNamePrefix())
 				if num, err := strconv.Atoi(numStr); err == nil {
 					var overrideName string
-					if num < 0 || num >= len(topHits.selectedColumns) {
+					if num < 0 || num >= len(topAggr.selectedColumns) {
 						logger.WarnWithCtx(p.ctx).Msgf("invalid top_hits column index %d", num)
 					} else {
-						selectedColumn := topHits.selectedColumns[num]
+						selectedColumn := topAggr.selectedColumns[num]
 						if colRef, ok := selectedColumn.(model.ColumnRef); ok {
 							overrideName = colRef.ColumnName
 						}
@@ -69,6 +69,9 @@ func (p *pancakeJSONRenderer) selectTopHitsRows(topHits *pancakeModelMetricAggre
 }
 
 func (p *pancakeJSONRenderer) selectPrefixRows(prefix string, rows []model.QueryResultRow) (result []model.QueryResultRow) {
+	if prefix == "" {
+		return rows
+	}
 	for _, row := range rows {
 		var newCols []model.QueryResultCol
 		for _, col := range row.Cols {
@@ -226,9 +229,10 @@ func (p *pancakeJSONRenderer) layerToJSON(remainingLayers []*pancakeModelLayer, 
 
 	for _, metric := range layer.currentMetricAggregations {
 		var metricRows []model.QueryResultRow
-		if _, ok := metric.queryType.(metrics_aggregations.TopHits); ok {
-			metricRows = p.selectTopHitsRows(metric, rows)
-		} else {
+		switch metric.queryType.(type) {
+		case metrics_aggregations.TopMetrics, metrics_aggregations.TopHits:
+			metricRows = p.selectTopRows(metric, rows)
+		default:
 			metricRows = p.selectMetricRows(metric.InternalNamePrefix(), rows)
 		}
 		result[metric.name] = metric.queryType.TranslateSqlResponseToJson(metricRows, 0) // TODO: fill level?

--- a/quesma/queryparser/pancake_model.go
+++ b/quesma/queryparser/pancake_model.go
@@ -101,6 +101,20 @@ func (p pancakeModelMetricAggregation) InternalNameForCol(id int) string {
 	return fmt.Sprintf("%s%d", p.InternalNamePrefix(), id)
 }
 
+func (p pancakeModelBucketAggregation) ShallowClone() pancakeModelBucketAggregation {
+	return pancakeModelBucketAggregation{
+		name:                    p.name,
+		internalName:            p.internalName,
+		queryType:               p.queryType,
+		selectedColumns:         p.selectedColumns,
+		orderBy:                 p.orderBy,
+		limit:                   p.limit,
+		isKeyed:                 p.isKeyed,
+		metadata:                p.metadata,
+		filterOurEmptyKeyBucket: p.filterOurEmptyKeyBucket,
+	}
+}
+
 func (p pancakeModelBucketAggregation) InternalNameForKeyPrefix() string {
 	return fmt.Sprintf("%skey", p.internalName)
 }

--- a/quesma/queryparser/pancake_sql_query_generation.go
+++ b/quesma/queryparser/pancake_sql_query_generation.go
@@ -396,7 +396,7 @@ func (p *pancakeSqlQueryGenerator) generateSelectCommand(aggregation *pancakeMod
 
 	if optTopHitsOrMetrics != nil {
 		resultQuery.Columns = append(resultQuery.Columns, p.aliasedExprArrayToLiteralExpr(rankColumns)...)
-		resultQuery, err = p.generateTopQuery(aggregation, combinatorWhere, optTopHitsOrMetrics, groupBys, selectColumns, resultQuery)
+		resultQuery, err = p.generateTopHitsQuery(aggregation, combinatorWhere, optTopHitsOrMetrics, groupBys, selectColumns, resultQuery)
 		optimizerName = PancakeOptimizerName + "(with top_hits)"
 	}
 

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -49,11 +49,8 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if i == 29 || i == 30 {
 				t.Skip("Skipped also for previous implementation. New tests, harder, failing for now.")
 			}
-			if topHits(test.TestName) {
-				t.Skip("Fix top_hits")
-			}
-			if topMetrics(test.TestName) {
-				t.Skip("Fix top metrics")
+			if test.TestName == "Range with subaggregations. Reproduce: Visualize -> Pie chart -> Aggregation: Top Hit, Buckets: Aggregation: Range" {
+				t.Skip("Skipped also for previous implementation. Top_hits needs to be better.")
 			}
 			if filters(test.TestName) {
 				t.Skip("Fix filters")
@@ -183,21 +180,6 @@ func incorrectResult(testName string) bool {
 	//	"Skipped for now, as our response is different in 2 things: key_as_string date (probably not important) + we don't return 0's (e.g. doc_count: 0)."+
 	//	"If we need clients/kunkka/test_0, used to be broken before aggregations merge fix"
 	return t1 || t2 || t3
-}
-
-// TODO remove after fix
-func topHits(testName string) bool {
-	t1 := testName == "Range with subaggregations. Reproduce: Visualize -> Pie chart -> Aggregation: Top Hit, Buckets: Aggregation: Range" // also range
-	return t1
-}
-
-// TODO remove after fix
-func topMetrics(testName string) bool {
-	t1 := testName == "Kibana Visualize -> Last Value. Used to panic" // also filter
-	t2 := testName == "simplest top_metrics, no sort"
-	t3 := testName == "simplest top_metrics, with sort"
-	t4 := testName == "very long: multiple top_metrics + histogram" // also top_metrics
-	return t1 || t2 || t3 || t4
 }
 
 // TODO remove after fix

--- a/quesma/queryparser/pancake_top_hits.go
+++ b/quesma/queryparser/pancake_top_hits.go
@@ -14,7 +14,9 @@ func (p *pancakeSqlQueryGenerator) quotedLiteral(name string) model.LiteralExpr 
 	return model.NewLiteral(strconv.Quote(name))
 }
 
-func (p *pancakeSqlQueryGenerator) generateSimpleTopQuery(topHits *pancakeModelMetricAggregation,
+// generateSimpleTopHitsQuery generates an SQL for top_hits/top_metrics
+// original query does not any group aggregations and we don't need to do JOIN.
+func (p *pancakeSqlQueryGenerator) generateSimpleTopHitsQuery(topHits *pancakeModelMetricAggregation,
 	whereClause model.Expr,
 	orderBy []model.OrderByExpr,
 	size int) (*model.SelectCommand, error) {
@@ -36,7 +38,9 @@ func (p *pancakeSqlQueryGenerator) generateSimpleTopQuery(topHits *pancakeModelM
 	return resultQuery, nil
 }
 
-func (p *pancakeSqlQueryGenerator) generateTopQuery(aggregation *pancakeModel,
+// generateTopHitsQuery generates an SQL for top_hits/top_metrics.
+// It takes original group by query and JOIN it with select to actual fields.
+func (p *pancakeSqlQueryGenerator) generateTopHitsQuery(aggregation *pancakeModel,
 	combinatorWhere []model.Expr,
 	topHits *pancakeModelMetricAggregation,
 	groupBys []model.AliasedExpr,
@@ -73,7 +77,7 @@ func (p *pancakeSqlQueryGenerator) generateTopQuery(aggregation *pancakeModel,
 	}
 
 	if len(groupBys) == 0 {
-		return p.generateSimpleTopQuery(topHits, whereClause, topOrderBy, sizeLimit)
+		return p.generateSimpleTopHitsQuery(topHits, whereClause, topOrderBy, sizeLimit)
 	}
 
 	groupTableName := "group_table"

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -45,7 +45,10 @@ func (a *pancakeTransformer) generateUniqueInternalName(origName string, aggrNam
 
 func (a *pancakeTransformer) generateMetricInternalName(aggrNames []string, queryType model.QueryType) string {
 	prefix := "metric"
-	if _, isTopHits := queryType.(metrics_aggregations.TopHits); isTopHits {
+	switch queryType.(type) {
+	case metrics_aggregations.TopMetrics:
+		prefix = "top_metrics"
+	case metrics_aggregations.TopHits:
 		prefix = "top_hits"
 	}
 	origName := fmt.Sprintf("%s__%s", prefix, strings.Join(aggrNames, "__"))
@@ -297,12 +300,15 @@ func (a *pancakeTransformer) findParentBucketLayer(layers []*pancakeModelLayer, 
 	return layer, nil
 }
 
-func (a *pancakeTransformer) createTopHitPancakes(pancake *pancakeModel) (result []*pancakeModel, err error) {
+func (a *pancakeTransformer) createTopHitAndTopMetricsPancakes(pancake *pancakeModel) (result []*pancakeModel, err error) {
 	for layerIdx, layer := range pancake.layers {
 		metricsWithoutTopHits := make([]*pancakeModelMetricAggregation, 0, len(layer.currentMetricAggregations))
-		for _, metric := range layer.currentMetricAggregations {
-			if _, isTopHits := metric.queryType.(metrics_aggregations.TopHits); isTopHits {
-				canOptimize := layerIdx == len(pancake.layers)-1 && len(layer.currentMetricAggregations) == 1
+		for metricIDx, metric := range layer.currentMetricAggregations {
+			switch metric.queryType.(type) {
+			case metrics_aggregations.TopMetrics, metrics_aggregations.TopHits:
+				canOptimize := layerIdx == len(pancake.layers)-1 && (len(layer.currentMetricAggregations) == 1 ||
+					// if we have several top_metrics at bottom layer we can still optimize last one
+					(len(layer.currentMetricAggregations)-1 == metricIDx && len(metricsWithoutTopHits) == 0))
 				for _, layer2 := range pancake.layers[:layerIdx] {
 					if len(layer2.currentMetricAggregations) > 0 {
 						canOptimize = false
@@ -310,8 +316,7 @@ func (a *pancakeTransformer) createTopHitPancakes(pancake *pancakeModel) (result
 					if layer2.nextBucketAggregation != nil {
 						switch layer2.nextBucketAggregation.queryType.(type) {
 						case bucket_aggregations.CombinatorAggregationInterface:
-							// TODO: possible to implement, by generating more queries, skipped as it is rare
-							return nil, fmt.Errorf("top_hits can't be in filter(s)/range/dataRange aggregation")
+							canOptimize = false // might be changed, but not worth effort for now
 						}
 					}
 				}
@@ -320,26 +325,48 @@ func (a *pancakeTransformer) createTopHitPancakes(pancake *pancakeModel) (result
 					// and don't need to create new pancake
 					metricsWithoutTopHits = append(metricsWithoutTopHits, metric)
 				} else {
-					newLayers := make([]*pancakeModelLayer, layerIdx)
-					for i := range newLayers {
-						newLayers[i] = &pancakeModelLayer{
-							currentMetricAggregations: make([]*pancakeModelMetricAggregation, 0),
-							nextBucketAggregation:     pancake.layers[i].nextBucketAggregation,
+					arrayOfNewLayers := [][]*pancakeModelLayer{[]*pancakeModelLayer{}}
+					//newLayers := make([]*pancakeModelLayer, layerIdx)
+					for idx := range layerIdx {
+						switch queryType := pancake.layers[idx].nextBucketAggregation.queryType.(type) {
+						case bucket_aggregations.CombinatorAggregationInterface:
+							newArrayOfNewLayers := make([][]*pancakeModelLayer, 0)
+							for _, nextBucketAggregationQueryType := range queryType.CombinatorSplit() {
+								for _, newLayers := range arrayOfNewLayers {
+									nextBucketAggregation := pancake.layers[idx].nextBucketAggregation.ShallowClone()
+									nextBucketAggregation.queryType = nextBucketAggregationQueryType
+									newArrayOfNewLayers = append(newArrayOfNewLayers,
+										append(newLayers, &pancakeModelLayer{
+											currentMetricAggregations: make([]*pancakeModelMetricAggregation, 0),
+											nextBucketAggregation:     &nextBucketAggregation,
+										}))
+								}
+							}
+							arrayOfNewLayers = newArrayOfNewLayers
+						default:
+							for i := range arrayOfNewLayers {
+								arrayOfNewLayers[i] = append(arrayOfNewLayers[i], &pancakeModelLayer{
+									currentMetricAggregations: make([]*pancakeModelMetricAggregation, 0),
+									nextBucketAggregation:     pancake.layers[idx].nextBucketAggregation,
+								})
+							}
 						}
 					}
-					newLayers = append(newLayers, &pancakeModelLayer{
-						currentMetricAggregations: []*pancakeModelMetricAggregation{metric},
-						nextBucketAggregation:     nil,
-					})
+					for _, newLayers := range arrayOfNewLayers {
+						newLayers = append(newLayers, &pancakeModelLayer{
+							currentMetricAggregations: []*pancakeModelMetricAggregation{metric},
+							nextBucketAggregation:     nil,
+						})
 
-					newPancake := pancakeModel{
-						layers:      newLayers,
-						whereClause: pancake.whereClause,
-						sampleLimit: pancake.sampleLimit,
+						newPancake := pancakeModel{
+							layers:      newLayers,
+							whereClause: pancake.whereClause,
+							sampleLimit: pancake.sampleLimit,
+						}
+						result = append(result, &newPancake)
 					}
-					result = append(result, &newPancake)
 				}
-			} else {
+			default:
 				metricsWithoutTopHits = append(metricsWithoutTopHits, metric)
 			}
 		}
@@ -381,7 +408,7 @@ func (a *pancakeTransformer) aggregationTreeToPancakes(topLevel pancakeAggregati
 
 		pancakeResults = append(pancakeResults, &newPancake)
 
-		additionalTopHitPancakes, err := a.createTopHitPancakes(&newPancake)
+		additionalTopHitPancakes, err := a.createTopHitAndTopMetricsPancakes(&newPancake)
 		if err != nil {
 			return nil, err
 		}

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -303,12 +303,14 @@ func (a *pancakeTransformer) findParentBucketLayer(layers []*pancakeModelLayer, 
 func (a *pancakeTransformer) createTopHitAndTopMetricsPancakes(pancake *pancakeModel) (result []*pancakeModel, err error) {
 	for layerIdx, layer := range pancake.layers {
 		metricsWithoutTopHits := make([]*pancakeModelMetricAggregation, 0, len(layer.currentMetricAggregations))
-		for metricIDx, metric := range layer.currentMetricAggregations {
+		for metricIdx, metric := range layer.currentMetricAggregations {
 			switch metric.queryType.(type) {
 			case metrics_aggregations.TopMetrics, metrics_aggregations.TopHits:
-				canOptimize := layerIdx == len(pancake.layers)-1 && (len(layer.currentMetricAggregations) == 1 ||
+				isLastLayer := layerIdx == len(pancake.layers)-1
+				isOnlyAggregationOnLayer := len(layer.currentMetricAggregations) == 1 ||
 					// if we have several top_metrics at bottom layer we can still optimize last one
-					(len(layer.currentMetricAggregations)-1 == metricIDx && len(metricsWithoutTopHits) == 0))
+					(len(layer.currentMetricAggregations)-1 == metricIdx && len(metricsWithoutTopHits) == 0)
+				canOptimize := isLastLayer && isOnlyAggregationOnLayer
 				for _, layer2 := range pancake.layers[:layerIdx] {
 					if len(layer2.currentMetricAggregations) > 0 {
 						canOptimize = false

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -2569,7 +2569,93 @@ var AggregationTests = []AggregationTestCase{
 			},
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("hits", uint64(4))}}},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__1__count", uint64(4)),
+				model.NewQueryResultCol("aggr__1__2__key_0", int64(1707480000000/1000/60/60/12)),
+				model.NewQueryResultCol("aggr__1__2__count", 2),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__1__count", uint64(4)),
+				model.NewQueryResultCol("aggr__1__2__key_0", int64(1707739200000/1000/60/60/12)),
+				model.NewQueryResultCol("aggr__1__2__count", 1),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__1__count", uint64(4)),
+				model.NewQueryResultCol("aggr__1__2__key_0", int64(1707782400000/1000/60/60/12)),
+				model.NewQueryResultCol("aggr__1__2__count", 1),
+			}},
+		},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707480000000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 2),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_0", "2024-02-09T17:16:48.000Z"),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_1", "2024-02-09T17:16:48.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707480000000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 2),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_0", "2024-02-09T21:34:34.000Z"),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_1", "2024-02-09T21:34:34.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 2),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707739200000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 1),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_0", "2024-02-12T11:38:24.000Z"),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_1", "2024-02-12T11:38:24.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707782400000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 1),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_0", "2024-02-13T03:50:24.000Z"),
+					model.NewQueryResultCol("top_metrics__1__2__4_col_1", "2024-02-13T03:50:24.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+			},
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707480000000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 2),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_0", 310),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_1", "2024-02-09T17:16:48.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707480000000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 2),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_0", 393),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_1", "2024-02-09T21:34:34.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 2),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707739200000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 1),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_0", 283),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_1", "2024-02-12T11:38:24.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__1__count", uint64(4)),
+					model.NewQueryResultCol("aggr__1__2__key_0", int64(1707782400000/1000/60/60/12)),
+					model.NewQueryResultCol("aggr__1__2__count", 1),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_0", 301),
+					model.NewQueryResultCol("top_metrics__1__2__5_col_1", "2024-02-13T03:50:24.000Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+			},
+		},
 		ExpectedSQLs: []string{
 			`SELECT toInt64(toUnixTimestamp64Milli("order_date") / 43200000), maxOrNull("order_date") AS "windowed_order_date", ` +
 				`maxOrNull("order_date") AS "windowed_order_date" FROM ` +
@@ -2601,7 +2687,79 @@ var AggregationTests = []AggregationTestCase{
 			`SELECT count() FROM ` + TableName + ` WHERE (("order_date">=parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') ` +
 				`AND "order_date"<=parseDateTime64BestEffort('2024-02-13T09:59:57.034Z')) AND "taxful_total_price" > '250')`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT sum(countIf("taxful_total_price" > '250')) OVER () AS "aggr__1__count",
+			  toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+			  "aggr__1__2__key_0",
+			  countIf("taxful_total_price" > '250') AS "aggr__1__2__count"
+			FROM __quesma_table_name
+			WHERE ("order_date">=parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') AND
+			  "order_date"<=parseDateTime64BestEffort('2024-02-13T09:59:57.034Z'))
+			GROUP BY toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+			  "aggr__1__2__key_0"
+			ORDER BY "aggr__1__2__key_0" ASC`,
+		ExpectedAdditionalPancakeSQLs: []string{`
+			WITH quesma_top_hits_group_table AS (
+			  SELECT sum(countIf("taxful_total_price" > '250')) OVER () AS "aggr__1__count",
+				toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				"aggr__1__2__key_0",
+				countIf("taxful_total_price" > '250') AS "aggr__1__2__count"
+			  FROM __quesma_table_name
+			  WHERE ("order_date">=parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') AND
+				"order_date"<=parseDateTime64BestEffort('2024-02-13T09:59:57.034Z'))
+			  GROUP BY toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				"aggr__1__2__key_0"
+			  ORDER BY "aggr__1__2__key_0" ASC) ,
+			quesma_top_hits_join AS (
+			  SELECT "group_table"."aggr__1__count" AS "aggr__1__count",
+				"group_table"."aggr__1__2__key_0" AS "aggr__1__2__key_0",
+				"group_table"."aggr__1__2__count" AS "aggr__1__2__count",
+				"hit_table"."order_date" AS "top_metrics__1__2__4_col_0",
+				"hit_table"."order_date" AS "top_metrics__1__2__4_col_1",
+				ROW_NUMBER() OVER (PARTITION BY "group_table"."aggr__1__2__key_0" ORDER BY
+				"order_date" ASC) AS "top_hits_rank"
+			  FROM quesma_top_hits_group_table AS "group_table" LEFT OUTER JOIN
+				__quesma_table_name AS "hit_table" ON ("group_table"."aggr__1__2__key_0"=
+				toInt64(toUnixTimestamp64Milli("order_date") / 43200000))
+			  WHERE ("taxful_total_price" > '250' AND ("order_date">=
+				parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') AND "order_date"<=
+				parseDateTime64BestEffort('2024-02-13T09:59:57.034Z'))))
+			SELECT "aggr__1__count", "aggr__1__2__key_0", "aggr__1__2__count",
+			  "top_metrics__1__2__4_col_0", "top_metrics__1__2__4_col_1", "top_hits_rank"
+			FROM "quesma_top_hits_join"
+			WHERE "top_hits_rank"<=10
+			ORDER BY "aggr__1__2__key_0" ASC, "top_hits_rank" ASC
+			`, `
+			WITH quesma_top_hits_group_table AS (
+			  SELECT sum(countIf("taxful_total_price" > '250')) OVER () AS "aggr__1__count",
+				toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				"aggr__1__2__key_0",
+				countIf("taxful_total_price" > '250') AS "aggr__1__2__count"
+			  FROM __quesma_table_name
+			  WHERE ("order_date">=parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') AND
+				"order_date"<=parseDateTime64BestEffort('2024-02-13T09:59:57.034Z'))
+			  GROUP BY toInt64(toUnixTimestamp64Milli("order_date") / 43200000) AS
+				"aggr__1__2__key_0"
+			  ORDER BY "aggr__1__2__key_0" ASC) ,
+			quesma_top_hits_join AS (
+			  SELECT "group_table"."aggr__1__count" AS "aggr__1__count",
+				"group_table"."aggr__1__2__key_0" AS "aggr__1__2__key_0",
+				"group_table"."aggr__1__2__count" AS "aggr__1__2__count",
+				"hit_table"."taxful_total_price" AS "top_metrics__1__2__5_col_0",
+				"hit_table"."order_date" AS "top_metrics__1__2__5_col_1",
+				ROW_NUMBER() OVER (PARTITION BY "group_table"."aggr__1__2__key_0" ORDER BY
+				"order_date" ASC) AS "top_hits_rank"
+			  FROM quesma_top_hits_group_table AS "group_table" LEFT OUTER JOIN
+				__quesma_table_name AS "hit_table" ON ("group_table"."aggr__1__2__key_0"=
+				toInt64(toUnixTimestamp64Milli("order_date") / 43200000))
+			  WHERE ("taxful_total_price" > '250' AND ("order_date">=
+				parseDateTime64BestEffort('2024-02-06T09:59:57.034Z') AND "order_date"<=
+				parseDateTime64BestEffort('2024-02-13T09:59:57.034Z'))))
+			SELECT "aggr__1__count", "aggr__1__2__key_0", "aggr__1__2__count",
+			  "top_metrics__1__2__5_col_0", "top_metrics__1__2__5_col_1", "top_hits_rank"
+			FROM "quesma_top_hits_join"
+			WHERE "top_hits_rank"<=10
+			ORDER BY "aggr__1__2__key_0" ASC, "top_hits_rank" ASC`},
 	},
 	{ // [11], "old" test, also can be found in testdata/requests.go TestAsyncSearch[0]
 		// Copied it also here to be more sure we do not create some regression
@@ -6991,7 +7149,38 @@ var AggregationTests = []AggregationTestCase{
 				}},
 			},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1715212800000/86400000)),
+				model.NewQueryResultCol("aggr__0__count", 146),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", 146),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__0__key_0", int64(1716336000000/86400000)),
+				model.NewQueryResultCol("aggr__0__count", 58),
+				model.NewQueryResultCol("aggr__0__1-bucket__count", 58),
+			}},
+		},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__0__key_0", int64(1715212800000/86400000)),
+					model.NewQueryResultCol("aggr__0__count", 146),
+					model.NewQueryResultCol("aggr__0__1-bucket__count", 146),
+					model.NewQueryResultCol("top_metrics__0__1-bucket__1-metric_col_0", 5),
+					model.NewQueryResultCol("top_metrics__0__1-bucket__1-metric_col_1", "2024-05-09T23:52:48Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__0__key_0", int64(1716336000000/86400000)),
+					model.NewQueryResultCol("aggr__0__count", 58),
+					model.NewQueryResultCol("aggr__0__1-bucket__count", 58),
+					model.NewQueryResultCol("top_metrics__0__1-bucket__1-metric_col_0", 30),
+					model.NewQueryResultCol("top_metrics__0__1-bucket__1-metric_col_1", "2024-05-22T10:20:38Z"),
+					model.NewQueryResultCol("top_hits_rank", 1),
+				}},
+			},
+		},
 		ExpectedSQLs: []string{
 			`SELECT count() ` +
 				`FROM ` + TableName,
@@ -7020,7 +7209,41 @@ var AggregationTests = []AggregationTestCase{
 				`GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) ` +
 				`ORDER BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000)`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__0__key_0", count(*) AS "aggr__0__count",
+			  countIf("message" IS NOT NULL) AS "aggr__0__1-bucket__count"
+			FROM __quesma_table_name
+			GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+			  "aggr__0__key_0"
+			ORDER BY "aggr__0__key_0" ASC`,
+		ExpectedAdditionalPancakeSQLs: []string{`
+			WITH quesma_top_hits_group_table AS (
+			  SELECT toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+				"aggr__0__key_0", count(*) AS "aggr__0__count",
+				countIf("message" IS NOT NULL) AS "aggr__0__1-bucket__count"
+			  FROM __quesma_table_name
+			  GROUP BY toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000) AS
+				"aggr__0__key_0"
+			  ORDER BY "aggr__0__key_0" ASC) ,
+			quesma_top_hits_join AS (
+			  SELECT "group_table"."aggr__0__key_0" AS "aggr__0__key_0",
+				"group_table"."aggr__0__count" AS "aggr__0__count",
+				"group_table"."aggr__0__1-bucket__count" AS "aggr__0__1-bucket__count",
+				"hit_table"."message" AS "top_metrics__0__1-bucket__1-metric_col_0",
+				"hit_table"."order_date" AS "top_metrics__0__1-bucket__1-metric_col_1",
+				ROW_NUMBER() OVER (PARTITION BY "group_table"."aggr__0__key_0" ORDER BY
+				"order_date" DESC) AS "top_hits_rank"
+			  FROM quesma_top_hits_group_table AS "group_table" LEFT OUTER JOIN
+				__quesma_table_name AS "hit_table" ON ("group_table"."aggr__0__key_0"=
+				toInt64(toUnixTimestamp64Milli("@timestamp") / 86400000))
+			  WHERE "message" IS NOT NULL)
+			SELECT "aggr__0__key_0", "aggr__0__count", "aggr__0__1-bucket__count",
+			  "top_metrics__0__1-bucket__1-metric_col_0",
+			  "top_metrics__0__1-bucket__1-metric_col_1", "top_hits_rank"
+			FROM "quesma_top_hits_join"
+			WHERE "top_hits_rank"<=1
+			ORDER BY "aggr__0__key_0" ASC, "top_hits_rank" ASC`},
 	},
 	{ // [32]
 		TestName: "Standard deviation",
@@ -8177,7 +8400,13 @@ var AggregationTests = []AggregationTestCase{
 			{},
 			{{Cols: []model.QueryResultCol{model.NewQueryResultCol("message", "User updated")}}},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{model.NewQueryResultCol("top_metrics__tm_with_result_col_0", "User updated")}},
+		},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{},
+		},
+		AdditionalAcceptableDifference: []string{"tm_empty_result"}, // TODO: check, but we should return empty result
 		ExpectedSQLs: []string{
 			`SELECT count() ` +
 				`FROM ` + TableName,
@@ -8188,7 +8417,14 @@ var AggregationTests = []AggregationTestCase{
 				`FROM ` + TableName + ` ` +
 				`LIMIT 2`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT "message" AS "top_metrics__tm_with_result_col_0"
+			FROM __quesma_table_name
+			LIMIT 2`,
+		ExpectedAdditionalPancakeSQLs: []string{`
+			SELECT "message" AS "top_metrics__tm_empty_result_col_0"
+			FROM __quesma_table_name
+			LIMIT 1`},
 	},
 	{ // [39]
 		TestName: "simplest top_metrics, with sort",
@@ -8252,7 +8488,16 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("timestamp", "stamp"),
 			}}},
 		},
-		ExpectedPancakeResults: make([]model.QueryResultRow, 0),
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("top_metrics__tm_with_result_col_0", "User updated"),
+				model.NewQueryResultCol("top_metrics__tm_with_result_col_1", "stamp"),
+			},
+			}},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{},
+		},
+		AdditionalAcceptableDifference: []string{"tm_empty_result"}, // TODO: check, but we should return empty result
 		ExpectedSQLs: []string{
 			`SELECT count() ` +
 				`FROM ` + TableName,
@@ -8265,7 +8510,18 @@ var AggregationTests = []AggregationTestCase{
 				`ORDER BY "timestamp" DESC ` +
 				`LIMIT 1`,
 		},
-		ExpectedPancakeSQL: "TODO",
+		ExpectedPancakeSQL: `
+			SELECT "message" AS "top_metrics__tm_with_result_col_0",
+			  "timestamp" AS "top_metrics__tm_with_result_col_1"
+			FROM __quesma_table_name
+			ORDER BY "timestamp" DESC
+			LIMIT 1`,
+		ExpectedAdditionalPancakeSQLs: []string{`
+			SELECT "message" AS "top_metrics__tm_empty_result_col_0",
+			  "timestamp" AS "top_metrics__tm_empty_result_col_1"
+			FROM __quesma_table_name
+			ORDER BY "timestamp" DESC
+			LIMIT 1`},
 	},
 	{ // [40]
 		TestName: "terms ordered by subaggregation",


### PR DESCRIPTION
Implements `top_metrics`, which brings pancake to parity with previous processing and in some cases exceeding.

This also implements filters/range/dataRange for `top_hits`.