### PR TITLE
Missing `*` in ci-config.yaml

### DIFF
--- a/ci/quesma/config/ci-config.yaml
+++ b/ci/quesma/config/ci-config.yaml
@@ -37,6 +37,8 @@ processors:
                 type: text
         windows_logs:
           target: [ my-clickhouse-data-source ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
   - name: p2
     type: quesma-v1-processor-ingest
     config:
@@ -55,6 +57,8 @@ processors:
                 type: text
         windows_logs:   # Used for EQL e2e tests
           target: [ my-clickhouse-data-source ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
 
 pipelines:
   - name: p-query


### PR DESCRIPTION
Add missing `*` configuration in `ci-config.yaml`. This caused E2E tests to fail.