### PR TITLE
Fixing ingest to authenticated Elasticsearch

### DIFF
--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -41,6 +41,14 @@ func (es *SimpleClient) Request(ctx context.Context, method, endpoint string, pa
 	return es.doRequest(ctx, method, endpoint, body, nil)
 }
 
+func (es *SimpleClient) RequestWithHeaders(ctx context.Context, method, endpoint string, payload interface{}, headers http.Header) (*http.Response, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return es.doRequest(ctx, method, endpoint, body, headers)
+}
+
 func (es *SimpleClient) Authenticate(ctx context.Context, authHeader string) bool {
 	resp, err := es.doRequest(ctx, "GET", "_security/_authenticate", nil, http.Header{"Authorization": {authHeader}})
 	if err != nil {
@@ -62,7 +70,11 @@ func (es *SimpleClient) doRequest(ctx context.Context, method, endpoint string, 
 		req.SetBasicAuth(es.config.User, es.config.Password)
 	}
 	if headers != nil {
-		req.Header = headers
+		for key, values := range headers {
+			for _, value := range values {
+				req.Header.Set(key, value)
+			}
+		}
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return es.client.Do(req)

--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -69,6 +69,7 @@ func (es *SimpleClient) doRequest(ctx context.Context, method, endpoint string, 
 	if es.config.User != "" && es.config.Password != "" {
 		req.SetBasicAuth(es.config.User, es.config.Password)
 	}
+	req.Header.Set("Content-Type", "application/json")
 	if headers != nil {
 		for key, values := range headers {
 			for _, value := range values {
@@ -76,6 +77,5 @@ func (es *SimpleClient) doRequest(ctx context.Context, method, endpoint string, 
 			}
 		}
 	}
-	req.Header.Set("Content-Type", "application/json")
 	return es.client.Do(req)
 }

--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -70,11 +70,9 @@ func (es *SimpleClient) doRequest(ctx context.Context, method, endpoint string, 
 		req.SetBasicAuth(es.config.User, es.config.Password)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if headers != nil {
-		for key, values := range headers {
-			for _, value := range values {
-				req.Header.Set(key, value)
-			}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Set(key, value)
 		}
 	}
 	return es.client.Do(req)

--- a/quesma/elasticsearch/client_test.go
+++ b/quesma/elasticsearch/client_test.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package elasticsearch
 
 import (

--- a/quesma/elasticsearch/client_test.go
+++ b/quesma/elasticsearch/client_test.go
@@ -1,0 +1,101 @@
+package elasticsearch
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"quesma/quesma/config"
+	"testing"
+)
+
+const testPayload = "{'test': 'test'}"
+
+func getURL(urlStr string) *config.Url {
+	u, _ := url.Parse(urlStr)
+	newUrl := config.Url(*u)
+	return &newUrl
+}
+
+func TestSimpleClient_Request_AddsContentTypeAndDoesntAuthenticateWhenNotConfigured(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	esClient := &SimpleClient{
+		client: &http.Client{},
+		config: &config.ElasticsearchConfiguration{
+			Url: getURL(server.URL), // No user and password configured for Elasticsearch
+		},
+	}
+
+	_, err := esClient.Request(context.Background(), "POST", "test-endpoint", testPayload)
+	assert.NoError(t, err)
+}
+
+func TestSimpleClient_Request_AddsAuthHeadersIfElasticsearchAuthConfigured(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		assert.Equal(t, "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk", authHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	esClient := &SimpleClient{
+		client: &http.Client{},
+		config: &config.ElasticsearchConfiguration{
+			Url:      getURL(server.URL),
+			User:     "testuser",
+			Password: "testpassword",
+		},
+	}
+
+	_, err := esClient.Request(context.Background(), "POST", "test-endpoint", testPayload)
+	assert.NoError(t, err)
+}
+
+func TestSimpleClient_Authenticate_UsesAuthHeader(t *testing.T) {
+	// Even if Elasticsearch auth is configured, Authenticate should always send the Authorization header as is
+	const testAuthHeader = "Basic testtoken"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		assert.Equal(t, testAuthHeader, authHeader)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	esClient := &SimpleClient{
+		client: &http.Client{},
+		config: &config.ElasticsearchConfiguration{
+			Url:      getURL(server.URL),
+			User:     "testuser",
+			Password: "testpassword",
+		},
+	}
+
+	result := esClient.Authenticate(context.Background(), testAuthHeader)
+	assert.True(t, result)
+}
+
+func TestSimpleClient_RequestWithHeaders_OverwritesContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		assert.Equal(t, "application/x-ndjson", contentType)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	esClient := &SimpleClient{
+		client: &http.Client{},
+		config: &config.ElasticsearchConfiguration{
+			Url: getURL(server.URL),
+		},
+	}
+
+	headers := http.Header{"Content-Type": {"application/x-ndjson"}}
+
+	_, err := esClient.RequestWithHeaders(context.Background(), "POST", "test-endpoint", testPayload, headers)
+	assert.NoError(t, err)
+}

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -3,13 +3,13 @@
 package bulk
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"quesma/clickhouse"
+	"quesma/elasticsearch"
 	"quesma/ingest"
 	"quesma/jsonprocessor"
 	"quesma/logger"
@@ -157,10 +157,8 @@ func sendToElastic(elasticRequestBody []byte, cfg *config.QuesmaConfiguration, e
 		return nil
 	}
 
-	req, _ := http.NewRequest("POST", cfg.Elasticsearch.Url.String()+"/_bulk", bytes.NewBuffer(elasticRequestBody))
-	req.Header.Set("Content-Type", "application/x-ndjson")
-	client := http.Client{} // FIXME
-	response, err := client.Do(req)
+	esClient := elasticsearch.NewSimpleClient(&cfg.Elasticsearch)
+	response, err := esClient.RequestWithHeaders(context.Background(), "POST", "/_bulk", elasticRequestBody, http.Header{"Content-Type": {"application/x-ndjson"}})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixing ingesting to password-protected Elasticsearch cluster.

As a bonus I've cleaned up another accidental usage of `client := http.Client{}` and added some tests. 