### PR TITLE
Quickfix panic at Hdx

### DIFF
--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -75,6 +75,10 @@ func (s *OptimizePipeline) findConfig(transformer OptimizeTransformer, queries [
 
 func (s *OptimizePipeline) Transform(queries []*model.Query) ([]*model.Query, error) {
 
+	if len(queries) == 0 {
+		return queries, nil
+	}
+
 	// add  hints if not present
 	for _, query := range queries {
 		if query.OptimizeHints == nil {

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -191,7 +191,8 @@ func (q *QueryRunner) runExecutePlanAsync(ctx context.Context, plan *model.Execu
 			return
 		}
 
-		if len(translatedQueryBody) > 0 && len(results) == 0 {
+		if len(plan.Queries) > 0 && len(results) == 0 {
+			// if there are no queries, empty results are fine
 			logger.ErrorWithCtx(ctx).Msgf("no hits, sqls: %v", translatedQueryBody)
 			doneCh <- AsyncSearchWithError{translatedQueryBody: translatedQueryBody, err: errors.New("no hits")}
 			return

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -191,7 +191,7 @@ func (q *QueryRunner) runExecutePlanAsync(ctx context.Context, plan *model.Execu
 			return
 		}
 
-		if len(results) == 0 {
+		if len(translatedQueryBody) > 0 && len(results) == 0 {
 			logger.ErrorWithCtx(ctx).Msgf("no hits, sqls: %v", translatedQueryBody)
 			doneCh <- AsyncSearchWithError{translatedQueryBody: translatedQueryBody, err: errors.New("no hits")}
 			return
@@ -831,7 +831,7 @@ func (q *QueryRunner) findNonexistingProperties(query *model.Query, table *click
 func (q *QueryRunner) postProcessResults(plan *model.ExecutionPlan, results [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {
 
 	if len(plan.Queries) == 0 {
-		return nil, fmt.Errorf("postProcessResults: plan.Queries is empty")
+		return results, nil
 	}
 
 	// maybe model.Schema should be part of ExecutionPlan instead of Query


### PR DESCRIPTION
This request caused panic
```
POST /logs*/_search
{
  "_source": false,
  "fields": [
    {
      "field": "*",
      "include_unmapped": "true"
    },
    {
      "field": "reqTimeSec",
      "format": "strict_date_optional_time"
    }
  ],
  "highlight": {
    "fields": {
      "*": {}
    },
    "fragment_size": 2147483647,
    "post_tags": [
      "@/kibana-highlighted-field@"
    ],
    "pre_tags": [
      "@kibana-highlighted-field@"
    ]
  },
  "query": {
    "bool": {
      "filter": [
        {
          "range": {
            "timestamp": {
              "format": "strict_date_optional_time",
              "gte": "2024-10-01T11:12:46.174Z",
              "lte": "2024-10-14T11:27:46.174Z"
            }
          }
        }
      ],
      "must": [],
      "must_not": [],
      "should": []
    }
  },
  "runtime_mappings": {},
  "script_fields": {},
  "size": 0,
  "sort": [
    {
      "timestamp": {
        "format": "strict_date_optional_time",
        "order": "desc",
        "unmapped_type": "boolean"
      }
    },
    {
      "_doc": {
        "order": "desc",
        "unmapped_type": "boolean"
      }
    }
  ],
  "stored_fields": [
    "*"
  ],
  "track_total_hits": false,
  "version": true
}
```
<img width="1728" alt="Screenshot 2024-10-04 at 13 36 13" src="https://github.com/user-attachments/assets/cfc6ec0d-9393-4b95-9962-bc9ed0ffe8ac">
After:
<img width="400" alt="Screenshot 2024-10-04 at 13 48 18" src="https://github.com/user-attachments/assets/e33c425c-178c-48f1-978e-285a1f1c1bdd">
