### PR TITLE
Tiny fix for table autodiscovery

### DIFF
--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -101,7 +101,7 @@ func (td *tableDiscovery) TableDefinitionsFetchError() error {
 }
 
 func (td *tableDiscovery) TableAutodiscoveryEnabled() bool {
-	return td.cfg.IndexConfig == nil
+	return len(td.cfg.IndexConfig) == 0
 }
 
 func (td *tableDiscovery) LastAccessTime() time.Time {


### PR DESCRIPTION
In `config_v2` we initialize the `cfg` with `conf.IndexConfig = make(map[string]IndexConfiguration)` - therefore `nil` check is no longer relevant