### PR TITLE
Schema field encoding additions

### DIFF
--- a/quesma/clickhouse/parserCreateTable.go
+++ b/quesma/clickhouse/parserCreateTable.go
@@ -188,7 +188,13 @@ func parseColumn(q string, i int) (int, Column) {
 
 	// COMMENT
 	if i+7 < len(q) && q[i:i+7] == "COMMENT" {
-		return -1, col // TODO unsupported: parse comment, last thing to parse, let's do it later
+		// TODO should be good enough for now
+		for {
+			i++
+			if q[i] == ',' {
+				break
+			}
+		}
 	}
 
 	if i == -1 || i >= len(q) || (q[i] != ',' && q[i] != ')') {

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -504,7 +504,7 @@ func (td *tableDiscovery) readTables(database string) (map[string]map[string]str
 
 	logger.Debug().Msgf("describing tables: %s", database)
 
-	rows, err := td.dbConnPool.Query("SELECT table, name, type FROM system.columns WHERE database = ?", database)
+	rows, err := td.dbConnPool.Query("SELECT table, name, type, comment FROM system.columns WHERE database = ?", database)
 	if err != nil {
 		err = end_user_errors.GuessClickhouseErrorType(err).InternalDetails("reading list of columns from system.columns")
 		return map[string]map[string]string{}, err
@@ -512,8 +512,8 @@ func (td *tableDiscovery) readTables(database string) (map[string]map[string]str
 	defer rows.Close()
 	columnsPerTable := make(map[string]map[string]string)
 	for rows.Next() {
-		var table, colName, colType string
-		if err := rows.Scan(&table, &colName, &colType); err != nil {
+		var table, colName, colType, comment string
+		if err := rows.Scan(&table, &colName, &colType, &comment); err != nil {
 			return map[string]map[string]string{}, err
 		}
 		if _, ok := columnsPerTable[table]; !ok {

--- a/quesma/clickhouse/util.go
+++ b/quesma/clickhouse/util.go
@@ -28,7 +28,7 @@ func (t *columNameFormatter) Format(namespace, columnName string) string {
 }
 
 func DefaultColumnNameFormatter() TableColumNameFormatter {
-	return &columNameFormatter{separator: "::"}
+	return &columNameFormatter{separator: "_"}
 }
 
 // Code doesn't need to be pretty, 99.9% it's just for our purposes

--- a/quesma/ingest/processor_test.go
+++ b/quesma/ingest/processor_test.go
@@ -123,7 +123,8 @@ func TestAddTimestamp(t *testing.T) {
 	ip.schemaRegistry = schema.StaticRegistry{}
 	jsonData := types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`)
 	columnsFromJson, columnsFromSchema := ip.buildCreateTableQueryNoOurFields(context.Background(), "tableName", jsonData, tableConfig, nameFormatter)
-	columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema), Indexes(jsonData))
+	encodings := make(map[schema.FieldEncodingKey]schema.EncodedFieldName)
+	columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema, encodings, tableName), Indexes(jsonData))
 	query := createTableQuery(tableName, columns, tableConfig)
 	assert.True(t, strings.Contains(query, timestampFieldName))
 }

--- a/quesma/jsonprocessor/ingest.go
+++ b/quesma/jsonprocessor/ingest.go
@@ -27,7 +27,7 @@ type removeFieldsTransformer struct {
 func (t *removeFieldsTransformer) Transform(document types.JSON) (types.JSON, error) {
 	for _, field := range t.fields {
 		delete(document, field.AsString())
-		delete(document, strings.Replace(field.AsString(), ".", "::", -1))
+		delete(document, strings.Replace(field.AsString(), ".", "_", -1))
 	}
 	return document, nil
 }
@@ -35,7 +35,7 @@ func (t *removeFieldsTransformer) Transform(document types.JSON) (types.JSON, er
 func IngestTransformerFor(table string, cfg *config.QuesmaConfiguration) IngestTransformer {
 	var transformers []IngestTransformer
 
-	transformers = append(transformers, &flattenMapTransformer{separator: "::"})
+	transformers = append(transformers, &flattenMapTransformer{separator: "_"})
 
 	if indexConfig, found := cfg.IndexConfig[table]; found && indexConfig.SchemaOverrides != nil {
 		// FIXME: don't get ignored fields from schema config, but store

--- a/quesma/queryparser/pancake_aggregation_parser_metrics.go
+++ b/quesma/queryparser/pancake_aggregation_parser_metrics.go
@@ -106,7 +106,9 @@ func generateMetricSelectedColumns(ctx context.Context, metricsAggr metricsAggre
 		firstExpr := getFirstExpression()
 		result = make([]model.Expr, 0, 3)
 		if col, ok := firstExpr.(model.ColumnRef); ok {
-			colName := col.ColumnName
+			// TODO this is internalPropertyName and should be taken from schema
+			// instead of using util.FieldToColumnEncoder and doing encoding in-place
+			colName := util.FieldToColumnEncoder(col.ColumnName)
 			// TODO we have create columns according to the schema
 			latColumn := model.NewGeoLat(colName)
 			lonColumn := model.NewGeoLon(colName)

--- a/quesma/quesma/schema_array_transformer.go
+++ b/quesma/quesma/schema_array_transformer.go
@@ -28,9 +28,8 @@ func (v *arrayTypeResolver) dbColumnType(columName string) string {
 	//
 	// here we should resolve field by column name not field name
 	columName = strings.TrimSuffix(columName, ".keyword")
-	columName = strings.ReplaceAll(columName, "::", ".")
 
-	field, ok := v.indexSchema.ResolveField(columName)
+	field, ok := v.indexSchema.ResolveFieldByInternalName(columName)
 
 	if !ok {
 		return ""

--- a/quesma/quesma/schema_map_transformation.go
+++ b/quesma/quesma/schema_map_transformation.go
@@ -7,6 +7,7 @@ import (
 	"quesma/model"
 	"quesma/quesma/types"
 	"quesma/schema"
+	"quesma/util"
 	"strings"
 )
 
@@ -46,7 +47,7 @@ func (v *mapTypeResolver) isMap(fieldName string) (exists bool, scope searchScop
 		scope = scopeWholeMap
 	}
 
-	tableColumnName := strings.ReplaceAll(fieldName, ".", "::")
+	tableColumnName := util.FieldToColumnEncoder(fieldName)
 	col, ok := v.indexSchema.Fields[schema.FieldName(tableColumnName)]
 
 	if ok {

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -10,6 +10,7 @@ import (
 	"quesma/model/typical_queries"
 	"quesma/quesma/config"
 	"quesma/schema"
+	"quesma/util"
 	"sort"
 	"strings"
 )
@@ -159,23 +160,22 @@ func (s *SchemaCheckPass) applyGeoTransformations(schemaInstance schema.Schema, 
 
 	for _, field := range schemaInstance.Fields {
 		if field.Type.Name == schema.QuesmaTypePoint.Name {
-
-			lon := model.NewColumnRef(field.InternalPropertyName.AsString() + "::lon")
-			lat := model.NewColumnRef(field.InternalPropertyName.AsString() + "::lat")
+			lon := model.NewColumnRef(field.InternalPropertyName.AsString() + "_lon")
+			lat := model.NewColumnRef(field.InternalPropertyName.AsString() + "_lat")
 
 			// This is a workaround. Clickhouse Point is defined as Tuple. We need to know the type of the tuple.
 			// In this step we merge two columns into single map here. Map is in elastic format.
 
 			// In this point we assume that Quesma point type is stored into two separate columns.
-			replace[field.PropertyName.AsString()] = model.NewFunction("map",
+			replace[field.InternalPropertyName.AsString()] = model.NewFunction("map",
 				model.NewLiteral("'lat'"),
 				lat,
 				model.NewLiteral("'lon'"),
 				lon)
 
 			// these a just if we need multifields support
-			replace[field.PropertyName.AsString()+".lat"] = lat
-			replace[field.PropertyName.AsString()+".lon"] = lon
+			replace[field.InternalPropertyName.AsString()+".lat"] = lat
+			replace[field.InternalPropertyName.AsString()+".lon"] = lon
 
 			// if the point is stored as a single column, we need to extract the lat and lon
 			//replace[field.PropertyName.AsString()] = model.NewFunction("give_me_point", model.NewColumnRef(field.InternalPropertyName.AsString()))
@@ -358,13 +358,9 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 		return query, fmt.Errorf("index configuration not found for table %s", query.TableName)
 	}
 
-	useCommonTable := indexConf.UseCommonTable
+	useSingleTable := indexConf.UseCommonTable
 
 	physicalFromExpression := model.NewTableRefWithDatabaseName(query.TableName, currentSchema.DatabaseName)
-
-	if useCommonTable {
-		physicalFromExpression = model.NewTableRef(common_table.TableName)
-	}
 
 	visitor := model.NewBaseVisitor()
 
@@ -377,7 +373,7 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 
 	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
 		// TODO is this nessessery?
-		if useCommonTable {
+		if useSingleTable {
 			if e.ColumnName == "timestamp" || e.ColumnName == "epoch_time" || e.ColumnName == `"epoch_time"` {
 				return model.NewColumnRef("@timestamp")
 			}
@@ -407,8 +403,8 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 			where = selectStm.WhereClause.Accept(b).(model.Expr)
 		}
 
-		// add filter for common table, if needed
-		if useCommonTable && from == physicalFromExpression {
+		// add filter for single table, if needed
+		if useSingleTable && from == physicalFromExpression {
 			indexWhere := model.NewInfixExpr(model.NewColumnRef(common_table.IndexNameColumn), "=", model.NewLiteral(fmt.Sprintf("'%s'", query.TableName)))
 
 			if selectStm.WhereClause != nil {
@@ -606,11 +602,42 @@ func (s *SchemaCheckPass) handleDottedTColumnNames(indexSchema schema.Schema, qu
 		if strings.Contains(e.ColumnName, ".") {
 			logger.Warn().Msgf("Dotted column name found: %s", e.ColumnName)
 			//return model.NewColumnRef(strings.ReplaceAll(e.ColumnName, ".", "::"))
+			return e
 		}
 		return e
 	}
 
 	expr := query.SelectCommand.Accept(visitor)
+
+	if _, ok := expr.(*model.SelectCommand); ok {
+		query.SelectCommand = *expr.(*model.SelectCommand)
+	}
+	return query, nil
+}
+
+func (s *SchemaCheckPass) applyFieldEncoding(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
+
+	visitor := model.NewBaseVisitor()
+
+	var err error
+
+	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
+		if _, ok := indexSchema.ResolveField(e.ColumnName); ok {
+			// TODO util.FieldToColumnEncoder is a shortcut here
+			// we should use the schema to get the internal name
+			// however for now it's part of schema.registry not schema.Schema
+			// so we don't have direct access to it
+			return model.NewColumnRef(util.FieldToColumnEncoder(e.ColumnName))
+		} else {
+			return e
+		}
+	}
+
+	expr := query.SelectCommand.Accept(visitor)
+
+	if err != nil {
+		return nil, err
+	}
 
 	if _, ok := expr.(*model.SelectCommand); ok {
 		query.SelectCommand = *expr.(*model.SelectCommand)
@@ -626,6 +653,11 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 	}{
 		{TransformationName: "PhysicalFromExpressionTransformation", Transformation: s.applyPhysicalFromExpression},
 		{TransformationName: "WildcardExpansion", Transformation: s.applyWildcardExpansion},
+		// FieldEncodingTransformation should be after WildcardExpansion
+		// because WildcardExpansion expands the wildcard to all fields
+		// and columns are expanded as PublicFieldName, so we need to encode them
+		// or in other words use internal field names
+		{TransformationName: "FieldEncodingTransformation", Transformation: s.applyFieldEncoding},
 		{TransformationName: "FullTextFieldTransformation", Transformation: s.applyFullTextField},
 		{TransformationName: "TimestampFieldTransformation", Transformation: s.applyTimestampField},
 		{TransformationName: "BooleanLiteralTransformation", Transformation: s.applyBooleanLiteralLowering},

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -763,7 +763,7 @@ func (q *QueryRunner) postProcessResults(table *clickhouse.Table, results [][]mo
 		name        string
 		transformer model.ResultTransformer
 	}{
-		{"replaceColumNamesWithFieldNames", &replaceColumNamesWithFieldNames{}},
+		{"replaceColumNamesWithFieldNames", &replaceColumNamesWithFieldNames{schemaRegistry: q.schemaRegistry, fromTable: table.Name}},
 		{"arrayResultTransformer", &ArrayResultTransformer{}},
 	}
 

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 )
 
+// TODO we should rethink naming and types used in this package
+
 type (
 	Registry interface {
 		AllSchemas() map[TableName]Schema
@@ -16,6 +18,7 @@ type (
 		UpdateDynamicConfiguration(name TableName, table Table)
 		UpdateFieldEncodings(encodings map[FieldEncodingKey]EncodedFieldName)
 	}
+
 	FieldEncodingKey struct {
 		TableName string
 		FieldName string

--- a/quesma/schema/static_registry.go
+++ b/quesma/schema/static_registry.go
@@ -8,6 +8,7 @@ package schema
 type StaticRegistry struct {
 	Tables               map[TableName]Schema
 	DynamicConfiguration map[string]Table
+	FieldEncodings       map[FieldEncodingKey]EncodedFieldName
 }
 
 func (e StaticRegistry) AllSchemas() map[TableName]Schema {
@@ -28,4 +29,13 @@ func (e StaticRegistry) FindSchema(name TableName) (Schema, bool) {
 
 func (e StaticRegistry) UpdateDynamicConfiguration(name TableName, table Table) {
 	e.DynamicConfiguration[name.AsString()] = table
+}
+
+func (e StaticRegistry) UpdateFieldEncodings(encodings map[FieldEncodingKey]EncodedFieldName) {
+	if e.FieldEncodings == nil {
+		e.FieldEncodings = map[FieldEncodingKey]EncodedFieldName{}
+	}
+	for k, v := range encodings {
+		e.FieldEncodings[k] = EncodedFieldName(v)
+	}
 }

--- a/quesma/schema/types.go
+++ b/quesma/schema/types.go
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Elastic-2.0
 package schema
 
-import "slices"
+import (
+	"slices"
+)
 
 type (
 	QuesmaType struct {

--- a/quesma/testdata/opensearch_requests.go
+++ b/quesma/testdata/opensearch_requests.go
@@ -80,24 +80,24 @@ var OpensearchSearchTests = []SearchTestCase{
 			"track_total_hits": true
 		}`,
 		WantedSql: []string{
-			`("-@timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND "-@timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))`,
+			`("__timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND "__timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))`,
 		},
 		WantedQueryType: model.ListAllFields,
 		WantedQueries: []string{
-			`SELECT "-@bytes", "-@timestamp", "message$*%:;"
+			`SELECT "__bytes", "__timestamp", "message_____"
 			FROM __quesma_table_name
-			WHERE ("-@timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z')
-			           AND "-@timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
-			ORDER BY "-@timestamp" DESC LIMIT 500`,
+			WHERE ("__timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z')
+			           AND "__timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
+			ORDER BY "__timestamp" DESC LIMIT 500`,
 			`SELECT sum(count(*)) OVER () AS "metric____quesma_total_count_col_0",
-			  toInt64((toUnixTimestamp64Milli("-@timestamp")+timeZoneOffset(toTimezone(
-			  "-@timestamp", 'Europe/Warsaw'))*1000) / 30000) AS "aggr__2__key_0",
+			  toInt64((toUnixTimestamp64Milli("__timestamp")+timeZoneOffset(toTimezone(
+			  "__timestamp", 'Europe/Warsaw'))*1000) / 30000) AS "aggr__2__key_0",
 			  count(*) AS "aggr__2__count"
 			FROM __quesma_table_name
-			WHERE ("-@timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND
-			  "-@timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
-			GROUP BY toInt64((toUnixTimestamp64Milli("-@timestamp")+timeZoneOffset(
-			  toTimezone("-@timestamp", 'Europe/Warsaw'))*1000) / 30000) AS "aggr__2__key_0"
+			WHERE ("__timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND
+			  "__timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
+			GROUP BY toInt64((toUnixTimestamp64Milli("__timestamp")+timeZoneOffset(
+			  toTimezone("__timestamp", 'Europe/Warsaw'))*1000) / 30000) AS "aggr__2__key_0"
 			ORDER BY "aggr__2__key_0" ASC`,
 		},
 	},
@@ -173,17 +173,17 @@ var OpensearchSearchTests = []SearchTestCase{
 			"track_total_hits": true
 		}`,
 		WantedSql: []string{
-			`("-@timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND "-@timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))`,
+			`("__timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z') AND "__timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))`,
 		},
 		WantedQueryType: model.Normal,
 		WantedQueries: []string{
 			`SELECT sum(count(*)) OVER () AS "metric____quesma_total_count_col_0",
-       		  toInt64(toUnixTimestamp64Milli("-@timestamp") / 30000) AS "aggr__2__key_0",
+			  toInt64(toUnixTimestamp64Milli("__timestamp") / 30000) AS "aggr__2__key_0",
        		  count(*) AS "aggr__2__count"
 			FROM __quesma_table_name
-			WHERE ("-@timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z')
-			           AND "-@timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
-			GROUP BY toInt64(toUnixTimestamp64Milli("-@timestamp") / 30000) AS "aggr__2__key_0"
+			WHERE ("__timestamp">=parseDateTime64BestEffort('2024-04-04T13:18:18.149Z')
+			           AND "__timestamp"<=parseDateTime64BestEffort('2024-04-04T13:33:18.149Z'))
+			GROUP BY toInt64(toUnixTimestamp64Milli("__timestamp") / 30000) AS "aggr__2__key_0"
 			ORDER BY "aggr__2__key_0" ASC`,
 		},
 	},

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -149,18 +149,18 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 		model.HitsCountInfo{Typ: model.Normal},
 		[]string{
 			`SELECT sum(count(*)) OVER () AS "aggr__sample__count",
-			  sum(count("host.name")) OVER () AS "metric__sample__sample_count_col_0",
+			  sum(count("host_name")) OVER () AS "metric__sample__sample_count_col_0",
 			  sum(count(*)) OVER () AS "aggr__sample__top_values__parent_count",
-			  "host.name" AS "aggr__sample__top_values__key_0",
+			  "host_name" AS "aggr__sample__top_values__key_0",
 			  count(*) AS "aggr__sample__top_values__count"
 			FROM (
-			  SELECT "host.name"
+			  SELECT "host_name"
 			  FROM __quesma_table_name
 			  WHERE (("@timestamp">=parseDateTime64BestEffort('2024-01-23T11:27:16.820Z')
 				AND "@timestamp"<=parseDateTime64BestEffort('2024-01-23T11:42:16.820Z')) AND
 				"message" iLIKE '%user%')
 			  LIMIT 20000)
-			GROUP BY "host.name" AS "aggr__sample__top_values__key_0"
+			GROUP BY "host_name" AS "aggr__sample__top_values__key_0"
 			ORDER BY "aggr__sample__top_values__count" DESC,
 			  "aggr__sample__top_values__key_0" ASC
 			LIMIT 11`,
@@ -558,7 +558,7 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 		"Truncated most results. TODO Check what's at the end of response, probably count?",
 		model.HitsCountInfo{Typ: model.ListAllFields, RequestedFields: []string{"*"}, Size: 500},
 		[]string{
-			`SELECT "@timestamp", "host.name", "message", "properties::isreg"
+			`SELECT "@timestamp", "host_name", "message", "properties_isreg"
 			FROM __quesma_table_name
 			WHERE ("message" iLIKE '%user%' AND ("@timestamp">=parseDateTime64BestEffort(
 			  '2024-01-23T14:43:19.481Z') AND "@timestamp"<=parseDateTime64BestEffort(
@@ -867,7 +867,7 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 			  count(*) AS "metric____quesma_total_count_col_0"
 			FROM __quesma_table_name
 			WHERE (("message" iLIKE '%posei%' AND "message" iLIKE '%User logged out%') AND
-			  "host.name" iLIKE '%poseidon%')`,
+			  "host_name" iLIKE '%poseidon%')`,
 		},
 		true,
 	},
@@ -884,7 +884,7 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 		"no comment yet",
 		model.HitsCountInfo{Typ: model.ListAllFields, RequestedFields: []string{"*"}, Size: 50},
 		[]string{
-			`SELECT "@timestamp", "host.name", "message", "properties::isreg"
+			`SELECT "@timestamp", "host_name", "message", "properties_isreg"
 			FROM __quesma_table_name
 			LIMIT 50`,
 		},
@@ -950,13 +950,13 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 		"happens e.g. in Explorer > Field Statistics view",
 		model.HitsCountInfo{Typ: model.ListByField, RequestedFields: []string{"properties::isreg"}, Size: 100},
 		[]string{
-			`SELECT "properties::isreg"
+			`SELECT "properties_isreg"
 				FROM __quesma_table_name
 				WHERE (((toUnixTimestamp64Milli("epoch_time")>=1.710171234276e+12 AND
 				  toUnixTimestamp64Milli("epoch_time")<=1.710172134276e+12) AND (
 				  toUnixTimestamp64Milli("epoch_time")>=1.710171234276e+12 AND
 				  toUnixTimestamp64Milli("epoch_time")<=1.710172134276e+12)) AND
-				  "properties::isreg" IS NOT NULL)
+				  "properties_isreg" IS NOT NULL)
 				LIMIT 100`,
 		},
 		false,

--- a/quesma/testdata/requests_with_special_characters.go
+++ b/quesma/testdata/requests_with_special_characters.go
@@ -146,11 +146,11 @@ var AggregationTestsWithSpecialCharactersInFieldNames = []AggregationTestCase{
 		ExpectedPancakeResults: []model.QueryResultRow{}, // checking only the SQLs is enough for now
 		ExpectedPancakeSQL: `WITH quesma_top_hits_group_table AS (
 			  SELECT sum(count(*)) OVER () AS "metric____quesma_total_count_col_0",
-				toInt64(toUnixTimestamp64Milli("-@timestamp") / 43200000) AS
+				toInt64(toUnixTimestamp64Milli("__timestamp") / 43200000) AS
 				"aggr__0__key_0", count(*) AS "aggr__0__count"
 			  FROM __quesma_table_name
-			  WHERE "message$*%:;" IS NOT NULL
-			  GROUP BY toInt64(toUnixTimestamp64Milli("-@timestamp") / 43200000) AS
+			  WHERE "message_____" IS NOT NULL
+			  GROUP BY toInt64(toUnixTimestamp64Milli("__timestamp") / 43200000) AS
 				"aggr__0__key_0"
 			  ORDER BY "aggr__0__key_0" ASC) ,
 			quesma_top_hits_join AS (
@@ -158,14 +158,14 @@ var AggregationTestsWithSpecialCharactersInFieldNames = []AggregationTestCase{
 				"metric____quesma_total_count_col_0",
 				"group_table"."aggr__0__key_0" AS "aggr__0__key_0",
 				"group_table"."aggr__0__count" AS "aggr__0__count",
-				"-@bytes" AS "top_metrics__0__1_col_0",
-				"-@timestamp" AS "top_metrics__0__1_col_1",
+				"__bytes" AS "top_metrics__0__1_col_0",
+				"__timestamp" AS "top_metrics__0__1_col_1",
 				ROW_NUMBER() OVER (PARTITION BY "group_table"."aggr__0__key_0" ORDER BY
-				"-@timestamp" DESC) AS "top_hits_rank"
+				"__timestamp" DESC) AS "top_hits_rank"
 			  FROM quesma_top_hits_group_table AS "group_table" LEFT OUTER JOIN
 				__quesma_table_name AS "hit_table" ON ("group_table"."aggr__0__key_0"=
-				toInt64(toUnixTimestamp64Milli("-@timestamp") / 43200000))
-			  WHERE "message$*%:;" IS NOT NULL)
+				toInt64(toUnixTimestamp64Milli("__timestamp") / 43200000))
+			  WHERE "message_____" IS NOT NULL)
 			SELECT "metric____quesma_total_count_col_0", "aggr__0__key_0", "aggr__0__count",
 			  "top_metrics__0__1_col_0", "top_metrics__0__1_col_1", "top_hits_rank"
 			FROM "quesma_top_hits_join"

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -851,14 +851,24 @@ func replaceNonAlphabetic(str string) string {
 	return string(chars)
 }
 
+// FieldToColumnEncoder takes input field name
+// and converts it using algorithm defined in
+// https://github.com/QuesmaOrg/quesma/blob/main/adr/5_nested_fields_representation.md
+// all lower case
+// all non-alphanumeric are translated to ‘_’ (e.g. “host-name”, “host.name”, “host name” will be “host_name”)
+// if starts with digit, then add ‘_’ at beginning
+// Save mapping to persitent logic, on-collision do override.
 func FieldToColumnEncoder(field string) string {
+	if len(field) == 0 {
+		return field
+	}
 	// Skip timestamp
 	if field == timestampFieldName {
 		return field
 	}
 	newField := strings.ToLower(field)
 	newField = replaceNonAlphabetic(newField)
-	if isDigit(byte(newField[0])) {
+	if isDigit(newField[0]) {
 		newField = "_" + newField
 	}
 	return newField

--- a/smoke-test/main.go
+++ b/smoke-test/main.go
@@ -127,7 +127,7 @@ func main() {
 		println("   Kibana: OK")
 		waitForDataViews(5 * time.Minute)
 		println("   Data Views: OK")
-		waitForLogsInClickhouse("logs-generic-default", time.Minute, []string{"@timestamp", "attributes_values", "attributes_metadata", "host::name", "message", "service::name", "severity", "source"})
+		waitForLogsInClickhouse("logs-generic-default", time.Minute, []string{"@timestamp", "attributes_values", "attributes_metadata", "host_name", "message", "service_name", "severity", "source"})
 		println("   Logs in Clickhouse: OK")
 		waitForAsyncQuery(time.Minute)
 		println("   AsyncQuery: OK")


### PR DESCRIPTION
This PR introduces changes for field encodings according to defined criteria by https://github.com/QuesmaOrg/quesma/blob/main/adr/5_nested_fields_representation.md

Fields are encoded during ingest with original name stored as comment 

![image](https://github.com/user-attachments/assets/9323bd2c-8b74-4871-9363-863b66827d0a)
