### PR TITLE
Database Column Comments as Metadata Storage – Part 2

### DIFF
--- a/quesma/comment_metadata/comment_metadata.go
+++ b/quesma/comment_metadata/comment_metadata.go
@@ -40,7 +40,7 @@ func UnmarshallCommentMetadata(s string) (*CommentMetadata, error) {
 	groups := rx.FindStringSubmatch(s)
 
 	if len(groups) == 0 {
-		return nil, fmt.Errorf("quesma metadata not found")
+		return nil, nil // no metadata, we return nil here, that's not an error
 	}
 
 	if len(groups) != 3 {

--- a/quesma/comment_metadata/comment_metadata.go
+++ b/quesma/comment_metadata/comment_metadata.go
@@ -1,0 +1,76 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package comment_metadata
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+)
+
+const ElasticFieldName = "fieldName"
+
+const commentMetadataVersion = "1"
+const metadataPrefix = "quesmaMetadata:"
+const versionParameter = "v"
+
+type CommentMetadata struct {
+	Values map[string]string
+}
+
+func NewCommentMetadata() *CommentMetadata {
+	return &CommentMetadata{
+		Values: make(map[string]string),
+	}
+}
+
+func (c *CommentMetadata) Marshall() string {
+
+	params := url.Values{}
+	for k, v := range c.Values {
+		params.Add(k, v)
+	}
+	params.Add(versionParameter, commentMetadataVersion)
+
+	return metadataPrefix + params.Encode()
+}
+
+func UnmarshallCommentMetadata(s string) (*CommentMetadata, error) {
+
+	rx := regexp.MustCompile(metadataPrefix + `([^\s]+)`)
+
+	groups := rx.FindStringSubmatch(s)
+
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("quesma metadata not found")
+	}
+
+	if len(groups) != 2 {
+		return nil, fmt.Errorf("invalid metadata format")
+	}
+
+	s = groups[1]
+
+	params, err := url.ParseQuery(s)
+	if err != nil {
+		return nil, err
+	}
+
+	version := params.Get(versionParameter)
+
+	if version != commentMetadataVersion {
+		return nil, fmt.Errorf("invalid metadata version: %s", version)
+	}
+
+	values := make(map[string]string)
+	for k, v := range params {
+		if k == versionParameter {
+			continue
+		}
+		values[k] = v[0]
+	}
+
+	return &CommentMetadata{
+		Values: values,
+	}, nil
+}

--- a/quesma/comment_metadata/comment_metadata_test.go
+++ b/quesma/comment_metadata/comment_metadata_test.go
@@ -74,6 +74,20 @@ func TestUnmarshallCommentMetadata(t *testing.T) {
 			},
 			fail: false,
 		},
+		{
+			name:  "with human comments invalid version ",
+			input: "some comment here  quesmaMetadataV2:foo=bar  and here ",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			fail: true,
+		},
+		{
+			name:  "no metadata ",
+			input: "some comment here    and here ",
+			want:  nil,
+			fail:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,10 +98,19 @@ func TestUnmarshallCommentMetadata(t *testing.T) {
 				if err == nil {
 					t.Fatal("Expecting error, got nil")
 				}
+				return
 			} else {
 				if err != nil {
 					t.Fatal("Unexpected error ", err)
 				}
+			}
+
+			if tt.want == nil && cm != nil {
+				t.Fatal("Expecting nil, got ", cm)
+			}
+
+			if tt.want == nil && cm == nil {
+				return
 			}
 
 			assert.Equal(t, tt.want, cm.Values)

--- a/quesma/comment_metadata/comment_metadata_test.go
+++ b/quesma/comment_metadata/comment_metadata_test.go
@@ -19,14 +19,14 @@ func TestCommentMetadata_Marshall(t *testing.T) {
 			input: map[string]string{
 				"foo": "bar",
 			},
-			want: "quesmaMetadata:foo=bar&v=1",
+			want: "quesmaMetadataV1:foo=bar",
 		},
 		{
 			name: "test2",
 			input: map[string]string{
 				"łąś": "żółć",
 			},
-			want: "quesmaMetadata:v=1&%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
+			want: "quesmaMetadataV1:%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
 		},
 	}
 
