### PR TITLE
Introduce `nightly` Docker tag

### DIFF
--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -1,7 +1,8 @@
-name: Docker image build (latest)
-# Pipeline which builds latest / nightly Docker images for Quesma
-# pushes them to Docker Hub and GCR with `latest` tag,
-# triggered by a push/merge to the `main` branch
+name: Docker image build (nightly)
+# Pipeline which builds `nightly` Docker images for Quesma
+# pushes them to Docker Hub and GCR with `nightly` tag.
+# This workflow is triggered by a push/merge to the `main` branch
+# quesma/quesma:latest image is a pointer to latest released version.
 
 on:
   push:
@@ -10,7 +11,7 @@ on:
     inputs:
       VERSION:
         description: 'Version number to tag the image with (optional)'
-        default: latest
+        default: nightly
         required: true
       PUSH:
         description: 'Whether to push the image to the registry'
@@ -58,9 +59,9 @@ jobs:
           # when called from the main branch, `github.event.inputs.VERSION` doesn't use default value and is just empty
           tags: | 
             europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.sha }}
-            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION || 'latest' }}
-            quesma/quesma:${{ github.event.inputs.VERSION || 'latest' }}
-            quesma/quesma:latest
+            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION || 'nightly' }}
+            quesma/quesma:${{ github.event.inputs.VERSION || 'nightly' }}
+            quesma/quesma:nightly
           # Pushes to GCR only for `main` branch builds, unless set explicitly in the job input
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.PUSH }}
           build-args: |

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -1,6 +1,7 @@
 name: Docker image build (nightly)
 # Pipeline which builds `nightly` Docker images for Quesma
-# pushes them to Docker Hub and GCR with `nightly` tag.
+# pushes them to Docker Hub as `quesma/quesma:nightly` (and `quesma/quesma:<VERSION>`, if VERSION is specified explicitly)
+#
 # This workflow is triggered by a push/merge to the `main` branch
 # quesma/quesma:latest image is a pointer to latest released version.
 
@@ -36,13 +37,6 @@ jobs:
           cache-dependency-path: ${{ matrix.module }}/go.sum
           go-version: '1.22'
 
-      - name: Login to GCR (only for build running on `main` branch)
-        uses: docker/login-action@v3
-        with:
-          registry: europe-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCR_SERVICE_ACCOUNT_PRIVATE_KEY }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -58,11 +52,9 @@ jobs:
           context: ${{ matrix.module }}/.
           # when called from the main branch, `github.event.inputs.VERSION` doesn't use default value and is just empty
           tags: | 
-            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.sha }}
-            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION || 'nightly' }}
             quesma/quesma:${{ github.event.inputs.VERSION || 'nightly' }}
             quesma/quesma:nightly
-          # Pushes to GCR only for `main` branch builds, unless set explicitly in the job input
+          # Pushes to DockerHub only for `main` branch builds, unless set explicitly in the job input
           push: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.PUSH }}
           build-args: |
             QUESMA_BUILD_SHA=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
           cache-dependency-path: ${{ matrix.module }}/go.sum
           go-version: '1.22'
 
+      - name: Login to GCR (only for build running on `main` branch)
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCR_SERVICE_ACCOUNT_PRIVATE_KEY }}
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -56,6 +63,8 @@ jobs:
         with:
           context: ${{ matrix.module }}/.
           tags: |
+            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION }}
+            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:latest
             quesma/quesma:${{ github.event.inputs.VERSION }}
             quesma/quesma:latest
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,6 @@ jobs:
           cache-dependency-path: ${{ matrix.module }}/go.sum
           go-version: '1.22'
 
-      - name: Login to GCR (only for build running on `main` branch)
-        uses: docker/login-action@v3
-        with:
-          registry: europe-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCR_SERVICE_ACCOUNT_PRIVATE_KEY }}
-
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -63,7 +56,6 @@ jobs:
         with:
           context: ${{ matrix.module }}/.
           tags: |
-            europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION }}
             quesma/quesma:${{ github.event.inputs.VERSION }}
             quesma/quesma:latest
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           tags: |
             europe-docker.pkg.dev/metal-figure-407109/quesma-nightly/quesma:${{ github.event.inputs.VERSION }}
             quesma/quesma:${{ github.event.inputs.VERSION }}
+            quesma/quesma:latest
           push: true
           build-args: |
             QUESMA_BUILD_SHA=${{ github.sha }}

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   quesma:
     build: ../quesma
-    image: quesma:latest
+    image: quesma:nigthly
     environment:
       - QUESMA_CONFIG_FILE=/mnt/ci-config.yaml
       - QUESMA_logging_path=/var/quesma/logs

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   quesma:
     build: ../quesma
-    image: quesma:nigthly
+    image: quesma:nightly
     environment:
       - QUESMA_CONFIG_FILE=/mnt/ci-config.yaml
       - QUESMA_logging_path=/var/quesma/logs

--- a/ci/e2e.yml
+++ b/ci/e2e.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   quesma:
     build: ../quesma
-    image: quesma:latest
+    image: quesma:nigthly
     environment:
       - QUESMA_CONFIG_FILE=/mnt/ci-config.yaml
       - QUESMA_elasticsearch_url=http://elasticsearch:9200

--- a/ci/e2e.yml
+++ b/ci/e2e.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   quesma:
     build: ../quesma
-    image: quesma:nigthly
+    image: quesma:nightly
     environment:
       - QUESMA_CONFIG_FILE=/mnt/ci-config.yaml
       - QUESMA_elasticsearch_url=http://elasticsearch:9200


### PR DESCRIPTION
Changes to how we build/publish Quesma Docker images:
* what used to be `quesma/quesma:latest` now becomes a pointer to **latest released version**
* introducing `quesma/quesma:nightly` image which becomes the most recent (not necessarily released/stable) version, always built and pushed from the `main` branch
* removing image pushes to GCR for  `quesma/quesma:nightly`. Release images will stay, as GCP's products don't support pulling from DockerHub (😢) 