### PR TITLE
Dual write support in index config

### DIFF
--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -245,6 +245,11 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 		if ingestProcessor.Type != QuesmaV1ProcessorIngest && ingestProcessor.Type != QuesmaV1ProcessorNoOp {
 			return fmt.Errorf("ingest pipeline must have ingest-type or noop processor")
 		}
+		for _, indexConf := range ingestProcessor.Config.IndexConfig {
+			if len(indexConf.Optimizers) != 0 {
+				return fmt.Errorf("configuration of index '%s' in '%s' processor cannot have any optimizers, this is only a feature of query processor", ingestPipeline.Processors[0], indexConf.Name)
+			}
+		}
 		queryProcessor := c.getProcessorByName(queryPipeline.Processors[0])
 		if queryProcessor == nil {
 			return fmt.Errorf(fmt.Sprintf("query processor named [%s] not found in configuration", ingestPipeline.Processors[0]))
@@ -258,8 +263,32 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 			return fmt.Errorf("query pipeline must have query or noop processor")
 		}
 		if !(queryProcessor.Type == QuesmaV1ProcessorNoOp) {
-			if !reflect.DeepEqual(ingestProcessor.Config, queryProcessor.Config) {
-				return fmt.Errorf("ingest and query processors must have the same configuration due to current limitations")
+			// Indexes must be defined in both processors
+			for indexName := range queryProcessor.Config.IndexConfig {
+				if _, found := ingestProcessor.Config.IndexConfig[indexName]; !found {
+					return fmt.Errorf("index '%s' is defined in query processor, but not in ingest processor", indexName)
+				}
+			}
+			for indexName := range ingestProcessor.Config.IndexConfig {
+				if _, found := queryProcessor.Config.IndexConfig[indexName]; !found {
+					return fmt.Errorf("index '%s' is defined in query processor, but not in ingest processor", indexName)
+				}
+			}
+			for indexName, queryIndexConf := range queryProcessor.Config.IndexConfig {
+				ingestIndexConf := ingestProcessor.Config.IndexConfig[indexName]
+				if queryIndexConf.Override != ingestIndexConf.Override {
+					return fmt.Errorf("ingest and query processors must have the same configuration of 'override'")
+				}
+				if queryIndexConf.UseCommonTable != ingestIndexConf.UseCommonTable {
+					return fmt.Errorf("ingest and query processors must have the same configuration of 'useCommonTable'")
+				}
+				if queryIndexConf.SchemaOverrides == nil || ingestIndexConf.SchemaOverrides == nil {
+					if queryIndexConf.SchemaOverrides != ingestIndexConf.SchemaOverrides {
+						return fmt.Errorf("ingest and query processors must have the same configuration of 'schemaOverrides' for index '%s' due to current limitations", indexName)
+					}
+				} else if !reflect.DeepEqual(*queryIndexConf.SchemaOverrides, *ingestIndexConf.SchemaOverrides) {
+					return fmt.Errorf("ingest and query processors must have the same configuration of 'schemaOverrides' for index '%s' due to current limitations", indexName)
+				}
 			}
 		}
 	}
@@ -303,9 +332,16 @@ func (c *QuesmaNewConfiguration) validateProcessor(p Processor) error {
 	}
 	if p.Type == QuesmaV1ProcessorQuery || p.Type == QuesmaV1ProcessorIngest {
 		for indexName, indexConfig := range p.Config.IndexConfig {
-			if len(indexConfig.Target) != 1 {
-				return fmt.Errorf("configuration of index %s must have exactly one target", indexName)
+			if p.Type == QuesmaV1ProcessorQuery {
+				if len(indexConfig.Target) != 1 {
+					return fmt.Errorf("configuration of index %s must have exactly one target (query processor)", indexName)
+				}
+			} else {
+				if len(indexConfig.Target) != 1 && len(indexConfig.Target) != 2 {
+					return fmt.Errorf("configuration of index %s must have one or two targets (ingest processor)", indexName)
+				}
 			}
+
 			for _, target := range indexConfig.Target {
 				if c.getBackendConnectorByName(target) == nil {
 					return fmt.Errorf("invalid target %s in configuration of index %s", target, indexName)

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -13,7 +13,6 @@ const (
 )
 
 type IndexConfiguration struct {
-	Name            string                            `koanf:"name"`
 	SchemaOverrides *SchemaConfiguration              `koanf:"schemaOverrides"`
 	Optimizers      map[string]OptimizerConfiguration `koanf:"optimizers"`
 	Override        string                            `koanf:"override"`
@@ -21,6 +20,7 @@ type IndexConfiguration struct {
 	Target          []string                          `koanf:"target"`
 
 	// Computed based on the overall configuration
+	Name         string
 	QueryTarget  []string
 	IngestTarget []string
 }

--- a/quesma/quesma/functionality/doc/doc.go
+++ b/quesma/quesma/functionality/doc/doc.go
@@ -4,29 +4,18 @@ package doc
 
 import (
 	"context"
-	"quesma/clickhouse"
 	"quesma/ingest"
-	"quesma/jsonprocessor"
 	"quesma/quesma/config"
-	"quesma/quesma/recovery"
+	"quesma/quesma/functionality/bulk"
 	"quesma/quesma/types"
-	"quesma/stats"
+	"quesma/telemetry"
 )
 
-func Write(ctx context.Context, tableName string, body types.JSON, ip *ingest.IngestProcessor, cfg *config.QuesmaConfiguration) error {
-	stats.GlobalStatistics.Process(cfg, tableName, body, clickhouse.NestedSeparator)
-
-	defer recovery.LogPanic()
-	if len(body) == 0 {
-		return nil
-	}
-
-	return config.RunConfiguredIngest(ctx, cfg, tableName, body, func() error {
-		if len(cfg.IndexConfig[tableName].Override) > 0 {
-			tableName = cfg.IndexConfig[tableName].Override
-		}
-		nameFormatter := clickhouse.DefaultColumnNameFormatter()
-		transformer := jsonprocessor.IngestTransformerFor(tableName, cfg)
-		return ip.ProcessInsertQuery(ctx, tableName, types.NDJSON{body}, transformer, nameFormatter)
-	})
+func Write(ctx context.Context, tableName *string, body types.JSON, ip *ingest.IngestProcessor, cfg *config.QuesmaConfiguration, phoneHomeAgent telemetry.PhoneHomeAgent) (bulk.BulkItem, error) {
+	// Translate single doc write to a bulk request, reusing exiting logic of bulk ingest
+	results, err := bulk.Write(ctx, tableName, []types.JSON{
+		map[string]interface{}{"index": map[string]interface{}{"_index": *tableName}},
+		body,
+	}, ip, cfg, phoneHomeAgent)
+	return results[0], err
 }


### PR DESCRIPTION
This PR makes it possible to configure dual writes by specifying two targets in ingest processor:

```yaml
my_index:
  target: [ my-clickhouse-data-source, my-minimal-elasticsearch ]
```

The limitation, that the ingest processor and query processor must have the same configuration, is now lifted (so you can specify reading from Elastic, but ingesting into both ClickHouse and Elastic).

The implementation of `/_doc` endpoint is now simplified to use the existing logic of bulk ingest (which already had a proper support for dual writes).