@@ -52,7 +52,7 @@ func TestUnmarshallCommentMetadata(t *testing.T) {
 	}{
 		{
 			name:  "simple",
-			input: "quesmaMetadata:foo=bar&v=1",
+			input: "quesmaMetadataV1:foo=bar",
 			want: map[string]string{
 				"foo": "bar",
 			},
@@ -60,7 +60,7 @@ func TestUnmarshallCommentMetadata(t *testing.T) {
 		},
 		{
 			name:  "with special characters",
-			input: "quesmaMetadata:v=1&%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
+			input: "quesmaMetadataV1:%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
 			want: map[string]string{
 				"łąś": "żółć",
 			},
@@ -68,7 +68,7 @@ func TestUnmarshallCommentMetadata(t *testing.T) {
 		},
 		{
 			name:  "with human comments ",
-			input: "some comment here  quesmaMetadata:foo=bar&v=1  and here ",
+			input: "some comment here  quesmaMetadataV1:foo=bar  and here ",
 			want: map[string]string{
 				"foo": "bar",
 			},

--- a/quesma/comment_metadata/comment_metadata_test.go
+++ b/quesma/comment_metadata/comment_metadata_test.go
@@ -1,0 +1,96 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package comment_metadata
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCommentMetadata_Marshall(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		input map[string]string
+		want  string
+	}{
+		{
+			name: "test1",
+			input: map[string]string{
+				"foo": "bar",
+			},
+			want: "quesmaMetadata:foo=bar&v=1",
+		},
+		{
+			name: "test2",
+			input: map[string]string{
+				"łąś": "żółć",
+			},
+			want: "quesmaMetadata:v=1&%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := NewCommentMetadata()
+			cm.Values = tt.input
+
+			if got := cm.Marshall(); got != tt.want {
+				t.Errorf("Marshall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshallCommentMetadata(t *testing.T) {
+
+	tests := []struct {
+		name  string
+		input string
+		want  map[string]string
+		fail  bool
+	}{
+		{
+			name:  "simple",
+			input: "quesmaMetadata:foo=bar&v=1",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			fail: false,
+		},
+		{
+			name:  "with special characters",
+			input: "quesmaMetadata:v=1&%C5%82%C4%85%C5%9B=%C5%BC%C3%B3%C5%82%C4%87",
+			want: map[string]string{
+				"łąś": "żółć",
+			},
+			fail: false,
+		},
+		{
+			name:  "with human comments ",
+			input: "some comment here  quesmaMetadata:foo=bar&v=1  and here ",
+			want: map[string]string{
+				"foo": "bar",
+			},
+			fail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm, err := UnmarshallCommentMetadata(tt.input)
+
+			if tt.fail {
+				if err == nil {
+					t.Fatal("Expecting error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatal("Unexpected error ", err)
+				}
+			}
+
+			assert.Equal(t, tt.want, cm.Values)
+		})
+	}
+}

--- a/quesma/common_table/const.go
+++ b/quesma/common_table/const.go
@@ -42,9 +42,7 @@ func EnsureCommonTableExists(db *sql.DB) {
 // Here are defintion of JSON objects that are used to store virtual tables in JSON database
 
 type VirtualTableColumn struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Comment string `json:"comment"`
+	Name string `json:"name"`
 }
 
 type VirtualTable struct {

--- a/quesma/ingest/insert_test.go
+++ b/quesma/ingest/insert_test.go
@@ -100,13 +100,13 @@ var expectedInserts = [][]string{
 	[]string{EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","service_name":"frontend","severity":"debug","source":"rhel"}`)},
 	[]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "service_name" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "service_name" 'service.name'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "service_name" 'quesmaMetadata:fieldName=service.name&v=1'`),
 
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'severity'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadata:fieldName=severity&v=1'`),
 
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "source" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "source" 'source'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "source" 'quesmaMetadata:fieldName=source&v=1'`),
 
 		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","service_name":"frontend","severity":"debug","source":"rhel"}`),
 	},
@@ -115,11 +115,11 @@ var expectedInserts = [][]string{
 	},
 	[]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random1" Array(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random1" 'random1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random1" 'quesmaMetadata:fieldName=random1&v=1'`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random2" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random2" 'random2'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random2" 'quesmaMetadata:fieldName=random2&v=1'`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'severity'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadata:fieldName=severity&v=1'`),
 		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
 	},
 }

--- a/quesma/ingest/insert_test.go
+++ b/quesma/ingest/insert_test.go
@@ -100,13 +100,13 @@ var expectedInserts = [][]string{
 	[]string{EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","service_name":"frontend","severity":"debug","source":"rhel"}`)},
 	[]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "service_name" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "service_name" 'quesmaMetadata:fieldName=service.name&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "service_name" 'quesmaMetadataV1:fieldName=service.name`),
 
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadata:fieldName=severity&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadataV1:fieldName=severity'`),
 
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "source" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "source" 'quesmaMetadata:fieldName=source&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "source" 'quesmaMetadataV1:fieldName=source'`),
 
 		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","service_name":"frontend","severity":"debug","source":"rhel"}`),
 	},
@@ -115,11 +115,11 @@ var expectedInserts = [][]string{
 	},
 	[]string{
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random1" Array(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random1" 'quesmaMetadata:fieldName=random1&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random1" 'quesmaMetadataV1:fieldName=random1'`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "random2" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random2" 'quesmaMetadata:fieldName=random2&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "random2" 'quesmaMetadataV1:fieldName=random2'`),
 		EscapeBrackets(`ALTER TABLE "` + tableName + `" ADD COLUMN IF NOT EXISTS "severity" Nullable(String)`),
-		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadata:fieldName=severity&v=1'`),
+		EscapeBrackets(`ALTER TABLE "` + tableName + `" COMMENT COLUMN "severity" 'quesmaMetadataV1:fieldName=severity'`),
 		EscapeBrackets(`INSERT INTO "` + tableName + `" FORMAT JSONEachRow {"@timestamp":"2024-01-27T16:11:19.94Z","host_name":"hermes","message":"User password reset failed","random1":["debug"],"random2":"random-string","severity":"frontend"}`),
 	},
 }

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	chLib "quesma/clickhouse"
+	"quesma/comment_metadata"
 	"quesma/common_table"
 	"quesma/concurrent"
 	"quesma/end_user_errors"
@@ -334,11 +335,15 @@ func (ip *IngestProcessor) generateNewColumns(
 			propertyName = field.FieldName
 		}
 
+		metadata := comment_metadata.NewCommentMetadata()
+		metadata.Values[comment_metadata.ElasticFieldName] = propertyName
+		comment := metadata.Marshall()
+
 		alterTable := fmt.Sprintf("ALTER TABLE \"%s\" ADD COLUMN IF NOT EXISTS \"%s\" %s", table.Name, attrKeys[i], columnType)
-		newColumns[attrKeys[i]] = &chLib.Column{Name: attrKeys[i], Type: chLib.NewBaseType(attrTypes[i]), Modifiers: modifiers, Comment: propertyName}
+		newColumns[attrKeys[i]] = &chLib.Column{Name: attrKeys[i], Type: chLib.NewBaseType(attrTypes[i]), Modifiers: modifiers, Comment: comment}
 		alterCmd = append(alterCmd, alterTable)
 
-		alterColumn := fmt.Sprintf("ALTER TABLE \"%s\" COMMENT COLUMN \"%s\" '%s'", table.Name, attrKeys[i], propertyName)
+		alterColumn := fmt.Sprintf("ALTER TABLE \"%s\" COMMENT COLUMN \"%s\" '%s'", table.Name, attrKeys[i], comment)
 		alterCmd = append(alterCmd, alterColumn)
 
 		deleteIndexes = append(deleteIndexes, i)
@@ -833,9 +838,7 @@ func (ip *IngestProcessor) storeVirtualTable(table *chLib.Table) error {
 
 	for _, col := range table.Cols {
 		columns = append(columns, common_table.VirtualTableColumn{
-			Name:    col.Name,
-			Type:    col.Type.String(),
-			Comment: col.Comment,
+			Name: col.Name,
 		})
 	}
 
@@ -848,6 +851,7 @@ func (ip *IngestProcessor) storeVirtualTable(table *chLib.Table) error {
 	if err != nil {
 		return err
 	}
+
 	return ip.virtualTableStorage.Put(table.Name, string(data))
 }
 

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -203,14 +203,18 @@ func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[strin
 				// is empty, read them from persistent storage, e.g. column comment
 			} else if len(column.Comment) > 0 {
 				propertyName = FieldName(column.Name)
+
 				metadata, err := comment_metadata.UnmarshallCommentMetadata(column.Comment)
 				if err != nil {
 					logger.Warn().Msgf("error unmarshalling column '%s' (table: %s)  comment metadata: %s %v", indexName, column.Name, column.Comment, err)
 				} else {
-					if fieldName, ok := metadata.Values[comment_metadata.ElasticFieldName]; ok {
-						propertyName = FieldName(fieldName)
+					if metadata != nil {
+						if fieldName, ok := metadata.Values[comment_metadata.ElasticFieldName]; ok {
+							propertyName = FieldName(fieldName)
+						}
 					}
 				}
+
 			} else {
 				// if field encoding is not found, use the column name as the property name
 				propertyName = FieldName(column.Name)

--- a/quesma/schema/registry.go
+++ b/quesma/schema/registry.go
@@ -3,6 +3,7 @@
 package schema
 
 import (
+	"quesma/comment_metadata"
 	"quesma/logger"
 	"quesma/quesma/config"
 	"quesma/util"
@@ -201,7 +202,15 @@ func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[strin
 				// if field encodings are not coming from ingest e.g. encodings map
 				// is empty, read them from persistent storage, e.g. column comment
 			} else if len(column.Comment) > 0 {
-				propertyName = FieldName(column.Comment)
+				propertyName = FieldName(column.Name)
+				metadata, err := comment_metadata.UnmarshallCommentMetadata(column.Comment)
+				if err != nil {
+					logger.Warn().Msgf("error unmarshalling column '%s' (table: %s)  comment metadata: %s %v", indexName, column.Name, column.Comment, err)
+				} else {
+					if fieldName, ok := metadata.Values[comment_metadata.ElasticFieldName]; ok {
+						propertyName = FieldName(fieldName)
+					}
+				}
 			} else {
 				// if field encoding is not found, use the column name as the property name
 				propertyName = FieldName(column.Name)


### PR DESCRIPTION
This PR changes the way we store metadata in column comments. Now we store it as a structure. 

<img width="1603" alt="Screenshot 2024-09-25 at 14 52 59" src="https://github.com/user-attachments/assets/ebb585b0-3681-4833-a4a6-01d201ba2fa8">



