### PR TITLE
Quickfix: don't leave arrays uninitialized in constructor

### DIFF
--- a/quesma/queryparser/pancake_model.go
+++ b/quesma/queryparser/pancake_model.go
@@ -28,8 +28,9 @@ type pancakeModelLayer struct {
 	childrenPipelineAggregations []*pancakeModelPipelineAggregation
 }
 
-func newPancakeModelLayer() *pancakeModelLayer {
+func newPancakeModelLayer(nextBucketAggregation *pancakeModelBucketAggregation) *pancakeModelLayer {
 	return &pancakeModelLayer{
+		nextBucketAggregation:        nextBucketAggregation,
 		currentMetricAggregations:    make([]*pancakeModelMetricAggregation, 0),
 		currentPipelineAggregations:  make([]*pancakeModelPipelineAggregation, 0),
 		childrenPipelineAggregations: make([]*pancakeModelPipelineAggregation, 0),

--- a/quesma/queryparser/pancake_transformer_test.go
+++ b/quesma/queryparser/pancake_transformer_test.go
@@ -66,10 +66,9 @@ func Test_pancakeTranslateFromAggregationToLayered(t *testing.T) {
 	}
 
 	layer := func(bucket *pancakeModelBucketAggregation, metrics ...*pancakeModelMetricAggregation) *pancakeModelLayer {
-		return &pancakeModelLayer{
-			nextBucketAggregation:     bucket,
-			currentMetricAggregations: metrics,
-		}
+		layer := newPancakeModelLayer(bucket)
+		layer.currentMetricAggregations = metrics
+		return layer
 	}
 
 	pancake := func(panLayers ...*pancakeModelLayer) *pancakeModel {


### PR DESCRIPTION
Better not to leave pipeline arrays uninitialized as `nil`, I'm 95% sure having both top_hits and pipeline aggregations in 1 request would cause panics because of that. Had that multiple times before.