### PR TITLE
Change default log level to `INFO`

### DIFF
--- a/quesma/licensing/runner.go
+++ b/quesma/licensing/runner.go
@@ -91,7 +91,7 @@ func (l *LicenseModule) logInfo(msg string, args ...interface{}) {
 }
 
 func (l *LicenseModule) logDebug(msg string, args ...interface{}) {
-	if l.Config.Logging.Level == zerolog.DebugLevel {
+	if *l.Config.Logging.Level == zerolog.DebugLevel {
 		fmt.Printf(msg+"\n", args...)
 	}
 }

--- a/quesma/logger/logger.go
+++ b/quesma/logger/logger.go
@@ -101,7 +101,7 @@ func InitLogger(cfg Configuration, sig chan os.Signal, doneCh chan struct{}, asy
 		logger = logger.Hook(asyncQueryTraceLogger)
 	}
 
-	logger.Info().Msg("Logger initialized")
+	logger.Info().Msgf("Logger initialized with level %s", cfg.Level)
 	return logChannel
 }
 

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -62,7 +62,7 @@ func main() {
 		FileLogging:       cfg.Logging.FileLogging,
 		Path:              cfg.Logging.Path,
 		RemoteLogDrainUrl: cfg.Logging.RemoteLogDrainUrl.ToUrl(),
-		Level:             cfg.Logging.Level,
+		Level:             *cfg.Logging.Level,
 		ClientId:          licenseMod.License.ClientID,
 	}, sig, doneCh, asyncQueryTraceLogger)
 	defer logger.StdLogFile.Close()

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -50,10 +50,10 @@ type QuesmaConfiguration struct {
 }
 
 type LoggingConfiguration struct {
-	Path              string        `koanf:"path"`
-	Level             zerolog.Level `koanf:"level"`
-	RemoteLogDrainUrl *Url          `koanf:"remoteUrl"`
-	FileLogging       bool          `koanf:"fileLogging"`
+	Path              string         `koanf:"path"`
+	Level             *zerolog.Level `koanf:"level"`
+	RemoteLogDrainUrl *Url           `koanf:"remoteUrl"`
+	FileLogging       bool           `koanf:"fileLogging"`
 }
 
 type RelationalDbConfiguration struct {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -7,12 +7,15 @@ import (
 	"fmt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/knadh/koanf/providers/env"
+	"github.com/rs/zerolog"
 	"log"
 	"quesma/network"
 	"reflect"
 	"slices"
 	"strings"
 )
+
+var DefaultLogLevel = zerolog.InfoLevel
 
 const (
 	ElasticsearchFrontendQueryConnectorName  = "elasticsearch-fe-query"
@@ -456,6 +459,10 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 	}
 
 	conf.Logging = c.Logging
+	if conf.Logging.Level == nil {
+		conf.Logging.Level = &DefaultLogLevel
+	}
+
 	conf.InstallationId = c.InstallationId
 	conf.LicenseKey = c.LicenseKey
 


### PR DESCRIPTION
Before this change if the user did not configure the log level in the configuration it would default to `DEBUG` (as this is the first entry in `DebugLevel` enum). Debug log level is very verbose and it's not a great experience for a user (who tried a minimal config).

Therefore set log level to `INFO` if none was provided in the loaded config.