### PR TITLE
Remove requirement of defining indexes in both processors, bring back required `*` configuration

### DIFF
--- a/ci/quesma/config/ci-config.yaml
+++ b/ci/quesma/config/ci-config.yaml
@@ -37,6 +37,8 @@ processors:
                 type: text
         windows_logs:
           target: [ my-clickhouse-data-source ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
   - name: p2
     type: quesma-v1-processor-ingest
     config:
@@ -55,6 +57,8 @@ processors:
                 type: text
         windows_logs:   # Used for EQL e2e tests
           target: [ my-clickhouse-data-source ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
 
 pipelines:
   - name: p-query

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -71,6 +71,8 @@ processors:
                 type: "keyword"
               severity:
                 type: "keyword"
+        "*":
+          target: [ my-minimal-elasticsearch ]
   - name: my-ingest-processor
     type: quesma-v1-processor-ingest
     config:
@@ -114,6 +116,8 @@ processors:
                 type: "keyword"
               severity:
                 type: "keyword"
+        "*":
+          target: [ my-minimal-elasticsearch ]
 pipelines:
   - name: my-pipeline-elasticsearch-query-clickhouse
     frontendConnectors: [ elastic-query ]

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -183,6 +183,9 @@ func (c *QuesmaConfiguration) validateDeprecated(indexName IndexConfiguration, r
 }
 
 func (c *QuesmaConfiguration) validateIndexName(indexName string, result error) error {
+	if indexName == DefaultWildcardIndexName {
+		return result
+	}
 	if strings.Contains(indexName, "*") || indexName == "_all" {
 		result = multierror.Append(result, fmt.Errorf("wildcard patterns are not allowed in index configuration: %s", indexName))
 	}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -78,6 +78,11 @@ type Processor struct {
 	Config QuesmaProcessorConfig `koanf:"config"`
 }
 
+var (
+	DefaultIngestTarget = []string{ElasticsearchTarget}
+	DefaultQueryTarget  = []string{ElasticsearchTarget}
+)
+
 // Configuration of QuesmaV1ProcessorQuery and QuesmaV1ProcessorIngest
 type QuesmaProcessorConfig struct {
 	IndexConfig map[string]IndexConfiguration `koanf:"indexes"`
@@ -544,6 +549,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			processedConfig := indexConfig
 			processedConfig.Name = indexName
 
+			processedConfig.IngestTarget = DefaultIngestTarget
+
 			if slices.Contains(indexConfig.Target, elasticBackendName) {
 				processedConfig.QueryTarget = append(processedConfig.QueryTarget, ElasticsearchTarget)
 			}
@@ -577,8 +584,10 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				// use the ingest processor's configuration as the base (similarly as in the previous loop)
 				processedConfig = indexConfig
 				processedConfig.Name = indexName
+				processedConfig.QueryTarget = DefaultQueryTarget
 			}
 
+			processedConfig.IngestTarget = make([]string, 0) // reset previously set DefaultIngestTarget
 			if slices.Contains(indexConfig.Target, elasticBackendName) {
 				processedConfig.IngestTarget = append(processedConfig.IngestTarget, ElasticsearchTarget)
 			}

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"slices"
+	"strings"
 )
 
 const (
@@ -26,16 +27,30 @@ type IndexConfiguration struct {
 }
 
 func (c IndexConfiguration) String() string {
-	var str = fmt.Sprintf("\n\t\t%s, query targets: %v, ingest targets: %v, schema overrides: %s, override: %s, useSingleTable: %t",
-		c.Name,
-		c.QueryTarget,
-		c.IngestTarget,
-		c.SchemaOverrides.String(),
-		c.Override,
-		c.UseCommonTable,
-	)
+	var builder strings.Builder
 
-	return str
+	builder.WriteString("\n\t\t")
+	builder.WriteString(c.Name)
+	builder.WriteString(", query targets: ")
+	builder.WriteString(fmt.Sprintf("%v", c.QueryTarget))
+	builder.WriteString(", ingest targets: ")
+	builder.WriteString(fmt.Sprintf("%v", c.IngestTarget))
+	if c.SchemaOverrides != nil && len(c.SchemaOverrides.Fields) > 0 {
+		builder.WriteString(",\n\t\t\tschema overrides: ")
+		builder.WriteString(c.SchemaOverrides.String())
+		builder.WriteString("\n\t\t\t")
+	} else {
+		builder.WriteString("\n\t\t\t")
+	}
+	if len(c.Override) > 0 {
+		builder.WriteString(", override: ")
+		builder.WriteString(c.Override)
+	}
+	if c.UseCommonTable {
+		builder.WriteString(", useSingleTable: true")
+	}
+
+	return builder.String()
 }
 
 func (c IndexConfiguration) GetOptimizerConfiguration(optimizerName string) (props map[string]string, disabled bool) {

--- a/quesma/quesma/config/schema_config.go
+++ b/quesma/quesma/config/schema_config.go
@@ -32,9 +32,12 @@ func (fn FieldName) AsString() string {
 }
 
 func (fc FieldConfiguration) String() string {
-	baseString := fmt.Sprintf("FieldConfiguration: Type=%s", fc.Type) //fc.IsTimestampField)
+	baseString := fmt.Sprintf("Type=%s", fc.Type)
 	if fc.TargetColumnName != "" {
 		baseString += fmt.Sprintf(", TargetColumnName=%s", fc.TargetColumnName)
+	}
+	if fc.Ignored {
+		baseString += ", Ignored"
 	}
 	return baseString
 }
@@ -45,11 +48,14 @@ func (sc *SchemaConfiguration) String() string {
 	}
 	var builder strings.Builder
 
-	builder.WriteString("SchemaConfiguration:\n")
-
-	builder.WriteString("Fields:\n")
+	addComma := false
 	for fieldName, fieldConfig := range sc.Fields {
-		builder.WriteString(fmt.Sprintf("\t%s: %+v\n", fieldName, fieldConfig))
+		if addComma {
+			builder.WriteString(", ")
+		} else {
+			addComma = true
+		}
+		builder.WriteString(fmt.Sprintf("%s: %v", fieldName, fieldConfig))
 	}
 	return builder.String()
 }

--- a/quesma/quesma/config/test_configs/quesma_adding_two_hydrolix_tables.yaml
+++ b/quesma/quesma/config/test_configs/quesma_adding_two_hydrolix_tables.yaml
@@ -42,6 +42,8 @@ processors:
           target: [my-hydrolix-instance]
         logs:
           target: [my-hydrolix-instance]
+        "*":
+          target: [ my-minimal-elasticsearch ]
   - name: my-ingest-processor
     type: quesma-v1-processor-ingest
     config:
@@ -49,6 +51,8 @@ processors:
         siem:
           target: [ my-minimal-elasticsearch ]
         logs:
+          target: [ my-minimal-elasticsearch ]
+        "*":
           target: [ my-minimal-elasticsearch ]
 pipelines:
   - name: my-elasticsearch-proxy-read

--- a/quesma/quesma/config/test_configs/quesma_hydrolix_tables_query_only.yaml
+++ b/quesma/quesma/config/test_configs/quesma_hydrolix_tables_query_only.yaml
@@ -42,6 +42,8 @@ processors:
           target: [my-hydrolix-instance]
         logs:
           target: [my-hydrolix-instance]
+        "*":
+          target: [my-minimal-elasticsearch]
 pipelines:
   - name: my-elasticsearch-proxy-read
     frontendConnectors: [ elastic-query ]

--- a/quesma/quesma/config/test_configs/test_config_v2.yaml
+++ b/quesma/quesma/config/test_configs/test_config_v2.yaml
@@ -74,6 +74,8 @@ processors:
             fields:
               message:
                 type: text
+        "*":
+          target: [ my-minimal-elasticsearch ]
   - name: my-ingest-processor
     type: quesma-v1-processor-ingest
     config:
@@ -123,6 +125,8 @@ processors:
             fields:
               message:
                 type: text
+        "*":
+          target: [ my-minimal-elasticsearch ]
 pipelines:
   - name: my-pipeline-elasticsearch-query-clickhouse
     frontendConnectors: [ elastic-query ]


### PR DESCRIPTION
Remove the requirement that the user has to configure some index in both ingest and query processors. After this change, the user can now define an index only in ingest or only in query processor.

Under the hood, the translated V1 index configuration will have an ingest target set to `DefaultIngestTarget` if index is missing from ingest processor configuration or query target set to `DefaultQueryTarget` if index is missing from query processor configuration.

Bring back required `*` configuration. The only supported configuration is `"*": target: [elastic]`. This will make it easier for the users to understand the configuration, instead of relying on some "magic" fallback behavior.

Additionally improve the logging of index configurations (printed at the start of Quesma).