### PR TITLE
Create common table if needed

### DIFF
--- a/quesma/main.go
+++ b/quesma/main.go
@@ -94,8 +94,10 @@ func main() {
 	var ingestProcessor *ingest.IngestProcessor
 
 	if cfg.EnableIngest {
-		// Ensure common table exists. This table have to be created before ingest processor starts
-		common_table.EnsureCommonTableExists(connectionPool)
+		if cfg.CreateCommonTable {
+			// Ensure common table exists. This table have to be created before ingest processor starts
+			common_table.EnsureCommonTableExists(connectionPool)
+		}
 
 		ingestProcessor = ingest.NewEmptyIngestProcessor(&cfg, connectionPool, phoneHomeAgent, tableDisco, schemaRegistry, virtualTableStorage)
 	} else {

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -46,7 +46,8 @@ type QuesmaConfiguration struct {
 	DisableAuth                bool                          `koanf:"disableAuth"`
 	AutodiscoveryEnabled       bool
 
-	EnableIngest bool // this is computed from the configuration 2.0
+	EnableIngest      bool // this is computed from the configuration 2.0
+	CreateCommonTable bool
 }
 
 type LoggingConfiguration struct {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -517,10 +517,11 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					processedConfig.QueryTarget = append(processedConfig.QueryTarget, ClickhouseTarget)
 				}
 
-				if len(processedConfig.QueryTarget) == 2 && !(processedConfig.QueryTarget[0] == ClickhouseTarget && processedConfig.QueryTarget[1] == ElasticsearchTarget) {
+				if len(processedConfig.QueryTarget) == 2 && !(indexConfig.Target[0] == relationalDBBackendName && indexConfig.Target[1] == elasticBackendName) {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("index %s has invalid dual query target configuration - when you specify two targets, ClickHouse has to be the primary one and Elastic has to be the secondary one", indexName))
 					continue
 				}
+
 				if len(processedConfig.QueryTarget) == 2 {
 					// Turn on A/B testing
 					processedConfig.Optimizers = make(map[string]OptimizerConfiguration)
@@ -579,7 +580,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				processedConfig.QueryTarget = append(processedConfig.QueryTarget, ClickhouseTarget)
 			}
 
-			if len(processedConfig.QueryTarget) == 2 && !(processedConfig.QueryTarget[0] == ClickhouseTarget && processedConfig.QueryTarget[1] == ElasticsearchTarget) {
+			if len(processedConfig.QueryTarget) == 2 && !(indexConfig.Target[0] == relationalDBBackendName && indexConfig.Target[1] == elasticBackendName) {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("index %s has invalid dual query target configuration - when you specify two targets, ClickHouse has to be the primary one and Elastic has to be the secondary one", indexName))
 				continue
 			}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -630,6 +630,13 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 END:
 
+	for _, idxCfg := range conf.IndexConfig {
+		if idxCfg.UseCommonTable {
+			conf.CreateCommonTable = true
+			break
+		}
+	}
+
 	if relationalDBErr != nil && !conf.TransparentProxy {
 		errAcc = multierror.Append(errAcc, relationalDBErr)
 	} else if relationalDBErr != nil && conf.TransparentProxy {

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -129,6 +130,19 @@ func TestHasCommonTable(t *testing.T) {
 
 	assert.Equal(t, true, legacyConf.EnableIngest)
 	assert.Equal(t, true, legacyConf.CreateCommonTable)
+}
+
+func TestInvalidDualTarget(t *testing.T) {
+	os.Setenv(configFileLocationEnvVar, "./test_configs/invalid_dual_target.yaml")
+	cfg := LoadV2Config()
+	if err := cfg.Validate(); err != nil {
+
+		if !strings.Contains(err.Error(), "has invalid dual query target configuration - when you specify two targets") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		t.Fatalf("expected error, but got none")
+	}
 }
 
 func TestMatchName(t *testing.T) {

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -70,6 +70,8 @@ func TestQuesmaTransparentProxyConfiguration(t *testing.T) {
 	}
 	legacyConf := cfg.TranslateToLegacyConfig()
 	assert.True(t, legacyConf.TransparentProxy)
+	assert.Equal(t, false, legacyConf.EnableIngest)
+	assert.Equal(t, false, legacyConf.CreateCommonTable)
 }
 
 func TestQuesmaAddingHydrolixTablesToExistingElasticsearch(t *testing.T) {
@@ -89,7 +91,8 @@ func TestQuesmaAddingHydrolixTablesToExistingElasticsearch(t *testing.T) {
 
 	assert.Equal(t, []string{"clickhouse"}, logsIndexConf.QueryTarget)
 	assert.Equal(t, []string{"elasticsearch"}, logsIndexConf.IngestTarget)
-
+	assert.Equal(t, true, legacyConf.EnableIngest)
+	assert.Equal(t, false, legacyConf.CreateCommonTable)
 }
 
 func TestQuesmaHydrolixQueryOnly(t *testing.T) {
@@ -113,6 +116,19 @@ func TestQuesmaHydrolixQueryOnly(t *testing.T) {
 
 	assert.Equal(t, false, legacyConf.EnableIngest)
 	assert.Equal(t, false, legacyConf.IngestStatistics)
+	assert.Equal(t, false, legacyConf.CreateCommonTable)
+}
+
+func TestHasCommonTable(t *testing.T) {
+	os.Setenv(configFileLocationEnvVar, "./test_configs/has_common_table.yaml")
+	cfg := LoadV2Config()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("error validating config: %v", err)
+	}
+	legacyConf := cfg.TranslateToLegacyConfig()
+
+	assert.Equal(t, true, legacyConf.EnableIngest)
+	assert.Equal(t, true, legacyConf.CreateCommonTable)
 }
 
 func TestMatchName(t *testing.T) {

--- a/quesma/quesma/config/test_configs/has_common_table.yaml
+++ b/quesma/quesma/config/test_configs/has_common_table.yaml
@@ -1,0 +1,70 @@
+installationId: #HYDROLIX_REQUIRES_THIS
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: E
+    type: elasticsearch
+    config:
+      url: "http://elasticsearch:9200"
+      user: elastic
+      password: quesmaquesma
+  - name: C
+    type: clickhouse-os
+    config:
+      url: "clickhouse://clickhouse:9000"
+ingestStatistics: true
+processors:
+  - name: QP
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        logs-1:
+          target: [ E ]
+        logs-2:
+          target: [ E ]
+        logs-3:
+          target: [ C, E ]
+        logs-4:
+          useCommonTable: true
+          target: [ C ]
+        logs-5:
+          useCommonTable: true
+          target: [ C ]
+        "*":
+          target: [ E ]
+
+  - name: IP
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        logs-1:
+          target: [ E ]
+        logs-2:
+          target: [ E ]
+        logs-3:
+          target: [ C, E ]
+        logs-4:
+          useCommonTable: true
+          target: [ C ]
+        "*":
+          target: [ E ]
+        logs-5:
+          useCommonTable: true
+          target: [  ]
+
+pipelines:
+  - name: my-elasticsearch-proxy-read
+    frontendConnectors: [ elastic-query ]
+    processors: [ QP ]
+    backendConnectors: [ E, C ]
+  - name: my-elasticsearch-proxy-write
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ IP ]
+    backendConnectors: [ E, C ]

--- a/quesma/quesma/config/test_configs/invalid_dual_target.yaml
+++ b/quesma/quesma/config/test_configs/invalid_dual_target.yaml
@@ -1,0 +1,53 @@
+installationId: #HYDROLIX_REQUIRES_THIS
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: E
+    type: elasticsearch
+    config:
+      url: "http://elasticsearch:9200"
+      user: elastic
+      password: quesmaquesma
+  - name: C
+    type: clickhouse-os
+    config:
+      url: "clickhouse://clickhouse:9000"
+ingestStatistics: true
+processors:
+  - name: QP
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        invalid:
+          target: [ E,C  ]
+        "*":
+          target: [ E ]
+
+  - name: IP
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        invalid:
+          target: [ C, E ]
+        "*":
+          target: [ E ]
+        logs-5:
+          useCommonTable: true
+          target: [  ]
+
+pipelines:
+  - name: my-elasticsearch-proxy-read
+    frontendConnectors: [ elastic-query ]
+    processors: [ QP ]
+    backendConnectors: [ E, C ]
+  - name: my-elasticsearch-proxy-write
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ IP ]
+    backendConnectors: [ E, C ]


### PR DESCRIPTION
We should create the common table if there is an index using it. In other cases, it emits unnecessary logs. 

It fixes a bug while processing the config.