### PR TITLE
Remove the need for SQL-type backend connector in transparent proxy mode

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -414,3 +414,7 @@ func NewChTableConfigTimestampStringAttr() *ChTableConfig {
 func (c *ChTableConfig) GetAttributes() []Attribute {
 	return c.Attributes
 }
+
+func (l *LogManager) IsInTransparentProxyMode() bool {
+	return l.cfg.TransparentProxy
+}

--- a/quesma/clickhouse/connection.go
+++ b/quesma/clickhouse/connection.go
@@ -75,7 +75,9 @@ func InitDBConnectionPool(c *config.QuesmaConfiguration) *sql.DB {
 	err = db.Ping()
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to connect to database. There can be errors in further requests.")
-		RunClickHouseConnectionDoctor(c)
+		if !c.TransparentProxy {
+			RunClickHouseConnectionDoctor(c)
+		}
 		// Other errors are not handled here, eg. authentication error, database not found, etc.
 		// Maybe we should return the error here and Quesma should handle it.
 	} else {

--- a/quesma/connectors/connector.go
+++ b/quesma/connectors/connector.go
@@ -28,11 +28,13 @@ func (c *ConnectorManager) GetConnector() *clickhouse.LogManager {
 		panic("No connectors found")
 	}
 	conn := c.connectors[0]
-	go func() {
-		if err := conn.LicensingCheck(); err != nil {
-			licensing.PanicWithLicenseViolation(fmt.Errorf("connector [%s] reported licensing issue: [%v]", conn.Type(), err))
-		}
-	}()
+	if !c.connectors[0].GetConnector().IsInTransparentProxyMode() {
+		go func() {
+			if err := conn.LicensingCheck(); err != nil {
+				licensing.PanicWithLicenseViolation(fmt.Errorf("connector [%s] reported licensing issue: [%v]", conn.Type(), err))
+			}
+		}()
+	}
 	return c.connectors[0].GetConnector()
 }
 

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -469,7 +469,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 	conf.IngestStatistics = c.IngestStatistics
 	conf.AutodiscoveryEnabled = false
 	conf.Connectors = make(map[string]RelationalDbConfiguration)
-	relDBConn, connType, err := c.getRelationalDBConf()
+	relDBConn, connType, relationalDBErr := c.getRelationalDBConf()
 
 	isSinglePipeline, isDualPipeline := c.getPipelinesType()
 
@@ -562,9 +562,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 END:
 
-	if err != nil && !conf.TransparentProxy {
-		errAcc = multierror.Append(errAcc, err)
-	} else if err != nil && conf.TransparentProxy {
+	if relationalDBErr != nil && !conf.TransparentProxy {
+		errAcc = multierror.Append(errAcc, relationalDBErr)
+	} else if relationalDBErr != nil && conf.TransparentProxy {
 		relDBConn := RelationalDbConfiguration{
 			ConnectorType: ClickHouseOSBackendConnectorName,
 			Url: &Url{

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -562,9 +562,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 END:
 
-	if err != nil && conf.TransparentProxy == false {
+	if err != nil && !conf.TransparentProxy {
 		errAcc = multierror.Append(errAcc, err)
-	} else if err != nil && conf.TransparentProxy == true {
+	} else if err != nil && conf.TransparentProxy {
 		relDBConn := RelationalDbConfiguration{
 			ConnectorType: ClickHouseOSBackendConnectorName,
 			Url: &Url{

--- a/quesma/quesma/config/test_configs/quesma_as_transparent_proxy.yml
+++ b/quesma/quesma/config/test_configs/quesma_as_transparent_proxy.yml
@@ -14,13 +14,6 @@ backendConnectors:
       url: "http://elasticsearch:9200"
       user: elastic
       password: quesmaquesma
-  - name: my-hydrolix-instance    # Okay maybe this is weird  but we require this ATM
-    type: hydrolix
-    config:
-      url: "clickhouse://localhost:9440"
-      user: "u"
-      password: "p"
-      database: "d"
 processors:
   - name: noop-query-processor
     type: quesma-v1-processor-noop


### PR DESCRIPTION
As in the description. The way I did it is quite ugly (esp. the `(l *LogManager) IsInTransparentProxyMode()`), but for now I think it's a decent compromise.