### PR TITLE
`date_histogram` timezones last

### DIFF
--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -469,34 +469,34 @@ var AggregationTests2 = []AggregationTestCase{
 				`FROM ` + TableName + ` ` +
 				`GROUP BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 ` +
 				`ORDER BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'Europe/Warsaw'))))*1000`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000, count() ` +
+			`SELECT toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'UTC'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
-				`GROUP BY toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 ` +
-				`ORDER BY toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000`,
+				`GROUP BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'UTC'))))*1000 ` +
+				`ORDER BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'UTC'))))*1000`,
 			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'Europe/Warsaw'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
 				`GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 ` +
 				`ORDER BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'Europe/Warsaw'))))*1000`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000, count() ` +
+			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'UTC'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
-				`GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 ` +
-				`ORDER BY toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000`,
+				`GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'UTC'))))*1000 ` +
+				`ORDER BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'UTC'))))*1000`,
 			`SELECT toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'Europe/Warsaw'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
 				`GROUP BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 ` +
 				`ORDER BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'Europe/Warsaw'))))*1000`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000, count() ` +
+			`SELECT toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'UTC'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
-				`GROUP BY toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 ` +
-				`ORDER BY toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000`,
+				`GROUP BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'UTC'))))*1000 ` +
+				`ORDER BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'UTC'))))*1000`,
 			`SELECT toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'Europe/Warsaw'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
 				`GROUP BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 ` +
 				`ORDER BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'Europe/Warsaw'))))*1000`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000, count() ` +
+			`SELECT toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'UTC'))))*1000, count() ` +
 				`FROM ` + TableName + ` ` +
-				`GROUP BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 ` +
-				`ORDER BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000`,
+				`GROUP BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'UTC'))))*1000 ` +
+				`ORDER BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'UTC'))))*1000`,
 		},
 		ExpectedPancakeSQL: `
 			SELECT toInt64((toUnixTimestamp64Milli("@timestamp")+timeZoneOffset(toTimezone(
@@ -545,10 +545,10 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'Europe/Warsaw'))))*1000
 			  AS "aggr__month1__key_0"
 			ORDER BY "aggr__month1__key_0" ASC`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			`SELECT toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__month2__key_0", count(*) AS "aggr__month2__count"
 			FROM ` + TableName + `
-			GROUP BY toInt64(toUnixTimestamp(toStartOfMonth("@timestamp")))*1000 AS
+			GROUP BY toInt64(toUnixTimestamp(toStartOfMonth(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__month2__key_0"
 			ORDER BY "aggr__month2__key_0" ASC`,
 			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'Europe/Warsaw'))))*1000
@@ -557,10 +557,10 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 AS
 			  "aggr__quarter1__key_0"
 			ORDER BY "aggr__quarter1__key_0" ASC`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			`SELECT toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__quarter2__key_0", count(*) AS "aggr__quarter2__count"
 			FROM ` + TableName + `
-			GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter("@timestamp")))*1000 AS
+			GROUP BY toInt64(toUnixTimestamp(toStartOfQuarter(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__quarter2__key_0"
 			ORDER BY "aggr__quarter2__key_0" ASC`,
 			`SELECT  toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'Europe/Warsaw'))))*1000 AS
@@ -569,10 +569,10 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'Europe/Warsaw'))))*1000
 			  AS "aggr__week1__key_0"
 			ORDER BY "aggr__week1__key_0" ASC`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			`SELECT toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__week2__key_0", count(*) AS "aggr__week2__count"
 			FROM ` + TableName + `
-			GROUP BY toInt64(toUnixTimestamp(toStartOfWeek("@timestamp")))*1000 AS
+			GROUP BY toInt64(toUnixTimestamp(toStartOfWeek(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__week2__key_0"
 			ORDER BY "aggr__week2__key_0" ASC`,
 			`SELECT toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'Europe/Warsaw'))))*1000
@@ -581,10 +581,10 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'Europe/Warsaw'))))*1000
 			  AS "aggr__year1__key_0"
 			ORDER BY "aggr__year1__key_0" ASC`,
-			`SELECT toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			`SELECT toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__year2__key_0", count(*) AS "aggr__year2__count"
 			FROM ` + TableName + `
-			GROUP BY toInt64(toUnixTimestamp(toStartOfYear("@timestamp")))*1000 AS
+			GROUP BY toInt64(toUnixTimestamp(toStartOfYear(toTimezone("@timestamp",'UTC'))))*1000 AS
 			  "aggr__year2__key_0"
 			ORDER BY "aggr__year2__key_0" ASC`,
 		},


### PR DESCRIPTION
https://github.com/QuesmaOrg/quesma/issues/307

There's still one issue:
Table: (`@timestamp` is in `Asia/Tokyo` zone in Clickhouse)
<img width="1728" alt="Screenshot 2024-09-10 at 11 44 29" src="https://github.com/user-attachments/assets/ed8699f5-c0df-4a84-8e08-72d60cee7a3e">
Query:
<img width="1728" alt="Screenshot 2024-09-10 at 11 44 41" src="https://github.com/user-attachments/assets/8bb9cc17-b385-4d88-ba00-fdedab17305d">
It should be `2023-12-01`, as in UTC the year is `2023`

Now it's fine:
<img width="1725" alt="Screenshot 2024-09-10 at 11 52 37" src="https://github.com/user-attachments/assets/da1488ff-9c2e-41da-b4ba-1c97d392774f">
