### PR TITLE
Run E2E tests as a required check in merge queue

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,7 @@
 name: E2E tests
 
-on: # @TODO TBD WHEN WE RUN
+on: # @TODO should we run it on PRs?
+  merge_group:
   push:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
Currently we don't run E2E tests on PRs or in merge queue, just on the main branch. That means that someone could merge a PR that ultimately fails on the main branch. Fix that by running E2E tests in the merge queue to catch the issue earlier.