### PR TITLE
Fix double JSON marshalling in elasticsearch client's Request*()

### DIFF
--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"quesma/logger"
@@ -33,19 +32,11 @@ func NewSimpleClient(configuration *config.ElasticsearchConfiguration) *SimpleCl
 		config: configuration,
 	}
 }
-func (es *SimpleClient) Request(ctx context.Context, method, endpoint string, payload interface{}) (*http.Response, error) {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
+func (es *SimpleClient) Request(ctx context.Context, method, endpoint string, body []byte) (*http.Response, error) {
 	return es.doRequest(ctx, method, endpoint, body, nil)
 }
 
-func (es *SimpleClient) RequestWithHeaders(ctx context.Context, method, endpoint string, payload interface{}, headers http.Header) (*http.Response, error) {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
+func (es *SimpleClient) RequestWithHeaders(ctx context.Context, method, endpoint string, body []byte, headers http.Header) (*http.Response, error) {
 	return es.doRequest(ctx, method, endpoint, body, headers)
 }
 


### PR DESCRIPTION
`Request()` and `RequestWithHeaders()` methods of elasticsearch client always "JSON marshalled" the incoming payload (body). However all users of those methods actually already gave a JSON marshalled payload! This caused the request body to be double marshalled, resulting in some strange base64 blob, which broke our double writes (sending bulk to Elastic).

Fix the problem by NOT marshalling in `Request*()` methods. Improve the `client_test.go` to validate that the client did not tamper with the body.