### PR TITLE
Fix last flight panel

### DIFF
--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -386,7 +386,7 @@ func (s *SchemaCheckPass) applyFullTextField(indexSchema schema.Schema, query *m
 			if col.ColumnName == model.FullTextFieldNamePlaceHolder {
 
 				if len(fullTextFields) == 0 {
-					if (e.Op == "LIKE" || e.Op == "ILIKE") && model.AsString(e.Right) == "'%'" {
+					if (strings.ToUpper(e.Op) == "LIKE" || strings.ToUpper(e.Op) == "ILIKE") && model.AsString(e.Right) == "'%'" {
 						return model.NewLiteral(true)
 					}
 					return model.NewLiteral(false)

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -386,6 +386,9 @@ func (s *SchemaCheckPass) applyFullTextField(indexSchema schema.Schema, query *m
 			if col.ColumnName == model.FullTextFieldNamePlaceHolder {
 
 				if len(fullTextFields) == 0 {
+					if (e.Op == "LIKE" || e.Op == "ILIKE") && model.AsString(e.Right) == "'%'" {
+						return model.NewLiteral(true)
+					}
 					return model.NewLiteral(false)
 				}
 


### PR DESCRIPTION
Fix the last flight panel previously we had fair chance of showing error there:
<img width="740" alt="Screenshot 2024-09-10 at 18 39 08" src="https://github.com/user-attachments/assets/296a96c7-59ec-4e32-844e-41ed1434061f">

Two fixes:
- if you do * query, even if there is no full-text field, we should default to true
- Implement `min_doc_count` for values different than zero, we also need to change default to `-1`
