### PR TITLE
Common table - query multiple indexes 

### DIFF
--- a/quesma/end_user_errors/end_user.go
+++ b/quesma/end_user_errors/end_user.go
@@ -93,6 +93,7 @@ var ErrExpectedNDJSON = errorType(1002, "Invalid request body. We're expecting N
 
 var ErrSearchCondition = errorType(2001, "Not supported search condition.")
 var ErrNoSuchTable = errorType(2002, "Missing table.")
+var ErrNoSuchSchema = errorType(2003, "Missing schema.")
 
 var ErrDatabaseTableNotFound = errorType(3001, "Table not found in database.")
 var ErrDatabaseFieldNotFound = errorType(3002, "Field not found in database.")

--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -88,7 +88,7 @@ func (cw *ClickhouseEQLQueryTranslator) ParseQuery(body types.JSON) (*model.Exec
 	if simpleQuery.CanParse {
 
 		query = query_util.BuildHitsQuery(cw.Ctx, cw.Table.Name, []string{"*"}, &simpleQuery, queryInfo.Size)
-		queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, query.SelectCommand.OrderByFieldNames(), true, false, false, cw.Table.Name)
+		queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, query.SelectCommand.OrderByFieldNames(), true, false, false, []string{cw.Table.Name})
 		query.Type = &queryType
 		query.Highlighter = highlighter
 		query.SelectCommand.OrderBy = simpleQuery.OrderBy

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -3,6 +3,7 @@
 package model
 
 import (
+	"quesma/schema"
 	"time"
 )
 
@@ -47,7 +48,12 @@ type (
 		TransformationHistory TransformationHistory // it can be optional
 
 		Type      QueryType
-		TableName string
+		TableName string // TODO delete this and use MatchedIndexes instead
+
+		MatchedIndexes []string // list of indexes we're going to use for this query
+
+		// this is schema for current query, this schema should be used in pipeline processing
+		Schema schema.Schema
 
 		Highlighter Highlighter
 

--- a/quesma/model/query.go
+++ b/quesma/model/query.go
@@ -48,9 +48,9 @@ type (
 		TransformationHistory TransformationHistory // it can be optional
 
 		Type      QueryType
-		TableName string // TODO delete this and use MatchedIndexes instead
+		TableName string // TODO delete this and use Indexes instead
 
-		MatchedIndexes []string // list of indexes we're going to use for this query
+		Indexes []string // list of indexes we're going to use for this query
 
 		// this is schema for current query, this schema should be used in pipeline processing
 		Schema schema.Schema

--- a/quesma/model/typical_queries/hits.go
+++ b/quesma/model/typical_queries/hits.go
@@ -11,6 +11,7 @@ import (
 	"quesma/model"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -28,15 +29,15 @@ type Hits struct {
 	addSource          bool // true <=> we add hit.Source field to the response
 	addScore           bool // true <=> we add hit.Score field to the response (whose value is always 1)
 	addVersion         bool // true <=> we add hit.Version field to the response (whose value is always 1)
-	indexName          string
+	indexes            []string
 	timestampFieldName string
 }
 
 func NewHits(ctx context.Context, table *clickhouse.Table, highlighter *model.Highlighter,
-	sortFieldNames []string, addSource, addScore, addVersion bool, incomingIndexName string) Hits {
+	sortFieldNames []string, addSource, addScore, addVersion bool, indexes []string) Hits {
 
 	return Hits{ctx: ctx, table: table, highlighter: highlighter, sortFieldNames: sortFieldNames,
-		addSource: addSource, addScore: addScore, addVersion: addVersion, indexName: incomingIndexName}
+		addSource: addSource, addScore: addScore, addVersion: addVersion, indexes: indexes}
 }
 
 const (
@@ -49,9 +50,14 @@ func (query Hits) AggregationType() model.AggregationType {
 }
 
 func (query Hits) TranslateSqlResponseToJson(rows []model.QueryResultRow) model.JsonMap {
+
+	// TODO add proper handling of multiple indexes
+	// right now return result row for multiple index
+	indexName := query.indexes[0]
+
 	hits := make([]model.SearchHit, 0, len(rows))
 	for i, row := range rows {
-		hit := model.NewSearchHit(query.indexName)
+		hit := model.NewSearchHit(indexName)
 		if query.addScore {
 			hit.Score = defaultScore
 		}
@@ -163,5 +169,5 @@ func (query Hits) computeIdForDocument(doc model.SearchHit, defaultID string) st
 }
 
 func (query Hits) String() string {
-	return fmt.Sprintf("hits(table: %v)", query.indexName)
+	return fmt.Sprintf("hits(indexes: %v)", strings.Join(query.indexes, ", "))
 }

--- a/quesma/queryparser/aggregation_parser_new_logic_test.go
+++ b/quesma/queryparser/aggregation_parser_new_logic_test.go
@@ -55,7 +55,7 @@ func Test3AggregationParserNewLogic(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Schema: s.Tables[schema.TableName(tableName)]}
 
 	for i, test := range testdata.NewLogicTestCases {
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -724,7 +724,7 @@ func Test_parseFieldFromScriptField(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{Ctx: context.Background(), Schema: s.Tables["logs-generic-default"]}
 	for _, tc := range testcases {
 		field, success := cw.parseFieldFromScriptField(tc.queryMap)
 		assert.Equal(t, tc.expectedSuccess, success)

--- a/quesma/queryparser/aggregation_percentile_parser_test.go
+++ b/quesma/queryparser/aggregation_percentile_parser_test.go
@@ -34,7 +34,7 @@ func Test_parsePercentilesAggregationWithDefaultPercents(t *testing.T) {
 			},
 		},
 	}
-	cw := &ClickhouseQueryTranslator{Table: &clickhouse.Table{}, Ctx: context.Background(), SchemaRegistry: s}
+	cw := &ClickhouseQueryTranslator{Table: &clickhouse.Table{}, Ctx: context.Background(), Schema: s.Tables[schema.TableName("logs-generic-default")]}
 	field, _, userSpecifiedPercents := cw.parsePercentilesAggregation(payload)
 	assert.Equal(t, model.NewColumnRef("custom_name"), field)
 	assert.Equal(t, defaultPercentiles, userSpecifiedPercents)
@@ -81,7 +81,7 @@ func Test_parsePercentilesAggregationWithUserSpecifiedPercents(t *testing.T) {
 			},
 		},
 	}
-	cw := &ClickhouseQueryTranslator{Table: &clickhouse.Table{}, Ctx: context.Background(), SchemaRegistry: s}
+	cw := &ClickhouseQueryTranslator{Table: &clickhouse.Table{}, Ctx: context.Background(), Schema: s.Tables[schema.TableName("logs-generic-default")]}
 	fieldName, _, parsedMap := cw.parsePercentilesAggregation(payload)
 	assert.Equal(t, model.NewColumnRef("custom_name"), fieldName)
 

--- a/quesma/queryparser/lucene/expression.go
+++ b/quesma/queryparser/lucene/expression.go
@@ -60,8 +60,8 @@ func (p *luceneParser) buildWhereStatement(addDefaultOperator bool) model.Expr {
 			return invalidStatement
 		}
 		p.tokens = p.tokens[1:]
-		if name, resolved := p.fieldNameResolver.ResolveFieldName(currentToken.fieldName); resolved {
-			currentStatement = newLeafStatement([]string{name}, p.buildValue([]value{}, 0))
+		if name, resolved := p.currentSchema.ResolveField(currentToken.fieldName); resolved {
+			currentStatement = newLeafStatement([]string{name.InternalPropertyName.AsString()}, p.buildValue([]value{}, 0))
 		} else {
 			currentStatement = newLeafStatement([]string{currentToken.fieldName}, p.buildValue([]value{}, 0))
 		}

--- a/quesma/queryparser/lucene/lucene_parser.go
+++ b/quesma/queryparser/lucene/lucene_parser.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"quesma/logger"
 	"quesma/model"
+	"quesma/schema"
 	"slices"
 	"strconv"
 	"strings"
@@ -36,18 +37,16 @@ type (
 		ctx               context.Context
 		tokens            []token
 		defaultFieldNames []string
-		fieldNameResolver fieldNameResolver
 		// This is a little awkward, at some point we should remove `WhereStatement` and just return the statement from `BuildWhereStatement`
 		// However, given parsing implementation, it's easier to keep it for now.
 		WhereStatement model.Expr
-	}
-	fieldNameResolver interface {
-		ResolveFieldName(fieldName string) (string, bool)
+
+		currentSchema schema.Schema
 	}
 )
 
-func newLuceneParser(ctx context.Context, defaultFieldNames []string, resolver fieldNameResolver) luceneParser {
-	return luceneParser{ctx: ctx, defaultFieldNames: defaultFieldNames, tokens: make([]token, 0), fieldNameResolver: resolver}
+func newLuceneParser(ctx context.Context, defaultFieldNames []string, currentSchema schema.Schema) luceneParser {
+	return luceneParser{ctx: ctx, defaultFieldNames: defaultFieldNames, tokens: make([]token, 0), currentSchema: currentSchema}
 }
 
 const fuzzyOperator = '~'
@@ -73,8 +72,8 @@ var specialOperators = map[string]token{
 	string(rightParenthesis): rightParenthesisToken{},
 }
 
-func TranslateToSQL(ctx context.Context, query string, fields []string, resolver fieldNameResolver) model.Expr {
-	parser := newLuceneParser(ctx, fields, resolver)
+func TranslateToSQL(ctx context.Context, query string, fields []string, currentSchema schema.Schema) model.Expr {
+	parser := newLuceneParser(ctx, fields, currentSchema)
 	return parser.translateToSQL(query)
 }
 

--- a/quesma/queryparser/lucene/lucene_parser_test.go
+++ b/quesma/queryparser/lucene/lucene_parser_test.go
@@ -129,12 +129,3 @@ func TestResolvePropertyNamesWhenTranslatingToSQL(t *testing.T) {
 		})
 	}
 }
-
-type fixedFieldNameResolver struct {
-	namesMap map[string]string
-}
-
-func (f fixedFieldNameResolver) ResolveFieldName(fieldName string) (string, bool) {
-	name, exists := f.namesMap[fieldName]
-	return name, exists
-}

--- a/quesma/queryparser/pancake_aggregation_parser_buckets.go
+++ b/quesma/queryparser/pancake_aggregation_parser_buckets.go
@@ -80,6 +80,7 @@ func (cw *ClickhouseQueryTranslator) pancakeTryBucketAggregation(aggregation *pa
 		minDocCount := cw.parseMinDocCount(dateHistogram)
 		timezone := cw.parseStringField(dateHistogram, "time_zone", "")
 		interval, intervalType := cw.extractInterval(dateHistogram)
+		// TODO  GetDateTimeTypeFromExpr can be moved and it should take cw.Schema as an argument
 		dateTimeType := cw.Table.GetDateTimeTypeFromExpr(cw.Ctx, field)
 
 		if dateTimeType == clickhouse.Invalid {

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -37,9 +37,14 @@ func TestPancakeQueryGeneration(t *testing.T) {
 	}
 
 	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
-	schemaRegistry := schema.StaticRegistry{}
+	currentSchema := schema.Schema{
+		Fields:             nil,
+		Aliases:            nil,
+		ExistsInDataSource: false,
+		DatabaseName:       "",
+	}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: schemaRegistry}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Schema: currentSchema}
 
 	for i, test := range allAggregationTests() {
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {
@@ -207,9 +212,10 @@ func TestPancakeQueryGeneration_halfpancake(t *testing.T) {
 	}
 
 	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, &table), &config.QuesmaConfiguration{})
-	schemaRegistry := schema.StaticRegistry{}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: schemaRegistry}
+	currentSchema := schema.Schema{}
+
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Schema: currentSchema}
 
 	tests := []struct {
 		name string

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -81,10 +81,10 @@ func (cw *ClickhouseQueryTranslator) ParseQuery(body types.JSON) (*model.Executi
 		}
 	}
 
-	// Here we add physical table name.
-	// This is a temporary solution, we should resolve table name later
 	for _, query := range queries {
-		query.TableName = cw.Table.Name
+		query.TableName = cw.Table.Name // TODO remove this line
+		query.Indexes = cw.Indexes
+		query.Schema = cw.Schema
 	}
 
 	plan := &model.ExecutionPlan{
@@ -109,7 +109,7 @@ func (cw *ClickhouseQueryTranslator) buildListQueryIfNeeded(
 	if fullQuery != nil {
 		highlighter.SetTokensToHighlight(fullQuery.SelectCommand)
 		// TODO: pass right arguments
-		queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, fullQuery.SelectCommand.OrderByFieldNames(), true, false, false, cw.IncomingIndexName)
+		queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, fullQuery.SelectCommand.OrderByFieldNames(), true, false, false, cw.Indexes)
 		fullQuery.Type = &queryType
 		fullQuery.Highlighter = highlighter
 	}
@@ -380,6 +380,7 @@ func (cw *ClickhouseQueryTranslator) parseIds(queryMap QueryMap) model.SimpleQue
 	}
 
 	var whereStmt model.Expr
