### PR TITLE
Unskip 2 tests

### DIFF
--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -49,9 +49,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 
 	for i, test := range allAggregationTests() {
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {
-			if i != 29 { //  || i == 30 {
-				t.Skip("Skipped also for previous implementation. New tests, harder, failing for now.")
-			}
 			if test.TestName == "Range with subaggregations. Reproduce: Visualize -> Pie chart -> Aggregation: Top Hit, Buckets: Aggregation: Range(file:opensearch-visualize/agg_req,nr:1)" {
 				t.Skip("Skipped also for previous implementation. Top_hits needs to be better.")
 			}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -49,7 +49,7 @@ func TestPancakeQueryGeneration(t *testing.T) {
 
 	for i, test := range allAggregationTests() {
 		t.Run(test.TestName+"("+strconv.Itoa(i)+")", func(t *testing.T) {
-			if i == 29 || i == 30 {
+			if i != 29 { //  || i == 30 {
 				t.Skip("Skipped also for previous implementation. New tests, harder, failing for now.")
 			}
 			if test.TestName == "Range with subaggregations. Reproduce: Visualize -> Pie chart -> Aggregation: Top Hit, Buckets: Aggregation: Range(file:opensearch-visualize/agg_req,nr:1)" {

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -5310,49 +5310,6 @@ var AggregationTests = []AggregationTestCase{
 					}
 				}
 			},
-			"docvalue_fields": [
-				{
-					"field": "@timestamp",
-					"format": "date_time"
-				},
-				{
-					"field": "timestamp",
-					"format": "date_time"
-				},
-				{
-					"field": "utc_time",
-					"format": "date_time"
-				}
-			],
-			"query": {
-				"bool": {
-					"filter": [
-						{
-							"match_all": {}
-						},
-						{
-							"range": {
-								"timestamp": {
-									"format": "strict_date_optional_time",
-									"gte": "2024-05-10T06:15:26.167Z",
-									"lte": "2024-05-10T21:15:26.167Z"
-								}
-							}
-						}
-					],
-					"must": [],
-					"must_not": [],
-					"should": []
-				}
-			},
-			"script_fields": {
-				"hour_of_day": {
-					"script": {
-						"lang": "painless",
-						"source": "doc['timestamp'].value.getHour()"
-					}
-				}
-			},
 			"size": 0,
 			"stored_fields": [
 				"*"
@@ -5360,80 +5317,129 @@ var AggregationTests = []AggregationTestCase{
 		}`,
 		ExpectedResponse: `
 		{
-			"is_partial": false,
-			"is_running": false,
-			"start_time_in_millis": 1711785625800,
-			"expiration_time_in_millis": 1712217625800,
-			"completion_time_in_millis": 1711785625803,
-			"response": {
-				"took": 3,
-				"timed_out": false,
-				"_shards": {
-					"total": 1,
-					"successful": 1,
-					"skipped": 0,
-					"failed": 0
-				},
-				"hits": {
-					"total": {
-						"value": 2167,
-						"relation": "eq"
-					},
-					"max_score": null,
-					"hits": []
-				},
-				"aggregations": {
-					"0": {
-						"doc_count_error_upper_bound": 0,
-						"sum_other_doc_count": 0,
-						"buckets": [
-							{
-								"key": "Albuquerque",
-								"doc_count": 4,
-								"3-bucket": {
-									"doc_count": 2
-								},
-								"1-bucket": {
-									"doc_count": 1
-								}
+			"aggregations": {
+				"3": {
+					"buckets": [
+						{
+							"1": {
+								"value": 79725689
 							},
-							{
-								"key": "Atlanta",
-								"doc_count": 5,
-								"3-bucket": {
-									"doc_count": 0
-								},
-								"1-bucket": {
-									"doc_count": 0
-								}
+							"2": {
+								"buckets": [
+									{
+										"1": {
+											"value": 16537711
+										},
+										"doc_count": 2885,
+										"key": "win xp"
+									},
+									{
+										"1": {
+											"value": 3
+										},
+										"doc_count": 2,
+										"key": "win xd"
+									}
+								],
+								"doc_count_error_upper_bound": 0,
+								"sum_other_doc_count": 11187
 							},
-							{
-								"key": "Baltimore",
-								"doc_count": 5,
-								"3-bucket": {
-									"doc_count": 0
-								},
-								"1-bucket": {
-									"doc_count": 2
-								}
+							"doc_count": 14074,
+							"key": "US"
+						},
+						{
+							"key": "PL",
+							"doc_count": 1410,
+							"1": {
+								"value": null
 							}
-						]
-					}
+						},
+						{
+							"1": {
+								"value": 1.1
+							},
+							"2": {
+								"buckets": [
+									{
+										"1": {
+											"value": 2.2
+										},
+										"doc_count": 28,
+										"key": "win xp"
+									}
+								],
+								"doc_count_error_upper_bound": 0,
+								"sum_other_doc_count": 1
+							},
+							"doc_count": 29,
+							"key": "DE"
+						}
+					],
+					"doc_count_error_upper_bound": 0,
+					"sum_other_doc_count": 44487
 				}
 			}
 		}`,
 		ExpectedPancakeResults: []model.QueryResultRow{
 			{Cols: []model.QueryResultCol{
-				model.NewQueryResultCol("aggr__3__parent_count", uint64(619)),
-				model.NewQueryResultCol("aggr__3__key_0", "a"),
-				model.NewQueryResultCol("aggr__3__count", uint64(619)),
-				model.NewQueryResultCol("aggr__3__order_1", uint64(619)),
-				model.NewQueryResultCol("metric__3__1_col_0", uint64(619)),
-				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(619)),
-				model.NewQueryResultCol("aggr__3__2__key_0", "a"),
-				model.NewQueryResultCol("aggr__3__2__count", uint64(619)),
-				model.NewQueryResultCol("aggr__3__2__order_1", uint64(619)),
-				model.NewQueryResultCol("metric__3__2__1_col_0", uint64(619)),
+				model.NewQueryResultCol("aggr__3__parent_count", uint64(60000)),
+				model.NewQueryResultCol("aggr__3__key_0", "US"),
+				model.NewQueryResultCol("aggr__3__count", uint64(14074)),
+				model.NewQueryResultCol("aggr__3__order_1", 79725689),
+				model.NewQueryResultCol("metric__3__1_col_0", 79725689),
+				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(14074)),
+				model.NewQueryResultCol("aggr__3__2__key_0", "win xp"),
+				model.NewQueryResultCol("aggr__3__2__count", uint64(2885)),
+				model.NewQueryResultCol("aggr__3__2__order_1", 16537711),
+				model.NewQueryResultCol("metric__3__2__1_col_0", 16537711),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__3__parent_count", uint64(60000)),
+				model.NewQueryResultCol("aggr__3__key_0", "US"),
+				model.NewQueryResultCol("aggr__3__count", uint64(14074)),
+				model.NewQueryResultCol("aggr__3__order_1", 79725689),
+				model.NewQueryResultCol("metric__3__1_col_0", 79725689),
+				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(14074)),
+				model.NewQueryResultCol("aggr__3__2__key_0", "win xd"),
+				model.NewQueryResultCol("aggr__3__2__count", uint64(2)),
+				model.NewQueryResultCol("aggr__3__2__order_1", 3),
+				model.NewQueryResultCol("metric__3__2__1_col_0", 3),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__3__parent_count", uint64(60000)),
+				model.NewQueryResultCol("aggr__3__key_0", "PL"),
+				model.NewQueryResultCol("aggr__3__count", uint64(1410)),
+				model.NewQueryResultCol("aggr__3__order_1", nil),
+				model.NewQueryResultCol("metric__3__1_col_0", nil),
+				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(1410)),
+				model.NewQueryResultCol("aggr__3__2__key_0", nil),
+				model.NewQueryResultCol("aggr__3__2__count", uint64(2)),
+				model.NewQueryResultCol("aggr__3__2__order_1", nil),
+				model.NewQueryResultCol("metric__3__2__1_col_0", nil),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__3__parent_count", uint64(60000)),
+				model.NewQueryResultCol("aggr__3__key_0", "DE"),
+				model.NewQueryResultCol("aggr__3__count", uint64(29)),
+				model.NewQueryResultCol("aggr__3__order_1", 1.1),
+				model.NewQueryResultCol("metric__3__1_col_0", 1.1),
+				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(29)),
+				model.NewQueryResultCol("aggr__3__2__key_0", "win xp"),
+				model.NewQueryResultCol("aggr__3__2__count", uint64(28)),
+				model.NewQueryResultCol("aggr__3__2__order_1", 2.2),
+				model.NewQueryResultCol("metric__3__2__1_col_0", 2.2),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__3__parent_count", uint64(60000)),
+				model.NewQueryResultCol("aggr__3__key_0", "DE"),
+				model.NewQueryResultCol("aggr__3__count", uint64(29)),
+				model.NewQueryResultCol("aggr__3__order_1", 1.1),
+				model.NewQueryResultCol("metric__3__1_col_0", 1.1),
+				model.NewQueryResultCol("aggr__3__2__parent_count", uint64(29)),
+				model.NewQueryResultCol("aggr__3__2__key_0", nil),
+				model.NewQueryResultCol("aggr__3__2__count", uint64(1)),
+				model.NewQueryResultCol("aggr__3__2__order_1", 2),
+				model.NewQueryResultCol("metric__3__2__1_col_0", 2),
 			}},
 		},
 		ExpectedPancakeSQL: `
@@ -5465,8 +5471,6 @@ var AggregationTests = []AggregationTestCase{
 				  sumOrNull("memory") AS "aggr__3__2__order_1",
 				  sumOrNull("memory") AS "metric__3__2__1_col_0"
 				FROM __quesma_table_name
-				WHERE ("timestamp">=parseDateTime64BestEffort('2024-05-10T06:15:26.167Z')
-				  AND "timestamp"<=parseDateTime64BestEffort('2024-05-10T21:15:26.167Z'))
 				GROUP BY "geo.src" AS "aggr__3__key_0", "machine.os" AS "aggr__3__2__key_0"))
 			WHERE ("aggr__3__order_1_rank"<=6 AND "aggr__3__2__order_1_rank"<=6)
 			ORDER BY "aggr__3__order_1_rank" ASC, "aggr__3__2__order_1_rank" ASC`,


### PR DESCRIPTION
No changes in the code, just tests.

Completed 2 tests. Old logic had some problems with them, that is with subaggregations results missing (being empty) for some of the more top-level keys.
Pancakes seem to be handling it correctly, so no changes in the code were needed.