### PR TITLE
Add "target" field to index configuration (part 1, bare minimum)

### DIFF
--- a/ci/quesma/config/ci-config.yaml
+++ b/ci/quesma/config/ci-config.yaml
@@ -23,27 +23,37 @@ processors:
     config:
       indexes:
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "message":
                 type: text
         windows_logs:
+          target: [ my-clickhouse-data-source ]
   - name: p2
     type: quesma-v1-processor-ingest
     config:
       indexes:
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "message":
                 type: text
         windows_logs:   # Used for EQL e2e tests
+          target: [ my-clickhouse-data-source ]
 
 pipelines:
   - name: p-query

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -32,6 +32,7 @@ processors:
     config:
       indexes:
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "geoip.location":
@@ -45,6 +46,7 @@ processors:
               manufacturer:
                 type: text
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "DestLocation":
@@ -52,6 +54,7 @@ processors:
               "OriginLocation":
                 type: geo_point
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               timestamp:
@@ -72,6 +75,7 @@ processors:
     config:
       indexes:
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "geoip.location":
@@ -85,6 +89,7 @@ processors:
               manufacturer:
                 type: text
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               "DestLocation":
@@ -92,6 +97,7 @@ processors:
               "OriginLocation":
                 type: geo_point
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               timestamp:

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -6,13 +6,22 @@ import (
 	"fmt"
 )
 
+const (
+	ElasticsearchTarget = "elasticsearch"
+	ClickhouseTarget    = "clickhouse"
+)
+
 type IndexConfiguration struct {
-	Name     string `koanf:"name"`
-	Disabled bool   `koanf:"disabled"`
-	// TODO to be deprecated
+	Name            string                            `koanf:"name"`
+	Disabled        bool                              `koanf:"disabled"`
 	SchemaOverrides *SchemaConfiguration              `koanf:"schemaOverrides"`
 	Optimizers      map[string]OptimizerConfiguration `koanf:"optimizers"`
 	Override        string                            `koanf:"override"`
+	Target          []string                          `koanf:"target"`
+
+	// Computed based on the overall configuration
+	QueryTarget  []string
+	IngestTarget []string
 }
 
 func (c IndexConfiguration) String() string {

--- a/quesma/quesma/config/test_config_v2.yaml
+++ b/quesma/quesma/config/test_config_v2.yaml
@@ -30,16 +30,22 @@ processors:
     config:
       indexes:
         example-index:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               timestamp:
                 type: alias
                 targetColumnName: "@timestamp"
         kafka-example-topic:
+          target: [ my-clickhouse-data-source ]
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
@@ -47,17 +53,21 @@ processors:
               "host.name":
                 type: text
         device-logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
                 type: text
         phone_home_logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
                 type: text
         windows_logs:
+          target: [ my-clickhouse-data-source ]
         phone_home_data:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
@@ -67,16 +77,22 @@ processors:
     config:
       indexes:
         example-index:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_ecommerce:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_flights:
+          target: [ my-clickhouse-data-source ]
         kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               timestamp:
                 type: alias
                 targetColumnName: "@timestamp"
         kafka-example-topic:
+          target: [ my-clickhouse-data-source ]
         logs-generic-default:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
@@ -84,17 +100,21 @@ processors:
               "host.name":
                 type: text
         device-logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
                 type: text
         phone_home_logs:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:
                 type: text
         windows_logs:
+          target: [ my-clickhouse-data-source ]
         phone_home_data:
+          target: [ my-clickhouse-data-source ]
           schemaOverrides:
             fields:
               message:


### PR DESCRIPTION
When configuring indexes, users have a variety of use-cases, such as:
- querying from Elastic, but ingesting into ClickHouse
- querying from ClickHouse and ingesting into ClickHouse
- querying from Elastic, but ingesting into both Elastic and ClickHouse

The existing configuration was not flexible enough to encode those scenarios. This commit adds an additional required config option `target` that specifies the desired source/destination backend connector per each index. Since query and ingest processors are separate, this will allow in the future to have different preferences for query and ingest (not yet in this commit).

This added support in this commit is a bare-minimum support of the `target` config option. For example, it doesn't yet permit dual writes (specifying two targets) or having different configuration of ingest and query.

The actual query/ingest code is not yet changed in this PR and does not use the new `QueryTarget`, `IngestTarget` values. Currently the only permitted scenarios are: query+ingest into ES or query+ingest into CH, the first one being emulated by setting `Disabled=true`.

The following PRs will relax those constraints and enable more scenarios.