### PR TITLE
Quickfix `extended_stats`

### DIFF
--- a/quesma/model/metrics_aggregations/extended_stats.go
+++ b/quesma/model/metrics_aggregations/extended_stats.go
@@ -5,6 +5,7 @@ package metrics_aggregations
 import (
 	"context"
 	"fmt"
+	"math"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/util"
@@ -104,8 +105,10 @@ func (query ExtendedStats) getValue(row model.QueryResultRow, functionName strin
 		logger.WarnWithCtx(query.ctx).Msgf("unknown function name: %s, row: %+v", functionName, row)
 		return nil
 	}
-	if row.Cols[column].Value != nil {
-		return row.Cols[column].Value
+
+	valueAsFloat, isFloat := row.Cols[column].Value.(float64)
+	if row.Cols[column].Value == nil || (isFloat && math.IsNaN(valueAsFloat)) {
+		return "NaN"
 	}
-	return "NaN"
+	return row.Cols[column].Value
 }

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -3,6 +3,7 @@
 package testdata
 
 import (
+	"math"
 	"quesma/clickhouse"
 	"quesma/model"
 	"time"
@@ -6063,9 +6064,9 @@ var AggregationTests = []AggregationTestCase{
 				model.NewQueryResultCol("metric__0__1_col_4", 7676.0),
 				model.NewQueryResultCol("metric__0__1_col_5", 58920976.0),
 				model.NewQueryResultCol("metric__0__1_col_6", 0.0),
-				model.NewQueryResultCol("metric__0__1_col_7", nil),
+				model.NewQueryResultCol("metric__0__1_col_7", math.NaN()),
 				model.NewQueryResultCol("metric__0__1_col_8", 0.0),
-				model.NewQueryResultCol("metric__0__1_col_9", nil),
+				model.NewQueryResultCol("metric__0__1_col_9", math.NaN()),
 				model.NewQueryResultCol("metric__0__2_col_0", 1),
 				model.NewQueryResultCol("metric__0__2_col_1", 7676.0),
 				model.NewQueryResultCol("metric__0__2_col_2", 7676.0),


### PR DESCRIPTION
Fix for some edge case. `extended_stats` uses 10 Clickhouse functions, even though it seems like all of them return nulls
![Screenshot 2024-09-23 at 19 33 01](https://github.com/user-attachments/assets/243da594-d3ae-4d12-b586-38730c0d7f31)
2 of them can actually return `NaN` (those 2 nulls above are in fact `NaN`) (`varSamp` and `stddevSamp` both divide by `N-1`, when sample N is `1`, we get a `NaN` here)
We need to return `"NaN"` as string for Kibana to digest it, and that's done in this PR.
Before:
![Screenshot 2024-09-23 at 19 18 11](https://github.com/user-attachments/assets/330d05e5-e525-4b83-9232-0a789b31046f)
![Screenshot 2024-09-23 at 19 18 02](https://github.com/user-attachments/assets/3fdcec74-9a51-40c5-8f48-e6e9cdd18f92)

After:
![Screenshot 2024-09-23 at 19 28 39](https://github.com/user-attachments/assets/d2ccea9b-6351-4886-a250-c23a192d3683)