+	// TODO replace with cw.Schema
 	if v, ok := cw.Table.Cols[timestampColumnName]; ok {
 		switch v.Type.String() {
 		case clickhouse.DateTime64.String():

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -742,21 +742,6 @@ func (cw *ClickhouseQueryTranslator) parseQueryString(queryMap QueryMap) model.S
 	return model.NewSimpleQuery(whereStmtFromLucene, true)
 }
 
-type schemaRegistryAdapter struct {
-	tableName string
-	schema.Registry
-}
-
-func (s schemaRegistryAdapter) ResolveFieldName(fieldName string) (string, bool) {
-	if resolvedSchema, exists := s.Registry.FindSchema(schema.TableName(s.tableName)); exists {
-		if field, fieldFound := resolvedSchema.ResolveField(fieldName); fieldFound {
-			return field.InternalPropertyName.AsString(), true
-		}
-	}
-
-	return fieldName, false
-}
-
 func (cw *ClickhouseQueryTranslator) parseNested(queryMap QueryMap) model.SimpleQuery {
 	if query, ok := queryMap["query"]; ok {
 		if queryAsMap, ok := query.(QueryMap); ok {

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -1182,6 +1182,7 @@ func (cw *ClickhouseQueryTranslator) parseSortFields(sortMaps any) (sortColumns 
 
 			// sortMap has only 1 key, so we can just iterate over it
 			for k, v := range sortMap {
+				// TODO replace cw.Table.GetFieldInfo with schema.Field[]
 				if strings.HasPrefix(k, "_") && cw.Table.GetFieldInfo(cw.Ctx, cw.ResolveField(cw.Ctx, k)) == clickhouse.NotExists {
 					// we're skipping ELK internal fields, like "_doc", "_id", etc.
 					continue

--- a/quesma/queryparser/query_parser_async_search_test.go
+++ b/quesma/queryparser/query_parser_async_search_test.go
@@ -44,7 +44,7 @@ func TestQueryParserAsyncSearch(t *testing.T) {
 		},
 	}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Schema: s.Tables["logs-generic-default"]}
 	for _, tt := range testdata.TestsAsyncSearch {
 		t.Run(tt.Name, func(t *testing.T) {
 			query, queryInfo, _ := cw.ParseQueryAsyncSearch(tt.QueryJson)
@@ -77,7 +77,7 @@ func TestQueryParserAggregation(t *testing.T) {
 		},
 	}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Schema: s.Tables["tablename"]}
 	for _, tt := range testdata.AggregationTests {
 		t.Run(tt.TestName, func(t *testing.T) {
 			cw.ParseQueryAsyncSearch(tt.QueryRequestJson)

--- a/quesma/queryparser/query_parser_range_test.go
+++ b/quesma/queryparser/query_parser_range_test.go
@@ -103,7 +103,7 @@ func Test_parseRange(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
-			cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+			cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Schema: s.Tables[schema.TableName(tableName)]}
 
 			simpleQuery := cw.parseRange(test.rangePartOfQuery)
 			assert.Equal(t, test.expectedWhere, simpleQuery.WhereClauseAsString())

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -64,7 +64,7 @@ func TestQueryParserStringAttrConfig(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Config: &cfg, Schema: s.Tables[schema.TableName(tableName)]}
 
 	for i, tt := range testdata.TestsSearch {
 		t.Run(fmt.Sprintf("%s(%d)", tt.Name, i), func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestQueryParserNoFullTextFields(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Config: &cfg, Schema: s.Tables[schema.TableName(tableName)]}
 
 	for i, tt := range testdata.TestsSearchNoFullTextFields {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -195,7 +195,7 @@ func TestQueryParserNoAttrsConfig(t *testing.T) {
 		},
 	}
 	lm := clickhouse.NewLogManager(concurrent.NewMapWith(tableName, table), &config.QuesmaConfiguration{})
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s, Config: &cfg}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Config: &cfg, Schema: s.Tables["logs-generic-default"]}
 	for _, tt := range testdata.TestsSearchNoAttrs {
 		t.Run(tt.Name, func(t *testing.T) {
 			body, parseErr := types.ParseJSON(tt.QueryJson)
@@ -419,7 +419,7 @@ func TestNew(t *testing.T) {
 		},
 	}
 
-	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Schema: s.Tables[schema.TableName("logs-generic-default")]}
 	for _, tt := range tests {
 		t.Run("test", func(t *testing.T) {
 			simpleQuery, _, _ := cw.ParseQueryAsyncSearch(tt)

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -19,14 +19,17 @@ type JsonMap = map[string]interface{}
 
 type ClickhouseQueryTranslator struct {
 	ClickhouseLM *clickhouse.LogManager
-	Table        *clickhouse.Table // TODO this will be removed
-	Ctx          context.Context
+
+	Schema schema.Schema // This should be use instead
+	Ctx    context.Context
 
 	DateMathRenderer string // "clickhouse_interval" or "literal"  if not set, we use "clickhouse_interval"
 
-	SchemaRegistry    schema.Registry
 	IncomingIndexName string
 	Config            *config.QuesmaConfiguration
+
+	// TODO this will be removed
+	Table *clickhouse.Table
 }
 
 var completionStatusOK = func() *int { value := 200; return &value }()

--- a/quesma/queryparser/query_translator.go
+++ b/quesma/queryparser/query_translator.go
@@ -20,13 +20,14 @@ type JsonMap = map[string]interface{}
 type ClickhouseQueryTranslator struct {
 	ClickhouseLM *clickhouse.LogManager
 
-	Schema schema.Schema // This should be use instead
+	Schema schema.Schema
 	Ctx    context.Context
 
 	DateMathRenderer string // "clickhouse_interval" or "literal"  if not set, we use "clickhouse_interval"
 
-	IncomingIndexName string
-	Config            *config.QuesmaConfiguration
+	Indexes []string
+
+	Config *config.QuesmaConfiguration
 
 	// TODO this will be removed
 	Table *clickhouse.Table

--- a/quesma/queryparser/query_translator_test.go
+++ b/quesma/queryparser/query_translator_test.go
@@ -78,7 +78,7 @@ func TestSearchResponse(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{Table: &clickhouse.Table{Name: "test"}, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{Table: &clickhouse.Table{Name: "test"}, Ctx: context.Background(), Schema: s.Tables["test"]}
 	searchResp, err := cw.MakeAsyncSearchResponse(row, &model.Query{Highlighter: NewEmptyHighlighter()}, asyncRequestIdStr, false)
 	require.NoError(t, err)
 	searchRespBuf, err2 := searchResp.Marshal()
@@ -177,7 +177,7 @@ func TestMakeResponseSearchQuery(t *testing.T) {
 			},
 		},
 	}
-	cw := ClickhouseQueryTranslator{Table: &clickhouse.Table{Name: "test"}, Ctx: context.Background(), SchemaRegistry: s}
+	cw := ClickhouseQueryTranslator{Table: &clickhouse.Table{Name: "test"}, Ctx: context.Background(), Schema: s.Tables["test"]}
 	for i, tt := range args {
 		t.Run(tt.queryType.String(), func(t *testing.T) {
 			hitQuery := query_util.BuildHitsQuery(
@@ -185,7 +185,7 @@ func TestMakeResponseSearchQuery(t *testing.T) {
 				&model.SimpleQuery{FieldName: "*"}, model.WeNeedUnlimitedCount,
 			)
 			highlighter := NewEmptyHighlighter()
-			queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, hitQuery.SelectCommand.OrderByFieldNames(), true, false, false, cw.Table.Name)
+			queryType := typical_queries.NewHits(cw.Ctx, cw.Table, &highlighter, hitQuery.SelectCommand.OrderByFieldNames(), true, false, false, []string{cw.Table.Name})
 			hitQuery.Type = &queryType
 			ourResponseRaw := cw.MakeSearchResponse(
 				[]*model.Query{hitQuery},

--- a/quesma/quesma/functionality/terms_enum/terms_enum_test.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum_test.go
@@ -106,7 +106,7 @@ func testHandleTermsEnumRequest(t *testing.T, requestBody []byte) {
 			},
 		},
 	}
-	qt := &queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), SchemaRegistry: s}
+	qt := &queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: table, Ctx: context.Background(), Schema: s.Tables[schema.TableName(testTableName)]}
 	// Here we additionally verify that terms for `_tier` are **NOT** included in the SQL query
 	expectedQuery1 := `SELECT DISTINCT "client_name" FROM ` + testTableName + ` WHERE ("epoch_time">=parseDateTimeBestEffort('2024-02-27T12:25:00.000Z') AND "epoch_time"<=parseDateTimeBestEffort('2024-02-27T12:40:59.999Z')) LIMIT 13`
 	expectedQuery2 := `SELECT DISTINCT "client_name" FROM ` + testTableName + ` WHERE ("epoch_time"<=parseDateTimeBestEffort('2024-02-27T12:40:59.999Z') AND "epoch_time">=parseDateTimeBestEffort('2024-02-27T12:25:00.000Z')) LIMIT 13`

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -33,11 +33,11 @@ const (
 	QueryLanguageEQL     = "eql"
 )
 
-func NewQueryTranslator(ctx context.Context, language QueryLanguage, schema schema.Schema, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, incomingIndexName string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
+func NewQueryTranslator(ctx context.Context, language QueryLanguage, schema schema.Schema, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, indexes []string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
 	switch language {
 	case QueryLanguageEQL:
 		return &eql.ClickhouseEQLQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx}
 	default:
-		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer, IncomingIndexName: incomingIndexName, Config: configuration, Schema: schema}
+		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer, Indexes: indexes, Config: configuration, Schema: schema}
 	}
 }

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -33,11 +33,11 @@ const (
 	QueryLanguageEQL     = "eql"
 )
 
-func NewQueryTranslator(ctx context.Context, language QueryLanguage, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, schemaRegistry schema.Registry, incomingIndexName string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
+func NewQueryTranslator(ctx context.Context, language QueryLanguage, schema schema.Schema, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, incomingIndexName string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
 	switch language {
 	case QueryLanguageEQL:
 		return &eql.ClickhouseEQLQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx}
 	default:
-		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer, SchemaRegistry: schemaRegistry, IncomingIndexName: incomingIndexName, Config: configuration}
+		return &queryparser.ClickhouseQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx, DateMathRenderer: dateMathRenderer, IncomingIndexName: incomingIndexName, Config: configuration, Schema: schema}
 	}
 }

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -348,8 +348,8 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 	}
 
 	var useCommonTable bool
-	if len(query.MatchedIndexes) == 1 {
-		indexConf, ok := s.cfg[query.MatchedIndexes[0]]
+	if len(query.Indexes) == 1 {
+		indexConf, ok := s.cfg[query.Indexes[0]]
 		if !ok {
 			return query, fmt.Errorf("index configuration not found for table %s", query.TableName)
 		}
@@ -411,7 +411,7 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 
 			var indexWhere []model.Expr
 
-			for _, indexName := range query.MatchedIndexes {
+			for _, indexName := range query.Indexes {
 				indexWhere = append(indexWhere, model.NewInfixExpr(model.NewColumnRef(common_table.IndexNameColumn), "=", model.NewLiteral(fmt.Sprintf("'%s'", indexName))))
 			}
 

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -614,7 +614,9 @@ func (s *SchemaCheckPass) applyTimestampField(indexSchema schema.Schema, query *
 
 func (s *SchemaCheckPass) handleDottedTColumnNames(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
 
-	var doCompensation bool
+	// TODO this is a workaround for now,
+	// if we set true dashboards are working but not tests
+	doCompensation := false
 
 	visitor := model.NewBaseVisitor()
 
@@ -624,7 +626,7 @@ func (s *SchemaCheckPass) handleDottedTColumnNames(indexSchema schema.Schema, qu
 			logger.Warn().Msgf("Dotted column name found: %s", e.ColumnName)
 
 			if doCompensation {
-				return model.NewColumnRef(strings.ReplaceAll(e.ColumnName, ".", "::"))
+				return model.NewColumnRef(util.FieldToColumnEncoder(e.ColumnName))
 			}
 
 		}

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -15,8 +15,7 @@ import (
 )
 
 type SchemaCheckPass struct {
-	cfg            map[string]config.IndexConfiguration
-	schemaRegistry schema.Registry
+	cfg map[string]config.IndexConfiguration
 }
 
 func (s *SchemaCheckPass) applyBooleanLiteralLowering(index schema.Schema, query *model.Query) (*model.Query, error) {
@@ -609,13 +608,17 @@ func (s *SchemaCheckPass) applyTimestampField(indexSchema schema.Schema, query *
 
 func (s *SchemaCheckPass) handleDottedTColumnNames(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
 
+	var doCompensation bool
+
 	visitor := model.NewBaseVisitor()
 
 	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
 
 		if strings.Contains(e.ColumnName, ".") {
 			logger.Warn().Msgf("Dotted column name found: %s", e.ColumnName)
-			return model.NewColumnRef(strings.ReplaceAll(e.ColumnName, ".", "::"))
+			if doCompensation {
+				return model.NewColumnRef(strings.ReplaceAll(e.ColumnName, ".", "::"))
+			}
 		}
 		return e
 	}

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -470,6 +470,10 @@ func (s *SchemaCheckPass) applyWildcardExpansion(indexSchema schema.Schema, quer
 		}
 	}
 
+	if len(newColumns) == 0 {
+		return nil, fmt.Errorf("applyWildcardExpansion: no columns found in the query")
+	}
+
 	query.SelectCommand.Columns = newColumns
 
 	return query, nil

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -358,6 +358,7 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 		useCommonTable = true
 	}
 
+	// TODO here we should read table name from `query.Schema`
 	physicalFromExpression := model.NewTableRefWithDatabaseName(query.TableName, currentSchema.DatabaseName)
 
 	if useCommonTable {

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -75,7 +75,7 @@ func Test_ipRangeTransform(t *testing.T) {
 			}},
 		}}
 	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s}
+	transform := &SchemaCheckPass{cfg: indexConfig}
 
 	selectColumns := []model.Expr{model.NewColumnRef("message")}
 
@@ -422,13 +422,7 @@ func Test_arrayType(t *testing.T) {
 		},
 	}
 
-	schemaRegistry := &schema.StaticRegistry{
-		Tables: map[schema.TableName]schema.Schema{
-			"kibana_sample_data_ecommerce": indexSchema,
-		},
-	}
-
-	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: schemaRegistry}
+	transform := &SchemaCheckPass{cfg: indexConfig}
 
 	tests := []struct {
 		name     string
@@ -564,6 +558,8 @@ func Test_arrayType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.query.Schema = indexSchema
+			tt.query.Indexes = []string{tt.query.TableName}
 			actual, err := transform.Transform([]*model.Query{tt.query})
 			assert.NoError(t, err)
 
@@ -603,7 +599,7 @@ func TestApplyWildCard(t *testing.T) {
 		},
 	}
 
-	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s}
+	transform := &SchemaCheckPass{cfg: indexConfig}
 
 	tests := []struct {
 		name     string
@@ -693,7 +689,7 @@ func TestApplyPhysicalFromExpression(t *testing.T) {
 	td.Store(tableDefinition.Name, &tableDefinition)
 
 	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-	transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s}
+	transform := &SchemaCheckPass{cfg: indexConfig}
 
 	tests := []struct {
 		name     string
@@ -809,6 +805,8 @@ func TestApplyPhysicalFromExpression(t *testing.T) {
 			query := &model.Query{
 				TableName:     "test",
 				SelectCommand: tt.input,
+				Schema:        indexSchema,
+				Indexes:       []string{"test"},
 			}
 
 			expectedAsString := model.AsString(tt.expected)
@@ -952,7 +950,7 @@ func TestFullTextFields(t *testing.T) {
 			}
 
 			s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-			transform := &SchemaCheckPass{cfg: indexConfig, schemaRegistry: s}
+			transform := &SchemaCheckPass{cfg: indexConfig}
 
 			indexSchema, ok := s.FindSchema("test")
 			if !ok {

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -381,8 +381,22 @@ func Test_ipRangeTransform(t *testing.T) {
 				}},
 		},
 	}
+
 	for k := range queries {
 		t.Run(strconv.Itoa(k), func(t *testing.T) {
+
+			queriesToTransform := queries[k]
+
+			for _, q := range queriesToTransform {
+
+				currentSchema, ok := s.FindSchema(schema.TableName(q.TableName))
+				if !ok {
+					t.Fatalf("schema not found for table %s", q.TableName)
+				}
+				q.Schema = currentSchema
+				q.Indexes = []string{q.TableName}
+			}
+
 			resultQueries, err := transform.Transform(queries[k])
 			assert.NoError(t, err)
 			assert.Equal(t, expectedQueries[k].SelectCommand.String(), resultQueries[0].SelectCommand.String())

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -407,10 +407,8 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 				return []byte{}, end_user_errors.ErrNoSuchTable.New(fmt.Errorf("can't load %s schema", idx)).Details("Table: %s", idx)
 			}
 
-			for fieldName, _ := range scm.Fields {
+			for fieldName := range scm.Fields {
 				// here we construct our runtime  schema by merging fields from all resolved indexes
-				fmt.Println("XXX ", idx, fieldName, scm.Fields[fieldName])
-
 				resolvedSchema.Fields[fieldName] = scm.Fields[fieldName]
 			}
 		}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -811,6 +811,7 @@ func (q *QueryRunner) findNonexistingProperties(query *model.Query, table *click
 	}
 	allReferencedFields = append(allReferencedFields, query.SelectCommand.OrderByFieldNames()...)
 
+	// TODO This should be done using query.Schema instead of table
 	for _, property := range allReferencedFields {
 		queryTranslatorValue, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator)
 		if ok {
@@ -823,7 +824,7 @@ func (q *QueryRunner) findNonexistingProperties(query *model.Query, table *click
 	return results
 }
 
-func (q *QueryRunner) postProcessResults(plan model.ExecutionPlan, results [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {
+func (q *QueryRunner) postProcessResults(plan *model.ExecutionPlan, results [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {
 
 	if len(plan.Queries) == 0 {
 		return nil, fmt.Errorf("postProcessResults: plan.Queries is empty")

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -335,7 +335,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		return nil, err
 	}
 
-	var table *clickhouse.Table
+	var table *clickhouse.Table // TODO we should use schema here only
 	var currentSchema schema.Schema
 	resolvedIndexes := sourcesClickhouse
 
@@ -343,7 +343,6 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		indexName := resolvedIndexes[0] // we got exactly one table here because of the check above
 		resolvedTableName := indexName
 
-		// TODO this will be removed
 		if len(q.cfg.IndexConfig[indexName].Override) > 0 {
 			resolvedTableName = q.cfg.IndexConfig[indexName].Override
 		}
@@ -435,11 +434,6 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		bodyAsBytes, _ := body.Bytes()
 		pushSecondaryInfo(q.quesmaManagementConsole, id, "", path, bodyAsBytes, queriesBody, responseBody, startTime)
 		return responseBody, errors.New(string(responseBody))
-	}
-
-	for _, query := range plan.Queries {
-		query.Indexes = resolvedIndexes
-		query.Schema = currentSchema
 	}
 
 	plan.IndexPattern = indexPattern

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -82,7 +82,7 @@ func NewQueryRunner(lm *clickhouse.LogManager, cfg *config.QuesmaConfiguration, 
 		AsyncQueriesContexts: concurrent.NewMap[string, *AsyncQueryContext](),
 		transformationPipeline: TransformationPipeline{
 			transformers: []model.QueryTransformer{
-				&SchemaCheckPass{cfg: cfg.IndexConfig, schemaRegistry: schemaRegistry},
+				&SchemaCheckPass{cfg: cfg.IndexConfig},
 			},
 		},
 		schemaRegistry:  schemaRegistry,

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -335,7 +335,6 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		return nil, err
 	}
 
-	var incomingIndexName string
 	var resolvedTableName string
 	var table *clickhouse.Table
 	var currentSchema schema.Schema
@@ -411,7 +410,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		resolvedTableName = common_table.TableName
 	}
 
-	queryTranslator := NewQueryTranslator(ctx, queryLanguage, currentSchema, table, q.logManager, q.DateMathRenderer, incomingIndexName, q.cfg)
+	queryTranslator := NewQueryTranslator(ctx, queryLanguage, currentSchema, table, q.logManager, q.DateMathRenderer, resolvedIndexes, q.cfg)
 
 	plan, err := queryTranslator.ParseQuery(body)
 
@@ -432,7 +431,7 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 	}
 
 	for _, query := range plan.Queries {
-		query.MatchedIndexes = resolvedIndexes
+		query.Indexes = resolvedIndexes
 		query.Schema = currentSchema
 	}
 

--- a/quesma/quesma/search_alternative.go
+++ b/quesma/quesma/search_alternative.go
@@ -115,7 +115,14 @@ func (q *QueryRunner) runAlternativePlanAndComparison(ctx context.Context, plan 
 	return optComparePlansCh
 }
 
-func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, resolvedTableName string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
+func (q *QueryRunner) maybeCreateAlternativeExecutionPlan(ctx context.Context, indexes []string, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, body types.JSON, table *clickhouse.Table, isAsync bool) (*model.ExecutionPlan, executionPlanExecutor) {
+
+	// TODO not sure how to check configure when we have multiple indexes
+	if len(indexes) != 1 {
+		return nil, nil
+	}
+
+	resolvedTableName := indexes[0]
 
 	props, disabled := q.cfg.IndexConfig[resolvedTableName].GetOptimizerConfiguration(queryparser.PancakeOptimizerName)
 	if !disabled && props["mode"] == "alternative" {

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -112,7 +112,7 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 	go managementConsole.RunOnlyChannelProcessor()
 	s := schema.StaticRegistry{
 		Tables: map[schema.TableName]schema.Schema{
-			"logs-generic-default": {
+			tableName: {
 				Fields: map[schema.FieldName]schema.Field{
 					"host.name":         {PropertyName: "host.name", InternalPropertyName: "host.name", Type: schema.QuesmaTypeObject},
 					"type":              {PropertyName: "type", InternalPropertyName: "type", Type: schema.QuesmaTypeText},

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -45,7 +45,7 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 			go managementConsole.RunOnlyChannelProcessor()
 			s := schema.StaticRegistry{
 				Tables: map[schema.TableName]schema.Schema{
-					"logs-generic-default": {
+					tableName: {
 						Fields: map[schema.FieldName]schema.Field{
 							"host.name":         {PropertyName: "host.name", InternalPropertyName: "host.name", Type: schema.QuesmaTypeObject},
 							"type":              {PropertyName: "type", InternalPropertyName: "type", Type: schema.QuesmaTypeText},

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -51,7 +51,7 @@ func TestSearchOpensearch(t *testing.T) {
 			defer db.Close()
 			lm := clickhouse.NewLogManagerWithConnection(db, concurrent.NewMapWith(tableName, &table))
 			managementConsole := ui.NewQuesmaManagementConsole(&DefaultConfig, nil, nil, make(<-chan logger.LogWithLevel, 50000), telemetry.NewPhoneHomeEmptyAgent(), nil)
-			cw := queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), SchemaRegistry: s, Config: &DefaultConfig}
+			cw := queryparser.ClickhouseQueryTranslator{ClickhouseLM: lm, Table: &table, Ctx: context.Background(), Schema: s.Tables[tableName], Config: &DefaultConfig}
 
 			body, parseErr := types.ParseJSON(tt.QueryJson)
 			assert.NoError(t, parseErr)

--- a/quesma/quesma/transformations.go
+++ b/quesma/quesma/transformations.go
@@ -3,7 +3,6 @@
 package quesma
 
 import (
-	"quesma/logger"
 	"quesma/model"
 	"quesma/schema"
 )
@@ -24,20 +23,12 @@ func (o *TransformationPipeline) Transform(queries []*model.Query) ([]*model.Que
 }
 
 type replaceColumNamesWithFieldNames struct {
-	schemaRegistry schema.Registry
-	fromTable      string
+	indexSchema schema.Schema
 }
 
 func (t *replaceColumNamesWithFieldNames) Transform(result [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {
-	if t.schemaRegistry == nil {
-		logger.Error().Msg("Schema registry is not set")
-		return result, nil
-	}
-	schemaInstance, exists := t.schemaRegistry.FindSchema(schema.TableName(t.fromTable))
-	if !exists {
-		logger.Error().Msgf("Schema fot table %s not found", t.fromTable)
-		return result, nil
-	}
+
+	schemaInstance := t.indexSchema
 	for _, rows := range result {
 		for i, row := range rows {
 			for j := range row.Cols {


### PR DESCRIPTION
This PR adds support for querying multiple indexes.  It's limited to indexes stored in `common table`.

<img width="2204" alt="Screenshot 2024-09-19 at 12 37 33" src="https://github.com/user-attachments/assets/38184d11-3758-4109-9df4-909b34162406">

<img width="1942" alt="Screenshot 2024-09-19 at 12 37 53" src="https://github.com/user-attachments/assets/6ae23224-a137-478d-9cce-38cb5ee5cdd1">


There are a few things to do:
- check why some columns are not translated properly (see `handleDottedTColumnNames` transformer)
- `table.Clickhouse` removal from `ClickhouseQueryTranslator`
- testing, more testing

