### PR TITLE
Adding Field encoding logic

### DIFF
--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode"
 )
 
 type JsonMap = map[string]interface{}
@@ -789,4 +790,29 @@ func stringifyHelper(v interface{}, isInsideArray bool) string {
 func Stringify(v interface{}) string {
 	isInsideArray := false
 	return stringifyHelper(v, isInsideArray)
+}
+
+const timestampFieldName = "@timestamp"
+
+func replaceNonAlphabetic(str string) string {
+	runes := []rune(str)
+	for i, r := range runes {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			runes[i] = '_'
+		}
+	}
+	return string(runes)
+}
+
+func FieldToColumnEncoder(field string) string {
+	// Skip timestamp
+	if field == timestampFieldName {
+		return field
+	}
+	newField := strings.ToLower(field)
+	newField = replaceNonAlphabetic(newField)
+	if unicode.IsDigit(rune(newField[0])) {
+		newField = "_" + newField
+	}
+	return newField
 }

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"unicode"
 )
 
 type JsonMap = map[string]interface{}
@@ -794,14 +793,22 @@ func Stringify(v interface{}) string {
 
 const timestampFieldName = "@timestamp"
 
+func isLetter(char byte) bool {
+	return (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z')
+}
+
+func isDigit(char byte) bool {
+	return char >= '0' && char <= '9'
+}
+
 func replaceNonAlphabetic(str string) string {
-	runes := []rune(str)
-	for i, r := range runes {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			runes[i] = '_'
+	chars := []byte(str)
+	for i, c := range chars {
+		if !isLetter(c) && !isDigit(c) {
+			chars[i] = '_'
 		}
 	}
-	return string(runes)
+	return string(chars)
 }
 
 func FieldToColumnEncoder(field string) string {
@@ -811,7 +818,7 @@ func FieldToColumnEncoder(field string) string {
 	}
 	newField := strings.ToLower(field)
 	newField = replaceNonAlphabetic(newField)
-	if unicode.IsDigit(rune(newField[0])) {
+	if isDigit(byte(newField[0])) {
 		newField = "_" + newField
 	}
 	return newField

--- a/quesma/util/utils_test.go
+++ b/quesma/util/utils_test.go
@@ -821,3 +821,26 @@ func TestExtractInt64(t *testing.T) {
 		assert.False(t, success)
 	}
 }
+
+func TestFieldEncoding(t *testing.T) {
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{"@timestamp", "@timestamp"},
+		{"timestamp", "timestamp"},
+		{"9field", "_9field"},
+		{"field9", "field9"},
+		{"field::", "field__"},
+		{"host.name", "host_name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			got := FieldToColumnEncoder(tt.field)
+			if got != tt.want {
+				t.Errorf("FieldToColumnEncoder(%q) = %q; want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Field encoding logic is common and will be used both by ingest and query, so for now I decided to add this logic to `util` package