### PR TITLE
Remove "Disabled" from index conf, switch code to use QueryTarget, IngestTarget

### DIFF
--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -15,7 +15,6 @@ import (
 	"quesma/quesma/config"
 	"quesma/schema"
 	"quesma/util"
-	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -218,7 +217,7 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]string, d
 				indexConfig = config.IndexConfiguration{}
 			}
 
-			if !isCommonTable && !slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) && !slices.Contains(indexConfig.IngestTarget, config.ClickhouseTarget) {
+			if !isCommonTable && !indexConfig.IsClickhouseQueryEnabled() && !indexConfig.IsClickhouseIngestEnabled() {
 				explicitlyDisabledTables = append(explicitlyDisabledTables, table)
 			} else {
 				comment := td.tableComment(databaseName, table)

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -15,6 +15,7 @@ import (
 	"quesma/quesma/config"
 	"quesma/schema"
 	"quesma/util"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -217,7 +218,7 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]string, d
 				indexConfig = config.IndexConfiguration{}
 			}
 
-			if indexConfig.Disabled {
+			if !isCommonTable && !slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) && !slices.Contains(indexConfig.IngestTarget, config.ClickhouseTarget) {
 				explicitlyDisabledTables = append(explicitlyDisabledTables, table)
 			} else {
 				comment := td.tableComment(databaseName, table)

--- a/quesma/proxy/l4_proxy.go
+++ b/quesma/proxy/l4_proxy.go
@@ -57,7 +57,7 @@ func resolveHttpServer(inspect bool) *http.Server {
 
 func configureRouting() *http.ServeMux {
 	router := http.NewServeMux()
-	configuration := &config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", Disabled: false}}}
+	configuration := &config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"_all": {Name: "_all", QueryTarget: []string{config.ElasticsearchTarget}, IngestTarget: []string{config.ElasticsearchTarget}}}}
 	router.HandleFunc("POST /{index}/_doc", util.BodyHandler(func(body []byte, writer http.ResponseWriter, r *http.Request) {
 		index := r.PathValue("index")
 

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -480,17 +480,6 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 			conf.IndexConfig[indexName] = processedConfig
 		}
-		// For now, users of IndexConfig don't actually look at the QueryTarget and IngestTarget fields,
-		// and the only valid cases are Query+Ingest to Elasticsearch or Query+Ingest to ClickHouse. Emulate those
-		// behaviors by settings Disabled:
-		for indexName, indexConfig := range conf.IndexConfig {
-			if slices.Contains(indexConfig.QueryTarget, elasticBackendName) {
-				indexConfig.Disabled = true
-			} else {
-				indexConfig.Disabled = false
-			}
-			conf.IndexConfig[indexName] = indexConfig
-		}
 	}
 
 	if errAcc != nil {

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -32,7 +32,7 @@ func TestQuesmaConfigurationLoading(t *testing.T) {
 	assert.Equal(t, true, legacyCfg.IngestStatistics)
 	assert.Equal(t, "logs", legacyCfg.Logging.Path)
 	assert.Equal(t, logLevelPassedAsEnvVar, legacyCfg.Logging.Level.String())
-	assert.Equal(t, 10, len(legacyCfg.IndexConfig))
+	assert.Equal(t, 11, len(legacyCfg.IndexConfig))
 
 	findIndexConfig := func(name string) *IndexConfiguration {
 		if configuration, found := legacyCfg.IndexConfig[name]; found {
@@ -43,18 +43,21 @@ func TestQuesmaConfigurationLoading(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		enabled bool
+		name         string
+		queryTarget  []string
+		ingestTarget []string
 	}{
-		{"logs-generic-default", false},
-		{"device-logs", false},
+		{"logs-generic-default", []string{ClickhouseTarget}, []string{ClickhouseTarget}},
+		{"device-logs", []string{ClickhouseTarget}, []string{ClickhouseTarget}},
+		{"example-elastic-index", []string{ElasticsearchTarget}, []string{ElasticsearchTarget}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ic := findIndexConfig(tt.name)
 			assert.NotNil(t, ic)
-			assert.Equal(t, tt.enabled, ic.Disabled)
+			assert.Equal(t, tt.queryTarget, ic.QueryTarget)
+			assert.Equal(t, tt.ingestTarget, ic.IngestTarget)
 		})
 	}
 }

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 )
 
 const (
@@ -42,4 +43,20 @@ func (c IndexConfiguration) GetOptimizerConfiguration(optimizerName string) (pro
 		return optimizer.Properties, optimizer.Disabled
 	}
 	return nil, true
+}
+
+func (c IndexConfiguration) IsElasticQueryEnabled() bool {
+	return slices.Contains(c.QueryTarget, ElasticsearchTarget)
+}
+
+func (c IndexConfiguration) IsElasticIngestEnabled() bool {
+	return slices.Contains(c.IngestTarget, ElasticsearchTarget)
+}
+
+func (c IndexConfiguration) IsClickhouseQueryEnabled() bool {
+	return slices.Contains(c.QueryTarget, ClickhouseTarget)
+}
+
+func (c IndexConfiguration) IsClickhouseIngestEnabled() bool {
+	return slices.Contains(c.IngestTarget, ClickhouseTarget)
 }

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -13,7 +13,6 @@ const (
 
 type IndexConfiguration struct {
 	Name            string                            `koanf:"name"`
-	Disabled        bool                              `koanf:"disabled"`
 	SchemaOverrides *SchemaConfiguration              `koanf:"schemaOverrides"`
 	Optimizers      map[string]OptimizerConfiguration `koanf:"optimizers"`
 	Override        string                            `koanf:"override"`
@@ -26,9 +25,10 @@ type IndexConfiguration struct {
 }
 
 func (c IndexConfiguration) String() string {
-	var str = fmt.Sprintf("\n\t\t%s, disabled: %t, schema overrides: %s, override: %s, useSingleTable: %t",
+	var str = fmt.Sprintf("\n\t\t%s, query targets: %v, ingest targets: %v, schema overrides: %s, override: %s, useSingleTable: %t",
 		c.Name,
-		c.Disabled,
+		c.QueryTarget,
+		c.IngestTarget,
 		c.SchemaOverrides.String(),
 		c.Override,
 		c.UseCommonTable,

--- a/quesma/quesma/config/test_config_v2.yaml
+++ b/quesma/quesma/config/test_config_v2.yaml
@@ -29,6 +29,8 @@ processors:
     type: quesma-v1-processor-query
     config:
       indexes:
+        example-elastic-index:
+          target: [ my-minimal-elasticsearch ]
         example-index:
           target: [ my-clickhouse-data-source ]
         kibana_sample_data_ecommerce:
@@ -76,6 +78,8 @@ processors:
     type: quesma-v1-processor-ingest
     config:
       indexes:
+        example-elastic-index:
+          target: [ my-minimal-elasticsearch ]
         example-index:
           target: [ my-clickhouse-data-source ]
         kibana_sample_data_ecommerce:

--- a/quesma/quesma/config/util.go
+++ b/quesma/quesma/config/util.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"quesma/logger"
 	"quesma/quesma/types"
-	"slices"
 	"sync/atomic"
 )
 
@@ -26,7 +25,7 @@ func RunConfiguredIngest(ctx context.Context, cfg *QuesmaConfiguration, indexNam
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is not configured, skipping", indexName)
 			return nil
 		}
-		if !slices.Contains(matchingConfig.IngestTarget, ClickhouseTarget) {
+		if !matchingConfig.IsClickhouseIngestEnabled() {
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
 			return nil
 		} else {

--- a/quesma/quesma/config/util.go
+++ b/quesma/quesma/config/util.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"quesma/logger"
 	"quesma/quesma/types"
+	"slices"
 	"sync/atomic"
 )
 
 var insertCounter = atomic.Int32{}
 
-func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName string, body types.JSON, action func() error) error {
+func RunConfiguredIngest(ctx context.Context, cfg *QuesmaConfiguration, indexName string, body types.JSON, action func() error) error {
 	if len(cfg.IndexConfig) == 0 {
 		logger.InfoWithCtx(ctx).Msgf("%s  --> clickhouse, body(shortened): %s", indexName, body.ShortString())
 		err := action()
@@ -25,7 +26,7 @@ func RunConfigured(ctx context.Context, cfg *QuesmaConfiguration, indexName stri
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is not configured, skipping", indexName)
 			return nil
 		}
-		if matchingConfig.Disabled {
+		if !slices.Contains(matchingConfig.IngestTarget, ClickhouseTarget) {
 			logger.InfoWithCtx(ctx).Msgf("index '%s' is disabled, ignoring", indexName)
 			return nil
 		} else {

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -19,7 +19,6 @@ import (
 	"quesma/quesma/types"
 	"quesma/stats"
 	"quesma/telemetry"
-	"slices"
 	"sync"
 )
 
@@ -118,7 +117,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 		}
 
 		indexConfig, found := cfg.IndexConfig[index]
-		if !found || slices.Contains(indexConfig.IngestTarget, config.ElasticsearchTarget) {
+		if !found || indexConfig.IsElasticIngestEnabled() {
 			// Bulk entry for Elastic - forward the request as-is
 			opBytes, err := rawOp.Bytes()
 			if err != nil {
@@ -136,7 +135,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 
 			elasticBulkEntries = append(elasticBulkEntries, entryWithResponse)
 		}
-		if found && slices.Contains(indexConfig.IngestTarget, config.ClickhouseTarget) {
+		if found && indexConfig.IsClickhouseIngestEnabled() {
 			// Bulk entry for Clickhouse
 			if operation != "create" && operation != "index" {
 				// Elastic also fails the entire bulk in such case

--- a/quesma/quesma/functionality/doc/doc.go
+++ b/quesma/quesma/functionality/doc/doc.go
@@ -21,7 +21,7 @@ func Write(ctx context.Context, tableName string, body types.JSON, ip *ingest.In
 		return nil
 	}
 
-	return config.RunConfigured(ctx, cfg, tableName, body, func() error {
+	return config.RunConfiguredIngest(ctx, cfg, tableName, body, func() error {
 		if len(cfg.IndexConfig[tableName].Override) > 0 {
 			tableName = cfg.IndexConfig[tableName].Override
 		}

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -16,7 +16,6 @@ import (
 	"quesma/quesma/types"
 	"quesma/schema"
 	"quesma/util"
-	"slices"
 )
 
 func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.FieldCapability, colName string, fieldType schema.QuesmaType, index string) {
@@ -51,7 +50,7 @@ func handleFieldCapsIndex(cfg *config.QuesmaConfiguration, schemaRegistry schema
 
 		if schemaDefinition, found := schemaRegistry.FindSchema(schema.TableName(resolvedIndex)); found {
 			indexConfig, configured := cfg.IndexConfig[resolvedIndex]
-			if configured && !slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) {
+			if configured && !indexConfig.IsClickhouseQueryEnabled() {
 				continue
 			}
 

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -16,6 +16,7 @@ import (
 	"quesma/quesma/types"
 	"quesma/schema"
 	"quesma/util"
+	"slices"
 )
 
 func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.FieldCapability, colName string, fieldType schema.QuesmaType, index string) {
@@ -50,7 +51,7 @@ func handleFieldCapsIndex(cfg *config.QuesmaConfiguration, schemaRegistry schema
 
 		if schemaDefinition, found := schemaRegistry.FindSchema(schema.TableName(resolvedIndex)); found {
 			indexConfig, configured := cfg.IndexConfig[resolvedIndex]
-			if configured && indexConfig.Disabled {
+			if configured && !slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) {
 				continue
 			}
 

--- a/quesma/quesma/functionality/field_capabilities/field_caps_test.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps_test.go
@@ -79,7 +79,9 @@ func TestFieldCaps(t *testing.T) {
 	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-generic-default": {
-				Name: "logs-generic-default",
+				Name:         "logs-generic-default",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 		},
 	}, schema.StaticRegistry{
@@ -141,7 +143,7 @@ func TestFieldCapsWithAliases(t *testing.T) {
   ]
 }`)
 	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
-		IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Name: "logs-generic-default"}},
+		IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Name: "logs-generic-default", QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}}},
 	}, schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
 			"logs-generic-default": {
@@ -183,10 +185,14 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
-				Name: "logs-1",
+				Name:         "logs-1",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 			"logs-2": {
-				Name: "logs-2",
+				Name:         "logs-2",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 		},
 	}, schema.StaticRegistry{
@@ -290,13 +296,19 @@ func TestFieldCapsMultipleIndexesConflictingEntries(t *testing.T) {
 	resp, err := handleFieldCapsIndex(&config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
 			"logs-1": {
-				Name: "logs-1",
+				Name:         "logs-1",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 			"logs-2": {
-				Name: "logs-2",
+				Name:         "logs-2",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 			"logs-3": {
-				Name: "logs-3",
+				Name:         "logs-3",
+				QueryTarget:  []string{config.ClickhouseTarget},
+				IngestTarget: []string{config.ClickhouseTarget},
 			},
 		},
 	}, schema.StaticRegistry{

--- a/quesma/quesma/matchers.go
+++ b/quesma/quesma/matchers.go
@@ -10,7 +10,6 @@ import (
 	"quesma/quesma/types"
 	"quesma/schema"
 	"quesma/tracing"
-	"slices"
 	"strings"
 )
 
@@ -34,7 +33,7 @@ func matchedAgainstBulkBody(configuration *config.QuesmaConfiguration) mux.Reque
 			}
 			if idx%2 == 0 {
 				indexConfig, found := configuration.IndexConfig[extractIndexName(s)]
-				if found && slices.Contains(indexConfig.IngestTarget, config.ClickhouseTarget) {
+				if found && indexConfig.IsClickhouseIngestEnabled() {
 					return true
 				}
 			}
@@ -74,7 +73,7 @@ func matchedAgainstPattern(configuration *config.QuesmaConfiguration, sr schema.
 			for _, pattern := range indexPatterns {
 				for _, indexName := range configuration.IndexConfig {
 					if config.MatchName(elasticsearch.NormalizePattern(pattern), indexName.Name) {
-						if slices.Contains(configuration.IndexConfig[indexName.Name].QueryTarget, config.ClickhouseTarget) {
+						if configuration.IndexConfig[indexName.Name].IsClickhouseQueryEnabled() {
 							return true
 						}
 					}
@@ -93,7 +92,7 @@ func matchedAgainstPattern(configuration *config.QuesmaConfiguration, sr schema.
 				pattern := elasticsearch.NormalizePattern(indexPattern)
 				if config.MatchName(pattern, index.Name) {
 					if indexConfig, exists := configuration.IndexConfig[index.Name]; exists {
-						return slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget)
+						return indexConfig.IsClickhouseQueryEnabled()
 					}
 				}
 			}
@@ -112,9 +111,9 @@ func matchedExact(cfg *config.QuesmaConfiguration, queryPath bool) mux.RequestMa
 		}
 		indexConfig, exists := cfg.IndexConfig[req.Params["index"]]
 		if queryPath {
-			return exists && slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget)
+			return exists && indexConfig.IsClickhouseQueryEnabled()
 		} else {
-			return exists && slices.Contains(indexConfig.IngestTarget, config.ClickhouseTarget)
+			return exists && indexConfig.IsClickhouseIngestEnabled()
 		}
 	})
 }

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -42,7 +42,7 @@ func Test_matchedAgainstConfig(t *testing.T) {
 
 			req := &mux.Request{Params: map[string]string{"index": tt.index}, Body: tt.body}
 
-			assert.Equalf(t, tt.want, matchedExact(&tt.config).Matches(req), "matchedAgainstConfig(%v), index: %s", tt.config, tt.index)
+			assert.Equalf(t, tt.want, matchedExactQueryPath(&tt.config).Matches(req), "matchedExactQueryPath(%v), index: %s", tt.config, tt.index)
 		})
 	}
 }
@@ -137,8 +137,14 @@ func Test_matchedAgainstPattern(t *testing.T) {
 	}
 }
 
-func indexConfig(name string, disabled bool) config.QuesmaConfiguration {
-	return config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{name: {Name: name, Disabled: disabled}}}
+func indexConfig(name string, elastic bool) config.QuesmaConfiguration {
+	var targets []string
+	if elastic {
+		targets = []string{config.ElasticsearchTarget}
+	} else {
+		targets = []string{config.ClickhouseTarget}
+	}
+	return config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{name: {Name: name, QueryTarget: targets, IngestTarget: targets}}}
 }
 
 func Test_matchedAgainstBulkBody(t *testing.T) {

--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -33,7 +33,7 @@ const defaultAsyncSearchTimeout = 1000
 
 const tableName = model.SingleTableNamePlaceHolder
 
-var DefaultConfig = config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {}}}
+var DefaultConfig = config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{tableName: {QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}}}}
 
 var ctx = context.WithValue(context.TODO(), tracing.RequestIdCtxKey, tracing.GetRequestId())
 

--- a/quesma/quesma/source_resolver.go
+++ b/quesma/quesma/source_resolver.go
@@ -39,7 +39,7 @@ func ResolveSources(indexPattern string, cfg *config.QuesmaConfiguration, im ela
 			}
 
 			for indexName, indexConfig := range cfg.IndexConfig {
-				if util.IndexPatternMatches(pattern, indexName) && !indexConfig.Disabled {
+				if util.IndexPatternMatches(pattern, indexName) && slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) {
 					matchesClickhouse = append(matchesClickhouse, indexName)
 				}
 			}
@@ -65,7 +65,7 @@ func ResolveSources(indexPattern string, cfg *config.QuesmaConfiguration, im ela
 		}
 	} else {
 		if c, exists := cfg.IndexConfig[indexPattern]; exists {
-			if !c.Disabled {
+			if slices.Contains(c.QueryTarget, config.ClickhouseTarget) {
 				return sourceClickhouse, []string{}, []string{indexPattern}
 			} else {
 				return sourceElasticsearch, []string{indexPattern}, []string{}

--- a/quesma/quesma/source_resolver.go
+++ b/quesma/quesma/source_resolver.go
@@ -39,7 +39,7 @@ func ResolveSources(indexPattern string, cfg *config.QuesmaConfiguration, im ela
 			}
 
 			for indexName, indexConfig := range cfg.IndexConfig {
-				if util.IndexPatternMatches(pattern, indexName) && slices.Contains(indexConfig.QueryTarget, config.ClickhouseTarget) {
+				if util.IndexPatternMatches(pattern, indexName) && indexConfig.IsClickhouseQueryEnabled() {
 					matchesClickhouse = append(matchesClickhouse, indexName)
 				}
 			}
@@ -65,7 +65,7 @@ func ResolveSources(indexPattern string, cfg *config.QuesmaConfiguration, im ela
 		}
 	} else {
 		if c, exists := cfg.IndexConfig[indexPattern]; exists {
-			if slices.Contains(c.QueryTarget, config.ClickhouseTarget) {
+			if c.IsClickhouseQueryEnabled() {
 				return sourceClickhouse, []string{}, []string{indexPattern}
 			} else {
 				return sourceElasticsearch, []string{indexPattern}, []string{}

--- a/quesma/quesma/source_resolver_test.go
+++ b/quesma/quesma/source_resolver_test.go
@@ -26,7 +26,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Index only in Clickhouse,pattern:",
 			args: args{
 				indexPattern: "test",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}}}},
 				im:           NewFixedIndexManagement(),
 			},
 			want: sourceClickhouse,
@@ -35,7 +35,7 @@ func TestResolveSources(t *testing.T) {
 			name: "Index only in Clickhouse,pattern:",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"test": {QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}}}},
 				im:           NewFixedIndexManagement(),
 			},
 			want: sourceClickhouse,
@@ -62,16 +62,16 @@ func TestResolveSources(t *testing.T) {
 			name: "Indexes both in Elasticsearch and Clickhouse",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"kibana-sample-data-logs": {}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"kibana-sample-data-logs": {QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}}}},
 				im:           NewFixedIndexManagement("logs-generic-default"),
 			},
 			want: sourceBoth,
 		},
 		{
-			name: "Indexes both in Elasticsearch and Clickhouse, but explicitly disabled",
+			name: "Indexes both in Elasticsearch and Clickhouse, but configured to Elastic",
 			args: args{
 				indexPattern: "*",
-				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {Disabled: true}}},
+				cfg:          config.QuesmaConfiguration{IndexConfig: map[string]config.IndexConfiguration{"logs-generic-default": {QueryTarget: []string{config.ElasticsearchTarget}, IngestTarget: []string{config.ElasticsearchTarget}}}},
 				im:           NewFixedIndexManagement("logs-generic-default"),
 			},
 			want: sourceElasticsearch,

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -8,7 +8,9 @@ import (
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/end_user_errors"
+	"quesma/quesma/config"
 	"quesma/util"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -60,7 +62,7 @@ func (qmc *QuesmaManagementConsole) generateQuesmaAllLogs() []byte {
 					continue
 				}
 
-				if indexConf.Disabled || !indexConf.UseCommonTable {
+				if (!slices.Contains(indexConf.QueryTarget, config.ClickhouseTarget) && !slices.Contains(indexConf.IngestTarget, config.ClickhouseTarget)) || !indexConf.UseCommonTable {
 					continue
 				}
 
@@ -405,7 +407,7 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 
 	buffer.Html("\n<table>")
 	buffer.Html(`<tr class="tableName" id="quesma-config">`)
-	buffer.Html(`<th colspan=2><h2>`)
+	buffer.Html(`<th colspan=4><h2>`)
 	buffer.Html(`Quesma Config`)
 	buffer.Html(`</h2></th>`)
 	buffer.Html(`</tr>`)
@@ -415,7 +417,10 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 	buffer.Html(`Name Pattern`)
 	buffer.Html(`</th>`)
 	buffer.Html(`<th>`)
-	buffer.Html(`Disabled?`)
+	buffer.Html(`Query targets`)
+	buffer.Html(`</th>`)
+	buffer.Html(`<th>`)
+	buffer.Html(`Ingest targets`)
 	buffer.Html(`</th>`)
 
 	buffer.Html(`</tr>`)
@@ -425,12 +430,14 @@ func (qmc *QuesmaManagementConsole) generateTables() []byte {
 		buffer.Html(`<td>`)
 		buffer.Text(cfg.Name)
 		buffer.Html(`</td>`)
+
+		// TODO: these are not the backend connector names, but config.ElasticsearchTarget and config.ClickhouseTarget
+		// constants
 		buffer.Html(`<td>`)
-		if cfg.Disabled {
-			buffer.Text("true")
-		} else {
-			buffer.Text("false")
-		}
+		buffer.Text(strings.Join(cfg.QueryTarget, ", "))
+		buffer.Html(`</td>`)
+		buffer.Html(`<td>`)
+		buffer.Text(strings.Join(cfg.IngestTarget, ", "))
 		buffer.Html(`</td>`)
 
 		buffer.Html(`</tr>`)

--- a/quesma/quesma/ui/tables.go
+++ b/quesma/quesma/ui/tables.go
@@ -8,9 +8,7 @@ import (
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/end_user_errors"
-	"quesma/quesma/config"
 	"quesma/util"
-	"slices"
 	"sort"
 	"strings"
 )
@@ -62,7 +60,7 @@ func (qmc *QuesmaManagementConsole) generateQuesmaAllLogs() []byte {
 					continue
 				}
 
-				if (!slices.Contains(indexConf.QueryTarget, config.ClickhouseTarget) && !slices.Contains(indexConf.IngestTarget, config.ClickhouseTarget)) || !indexConf.UseCommonTable {
+				if (!indexConf.IsClickhouseQueryEnabled() && !indexConf.IsClickhouseIngestEnabled()) || !indexConf.UseCommonTable {
 					continue
 				}
 

--- a/quesma/schema/registry_test.go
+++ b/quesma/schema/registry_test.go
@@ -282,7 +282,7 @@ func Test_schemaRegistry_UpdateDynamicConfiguration(t *testing.T) {
 	tableName := "some_table"
 	cfg := config.QuesmaConfiguration{
 		IndexConfig: map[string]config.IndexConfiguration{
-			tableName: {Disabled: false},
+			tableName: {QueryTarget: []string{config.ClickhouseTarget}, IngestTarget: []string{config.ClickhouseTarget}},
 		},
 	}
 	tableDiscovery := fixedTableProvider{tables: map[string]schema.Table{


### PR DESCRIPTION
This commit removes the `disabled` option from index configuration, as it's now possible to reflect it via target configuration:

Previously:

```yaml
my_index:
  disabled: true
```

Now:

```yaml
my_index:
  target: [ "my-elastic-connector" ]
```

This highlights a problem with `disabled` - it meant that the index should be read/written from Elastic, but a user might have incorrectly thought that `disabled` means that all queries to the index will get rejected.

Upon removing `disabled`, all internal Quesma code is now modified to use the `QueryTarget` and `IngestTarget` arrays directly, paving the way for more flexible target configuration in the future (next PRs).