### PR TITLE
Fix histogram when `interval==1`

### DIFF
--- a/quesma/model/bucket_aggregations/histogram.go
+++ b/quesma/model/bucket_aggregations/histogram.go
@@ -112,8 +112,8 @@ func (query *HistogramRowsTransformer) getKeyFloat64(row model.QueryResultRow) (
 // we don't know the type
 func (query *HistogramRowsTransformer) getKeyUnknownType(row model.QueryResultRow) (float64, bool) {
 	val := row.Cols[len(row.Cols)-2].Value
-	if valTyped, ok := util.ExtractNumeric64Maybe(val); ok {
-		return valTyped, true
+	if valAsFloat, ok := util.ExtractNumeric64Maybe(val); ok {
+		return valAsFloat, true
 	}
 	return -1, false
 }

--- a/quesma/model/bucket_aggregations/histogram.go
+++ b/quesma/model/bucket_aggregations/histogram.go
@@ -74,6 +74,12 @@ func (query *HistogramRowsTransformer) Transform(ctx context.Context, rowsFromDB
 	}
 	postprocessedRows := make([]model.QueryResultRow, 0, len(rowsFromDB))
 	postprocessedRows = append(postprocessedRows, rowsFromDB[0])
+
+	getKey := query.getKeyFloat64
+	if query.interval == 1.0 {
+		getKey = query.getKeyUnknownType
+	}
+
 	for i := 1; i < len(rowsFromDB); i++ {
 		if len(rowsFromDB[i-1].Cols) < 2 || len(rowsFromDB[i].Cols) < 2 {
 			logger.ErrorWithCtx(ctx).Msgf(
@@ -82,20 +88,32 @@ func (query *HistogramRowsTransformer) Transform(ctx context.Context, rowsFromDB
 				i-1, rowsFromDB[i-1], i, rowsFromDB[i],
 			)
 		}
-		lastKey := query.getKey(rowsFromDB[i-1])
-		currentKey := query.getKey(rowsFromDB[i])
-		// we need to add rows in between
-		for midKey := lastKey + query.interval; util.IsSmaller(midKey, currentKey); midKey += query.interval {
-			midRow := rowsFromDB[i-1].Copy()
-			midRow.Cols[len(midRow.Cols)-2].Value = midKey
-			midRow.Cols[len(midRow.Cols)-1].Value = 0
-			postprocessedRows = append(postprocessedRows, midRow)
+		lastKey, okLast := getKey(rowsFromDB[i-1])
+		currentKey, okCurrent := getKey(rowsFromDB[i])
+		if okLast && okCurrent {
+			// we need to add rows in between
+			for midKey := lastKey + query.interval; util.IsSmaller(midKey, currentKey); midKey += query.interval {
+				midRow := rowsFromDB[i-1].Copy()
+				midRow.Cols[len(midRow.Cols)-2].Value = midKey
+				midRow.Cols[len(midRow.Cols)-1].Value = 0
+				postprocessedRows = append(postprocessedRows, midRow)
+			}
 		}
 		postprocessedRows = append(postprocessedRows, rowsFromDB[i])
 	}
 	return postprocessedRows
 }
 
-func (query *HistogramRowsTransformer) getKey(row model.QueryResultRow) float64 {
-	return row.Cols[len(row.Cols)-2].Value.(float64)
+// we're sure key is float64
+func (query *HistogramRowsTransformer) getKeyFloat64(row model.QueryResultRow) (float64, bool) {
+	return row.Cols[len(row.Cols)-2].Value.(float64), true
+}
+
+// we don't know the type
+func (query *HistogramRowsTransformer) getKeyUnknownType(row model.QueryResultRow) (float64, bool) {
+	val := row.Cols[len(row.Cols)-2].Value
+	if valTyped, ok := util.ExtractNumeric64Maybe(val); ok {
+		return valTyped, true
+	}
+	return -1, false
 }

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -3911,4 +3911,183 @@ var AggregationTests2 = []AggregationTestCase{
 			ORDER BY "aggr__histo5__key_0" ASC`,
 		},
 	},
+	{ // [64]
+		TestName: "histogram, min_doc_count=0, int keys when interval=1",
+		QueryRequestJson: `
+		{
+			"_source": {
+				"excludes": []
+			},
+			"aggs": {
+				"interval-2": {
+					"histogram": {
+						"field": "total_quantity",
+						"interval": 2,
+						"min_doc_count": 0
+					}
+				},
+				"interval-1": {
+					"histogram": {
+						"field": "total_quantity",
+						"interval": 1,
+						"min_doc_count": 0
+					}
+				},
+				"interval-0.5": {
+					"histogram": {
+						"field": "total_quantity",
+						"interval": 0.5,
+						"min_doc_count": 0
+					}
+				},
+				"interval-0": {
+					"histogram": {
+						"field": "total_quantity",
+						"interval": 0,
+						"min_doc_count": 0
+					}
+				}
+			},
+			"runtime_mappings": {},
+			"script_fields": {},
+			"size": 0,
+			"stored_fields": [
+				"*"
+			],
+			"track_total_hits": true
+		}`,
+		ExpectedResponse: `
+		{
+			"took": 0,
+			"timed_out": false,
+			"_shards": {
+				"total": 1,
+				"successful": 1,
+				"skipped": 0,
+				"failed": 0
+			},
+			"hits": {
+				"total": {
+					"value": 4675,
+					"relation": "eq"
+				},
+				"max_score": null,
+				"hits": []
+			},
+			"aggregations": {
+				"interval-2": {
+					"buckets": [
+						{
+							"doc_count": 87,
+							"key": 0
+						},
+						{
+							"doc_count": 0,
+							"key": 2
+						},
+						{
+							"doc_count": 411,
+							"key": 4
+						}
+					]
+				},
+				"interval-1": {
+					"buckets": [
+						{
+							"doc_count": 87,
+							"key": 0
+						},
+						{
+							"doc_count": 0,
+							"key": 1
+						},
+						{
+							"doc_count": 411,
+							"key": 2
+						}
+					]
+				},
+				"interval-0.5": {
+					"buckets": [
+						{
+							"doc_count": 87,
+							"key": 0
+						},
+						{
+							"doc_count": 0,
+							"key": 0.5
+						},
+						{
+							"doc_count": 411,
+							"key": 1
+						}
+					]
+				},
+				"interval-0": {
+					"buckets": []
+				}
+			}
+		}`,
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__interval-0__key_0", nil),
+				model.NewQueryResultCol("aggr__interval-0__count", int64(4675)),
+			}},
+		},
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-0.5__key_0", 0.0),
+					model.NewQueryResultCol("aggr__interval-0.5__count", int64(87)),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-0.5__key_0", 1.0),
+					model.NewQueryResultCol("aggr__interval-0.5__count", int64(411)),
+				}},
+			},
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-1__key_0", 0),
+					model.NewQueryResultCol("aggr__interval-1__count", int64(87)),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-1__key_0", int64(2)),
+					model.NewQueryResultCol("aggr__interval-1__count", int64(411)),
+				}},
+			},
+			{
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-2__key_0", 0.0),
+					model.NewQueryResultCol("aggr__interval-2__count", int64(87)),
+				}},
+				{Cols: []model.QueryResultCol{
+					model.NewQueryResultCol("aggr__interval-2__key_0", 4.0),
+					model.NewQueryResultCol("aggr__interval-2__count", int64(411)),
+				}},
+			},
+		},
+		ExpectedPancakeSQL: `
+			SELECT floor("total_quantity"/0)*0 AS "aggr__interval-0__key_0",
+			  count(*) AS "aggr__interval-0__count"
+			FROM __quesma_table_name
+			GROUP BY floor("total_quantity"/0)*0 AS "aggr__interval-0__key_0"
+			ORDER BY "aggr__interval-0__key_0" ASC`,
+		ExpectedAdditionalPancakeSQLs: []string{
+			`SELECT floor("total_quantity"/0.5)*0.5 AS "aggr__interval-0.5__key_0",
+			  count(*) AS "aggr__interval-0.5__count"
+			FROM __quesma_table_name
+			GROUP BY floor("total_quantity"/0.5)*0.5 AS "aggr__interval-0.5__key_0"
+			ORDER BY "aggr__interval-0.5__key_0" ASC`,
+			`SELECT "total_quantity" AS "aggr__interval-1__key_0",
+			  count(*) AS "aggr__interval-1__count"
+			FROM __quesma_table_name
+			GROUP BY "total_quantity" AS "aggr__interval-1__key_0"
+			ORDER BY "aggr__interval-1__key_0" ASC`,
+			`SELECT floor("total_quantity"/2)*2 AS "aggr__interval-2__key_0",
+			  count(*) AS "aggr__interval-2__count"
+			FROM __quesma_table_name
+			GROUP BY floor("total_quantity"/2)*2 AS "aggr__interval-2__key_0"
+			ORDER BY "aggr__interval-2__key_0" ASC`,
+		},
+	},
 }


### PR DESCRIPTION
When `interval` is any other than `1`, we receive a float, so no change needed (as we do `(field / interval) * interval` and it's a float even if `interval` is an integer, like `2` (tested))
When `interval` is `1`, we get any type the field is in DB, as we just do `SELECT field`, so we need to check all int/float types. Added that here.
Before:
<img width="1722" alt="Screenshot 2024-10-03 at 14 27 30" src="https://github.com/user-attachments/assets/ea8ddbf0-9cdd-413f-898b-bf941a8a5079">
<img width="1723" alt="Screenshot 2024-10-03 at 14 27 23" src="https://github.com/user-attachments/assets/d2344efd-b6dc-4a1c-8729-d1534517cdab">
After:
<img width="1713" alt="Screenshot 2024-10-03 at 14 50 38" src="https://github.com/user-attachments/assets/54d78d12-229a-43d1-8a71-2c8b7948df97">
