### PR TITLE
Fix dates in pipeline aggregations

### DIFF
--- a/quesma/model/bucket_aggregations/date_histogram.go
+++ b/quesma/model/bucket_aggregations/date_histogram.go
@@ -35,6 +35,7 @@ type DateHistogram struct {
 	field             model.Expr // name of the field, e.g. timestamp
 	interval          string
 	timezone          string
+	wantedTimezone    *time.Location // key is in `timezone` time, and we need it to be UTC
 	minDocCount       int
 	intervalType      DateHistogramIntervalType
 	fieldDateTimeType clickhouse.DateTimeType
@@ -42,7 +43,14 @@ type DateHistogram struct {
 
 func NewDateHistogram(ctx context.Context, field model.Expr, interval, timezone string,
 	minDocCount int, intervalType DateHistogramIntervalType, fieldDateTimeType clickhouse.DateTimeType) *DateHistogram {
-	return &DateHistogram{ctx: ctx, field: field, interval: interval, timezone: timezone,
+
+	wantedTimezone, err := time.LoadLocation(timezone)
+	if err != nil {
+		logger.ErrorWithCtx(ctx).Msgf("time.LoadLocation error: %v", err)
+		wantedTimezone = time.UTC
+	}
+
+	return &DateHistogram{ctx: ctx, field: field, interval: interval, timezone: timezone, wantedTimezone: wantedTimezone,
 		minDocCount: minDocCount, intervalType: intervalType, fieldDateTimeType: fieldDateTimeType}
 }
 
@@ -79,40 +87,20 @@ func (query *DateHistogram) TranslateSqlResponseToJson(rows []model.QueryResultR
 		rows = query.NewRowsTransformer().Transform(query.ctx, rows)
 	}
 
-	// key is in `query.timezone` time, and we need it to be UTC
-	wantedTimezone, err := time.LoadLocation(query.timezone)
-	if err != nil {
-		logger.ErrorWithCtx(query.ctx).Msgf("time.LoadLocation error: %v", err)
-		wantedTimezone = time.UTC
-	}
-
 	var response []model.JsonMap
 	for _, row := range rows {
-		var key int64
 		docCount := row.LastColValue()
 		if util.ExtractInt64(docCount) < int64(query.minDocCount) {
 			continue
 		}
-
 		originalKey := query.getKey(row)
-		if query.intervalType == DateHistogramCalendarInterval {
-			key = originalKey
-		} else {
-			intervalInMilliseconds := query.intervalAsDuration().Milliseconds()
-			key = originalKey * intervalInMilliseconds
-		}
-
-		ts := time.UnixMilli(key).UTC()
-		intervalStartNotUTC := time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), wantedTimezone)
-
-		_, timezoneOffsetInSeconds := intervalStartNotUTC.Zone()
-		key -= int64(timezoneOffsetInSeconds * 1000) // seconds -> milliseconds
+		responseKey := query.calculateResponseKey(originalKey)
 
 		response = append(response, model.JsonMap{
 			OriginalKeyName: originalKey,
-			"key":           key,
+			"key":           responseKey,
 			"doc_count":     docCount, // used to be [level], but because some columns are duplicated, it doesn't work in 100% cases now
-			"key_as_string": time.UnixMilli(key).UTC().Format("2006-01-02T15:04:05.000"),
+			"key_as_string": query.calcKeyAsString(responseKey),
 		})
 	}
 
@@ -124,6 +112,22 @@ func (query *DateHistogram) TranslateSqlResponseToJson(rows []model.QueryResultR
 func (query *DateHistogram) String() string {
 	return fmt.Sprintf("date_histogram(field: %v, interval: %v, min_doc_count: %v, timezone: %v",
 		query.field, query.interval, query.minDocCount, query.timezone)
+}
+
+func (query *DateHistogram) calculateResponseKey(originalKey int64) int64 {
+	var key int64
+	if query.intervalType == DateHistogramCalendarInterval {
+		key = originalKey
+	} else {
+		intervalInMilliseconds := query.intervalAsDuration().Milliseconds()
+		key = originalKey * intervalInMilliseconds
+	}
+
+	ts := time.UnixMilli(key).UTC()
+	intervalStartNotUTC := time.Date(ts.Year(), ts.Month(), ts.Day(), ts.Hour(), ts.Minute(), ts.Second(), ts.Nanosecond(), query.wantedTimezone)
+
+	_, timezoneOffsetInSeconds := intervalStartNotUTC.Zone()
+	return key - int64(timezoneOffsetInSeconds*1000) // seconds -> milliseconds
 }
 
 // only intervals <= days are needed
@@ -218,6 +222,15 @@ func (query *DateHistogram) generateSQLForCalendarInterval() model.Expr {
 
 func (query *DateHistogram) getKey(row model.QueryResultRow) int64 {
 	return row.Cols[len(row.Cols)-2].Value.(int64)
+}
+
+func (query *DateHistogram) calcKeyAsString(key int64) string {
+	return time.UnixMilli(key).UTC().Format("2006-01-02T15:04:05.000")
+}
+
+func (query *DateHistogram) OriginalKeyToKeyAsString(originalKey any) string {
+	key := query.calculateResponseKey(originalKey.(int64))
+	return query.calcKeyAsString(key)
 }
 
 func (query *DateHistogram) NewRowsTransformer() model.QueryRowsTransformer {

--- a/quesma/model/bucket_aggregations/date_histogram_test.go
+++ b/quesma/model/bucket_aggregations/date_histogram_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"quesma/model"
 	"testing"
+	"time"
 )
 
 func TestTranslateSqlResponseToJson(t *testing.T) {
@@ -20,6 +21,6 @@ func TestTranslateSqlResponseToJson(t *testing.T) {
 			{"key": int64(56962370) * 30_000, OriginalKeyName: int64(56962370), "doc_count": 14, "key_as_string": "2024-02-25T14:25:00.000"},
 		},
 	}
-	response := (&DateHistogram{interval: interval, intervalType: DateHistogramFixedInterval}).TranslateSqlResponseToJson(resultRows)
+	response := (&DateHistogram{interval: interval, intervalType: DateHistogramFixedInterval, wantedTimezone: time.UTC}).TranslateSqlResponseToJson(resultRows)
 	assert.Equal(t, expectedResponse, response)
 }

--- a/quesma/model/pipeline_aggregations/average_bucket.go
+++ b/quesma/model/pipeline_aggregations/average_bucket.go
@@ -12,12 +12,11 @@ import (
 )
 
 type AverageBucket struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewAverageBucket(ctx context.Context, bucketsPath string) AverageBucket {
-	return AverageBucket{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return AverageBucket{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query AverageBucket) AggregationType() model.AggregationType {

--- a/quesma/model/pipeline_aggregations/common.go
+++ b/quesma/model/pipeline_aggregations/common.go
@@ -9,14 +9,6 @@ import (
 	"quesma/util"
 )
 
-func getKey(ctx context.Context, row model.QueryResultRow) any {
-	if len(row.Cols) < 2 {
-		logger.WarnWithCtx(ctx).Msgf("row has less than 2 columns: %v", row)
-		return nil
-	}
-	return row.Cols[len(row.Cols)-2].Value
-}
-
 // translateSqlResponseToJsonCommon translates rows from DB (maybe postprocessed later), into JSON's format in which
 // we want to return them. It is common for a lot of pipeline aggregations
 func translateSqlResponseToJsonCommon(ctx context.Context, rows []model.QueryResultRow, aggregationName string) model.JsonMap {

--- a/quesma/model/pipeline_aggregations/cumulative_sum.go
+++ b/quesma/model/pipeline_aggregations/cumulative_sum.go
@@ -17,12 +17,11 @@ import (
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline-cumulative-sum-aggregation.html
 
 type CumulativeSum struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewCumulativeSum(ctx context.Context, bucketsPath string) CumulativeSum {
-	return CumulativeSum{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return CumulativeSum{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query CumulativeSum) AggregationType() model.AggregationType {

--- a/quesma/model/pipeline_aggregations/derivative.go
+++ b/quesma/model/pipeline_aggregations/derivative.go
@@ -13,12 +13,11 @@ import (
 const derivativeLag = 1
 
 type Derivative struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewDerivative(ctx context.Context, bucketsPath string) Derivative {
-	return Derivative{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return Derivative{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query Derivative) AggregationType() model.AggregationType {

--- a/quesma/model/pipeline_aggregations/max_bucket.go
+++ b/quesma/model/pipeline_aggregations/max_bucket.go
@@ -78,8 +78,6 @@ func (query MaxBucket) calculateSingleMaxBucket(parentRows []model.QueryResultRo
 		return resultRow
 	}
 
-	fmt.Println(parentRows)
-
 	if firstRowValueFloat, firstRowValueIsFloat := util.ExtractFloat64Maybe(parentRows[firstNonNilIndex].LastColValue()); firstRowValueIsFloat {
 		// find max
 		maxValue := firstRowValueFloat

--- a/quesma/model/pipeline_aggregations/max_bucket.go
+++ b/quesma/model/pipeline_aggregations/max_bucket.go
@@ -12,12 +12,11 @@ import (
 )
 
 type MaxBucket struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewMaxBucket(ctx context.Context, bucketsPath string) MaxBucket {
-	return MaxBucket{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return MaxBucket{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query MaxBucket) AggregationType() model.AggregationType {
@@ -79,6 +78,8 @@ func (query MaxBucket) calculateSingleMaxBucket(parentRows []model.QueryResultRo
 		return resultRow
 	}
 
+	fmt.Println(parentRows)
+
 	if firstRowValueFloat, firstRowValueIsFloat := util.ExtractFloat64Maybe(parentRows[firstNonNilIndex].LastColValue()); firstRowValueIsFloat {
 		// find max
 		maxValue := firstRowValueFloat
@@ -94,7 +95,7 @@ func (query MaxBucket) calculateSingleMaxBucket(parentRows []model.QueryResultRo
 		// find keys with max value
 		for _, row := range parentRows[firstNonNilIndex:] {
 			if value, ok := util.ExtractFloat64Maybe(row.LastColValue()); ok && value == maxValue {
-				resultKeys = append(resultKeys, getKey(query.ctx, row))
+				resultKeys = append(resultKeys, query.getKey(row))
 			}
 		}
 	} else if firstRowValueInt, firstRowValueIsInt := util.ExtractInt64Maybe(parentRows[firstNonNilIndex].LastColValue()); firstRowValueIsInt {
@@ -112,7 +113,7 @@ func (query MaxBucket) calculateSingleMaxBucket(parentRows []model.QueryResultRo
 		// find keys with max value
 		for _, row := range parentRows[firstNonNilIndex:] {
 			if value, ok := util.ExtractInt64Maybe(row.LastColValue()); ok && value == maxValue {
-				resultKeys = append(resultKeys, getKey(query.ctx, row))
+				resultKeys = append(resultKeys, query.getKey(row))
 			}
 		}
 	} else {

--- a/quesma/model/pipeline_aggregations/min_bucket.go
+++ b/quesma/model/pipeline_aggregations/min_bucket.go
@@ -12,12 +12,11 @@ import (
 )
 
 type MinBucket struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewMinBucket(ctx context.Context, bucketsPath string) MinBucket {
-	return MinBucket{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return MinBucket{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query MinBucket) AggregationType() model.AggregationType {
@@ -76,7 +75,7 @@ func (query MinBucket) calculateSingleMinBucket(parentRows []model.QueryResultRo
 		// find keys with min value
 		for _, row := range parentRows {
 			if value, ok := util.ExtractFloat64Maybe(row.LastColValue()); ok && value == minValue {
-				resultKeys = append(resultKeys, getKey(query.ctx, row))
+				resultKeys = append(resultKeys, query.getKey(row))
 			}
 		}
 	} else if firstRowValueInt, firstRowValueIsInt := util.ExtractInt64Maybe(parentRows[0].LastColValue()); firstRowValueIsInt {
@@ -94,7 +93,7 @@ func (query MinBucket) calculateSingleMinBucket(parentRows []model.QueryResultRo
 		// find keys with min value
 		for _, row := range parentRows {
 			if value, ok := util.ExtractInt64Maybe(row.LastColValue()); ok && value == minValue {
-				resultKeys = append(resultKeys, getKey(query.ctx, row))
+				resultKeys = append(resultKeys, query.getKey(row))
 			}
 		}
 	}

--- a/quesma/model/pipeline_aggregations/pipeline_aggregation.go
+++ b/quesma/model/pipeline_aggregations/pipeline_aggregation.go
@@ -5,23 +5,27 @@ package pipeline_aggregations
 import (
 	"context"
 	"quesma/logger"
+	"quesma/model"
+	"quesma/model/bucket_aggregations"
 	"strings"
 )
 
 const BucketsPathCount = "_count" // special name for `buckets_path` parameter, normally it's some other aggregation's name
 
 type PipelineAggregation struct {
+	ctx context.Context
 	// Deprecated: used only in old logic, can be removed later.
-	Parent       string
-	PathToParent []string
-	isCount      bool // count is a special case, `bucketsPath` is not a path to another aggregation, but path-to-aggregation>_count
+	Parent                  string
+	PathToParent            []string
+	parentBucketAggregation model.QueryType // may be nil
+	isCount                 bool            // count is a special case, `bucketsPath` is not a path to another aggregation, but path-to-aggregation>_count
 }
 
-func newPipelineAggregation(ctx context.Context, bucketsPath string) PipelineAggregation {
+func newPipelineAggregation(ctx context.Context, bucketsPath string) *PipelineAggregation {
 	const delimiter = ">"
 	if len(bucketsPath) == 0 {
 		logger.WarnWithCtx(ctx).Msgf("invalid bucketsPath: %s. Using empty string as parent.", bucketsPath)
-		return PipelineAggregation{}
+		return &PipelineAggregation{}
 	}
 
 	parent := ""
@@ -33,17 +37,32 @@ func newPipelineAggregation(ctx context.Context, bucketsPath string) PipelineAgg
 
 	isCount := bucketsPath == BucketsPathCount || strings.HasSuffix(bucketsPath, delimiter+BucketsPathCount)
 	splitPath := strings.Split(bucketsPath, delimiter)
-	return PipelineAggregation{Parent: parent, PathToParent: splitPath[:len(splitPath)-1], isCount: isCount}
+	return &PipelineAggregation{ctx: ctx, Parent: parent, PathToParent: splitPath[:len(splitPath)-1], isCount: isCount}
 }
 
-func (p PipelineAggregation) GetParent() string {
+func (p *PipelineAggregation) GetParent() string {
 	return p.Parent
 }
 
-func (p PipelineAggregation) GetPathToParent() []string {
+func (p *PipelineAggregation) GetPathToParent() []string {
 	return p.PathToParent
 }
 
-func (p PipelineAggregation) IsCount() bool {
+func (p *PipelineAggregation) IsCount() bool {
 	return p.isCount
+}
+
+func (p *PipelineAggregation) SetParentBucketAggregation(parentBucketAggregation model.QueryType) {
+	p.parentBucketAggregation = parentBucketAggregation
+}
+
+func (p *PipelineAggregation) getKey(row model.QueryResultRow) any {
+	if len(row.Cols) < 2 {
+		logger.WarnWithCtx(p.ctx).Msgf("row has less than 2 columns: %v", row)
+		return nil
+	}
+	if dateHistogram, ok := p.parentBucketAggregation.(*bucket_aggregations.DateHistogram); ok {
+		return dateHistogram.OriginalKeyToKeyAsString(row.Cols[len(row.Cols)-2].Value)
+	}
+	return row.Cols[len(row.Cols)-2].Value
 }

--- a/quesma/model/pipeline_aggregations/pipeline_aggregation.go
+++ b/quesma/model/pipeline_aggregations/pipeline_aggregation.go
@@ -15,10 +15,12 @@ const BucketsPathCount = "_count" // special name for `buckets_path` parameter, 
 type PipelineAggregation struct {
 	ctx context.Context
 	// Deprecated: used only in old logic, can be removed later.
-	Parent                  string
-	PathToParent            []string
-	parentBucketAggregation model.QueryType // may be nil
-	isCount                 bool            // count is a special case, `bucketsPath` is not a path to another aggregation, but path-to-aggregation>_count
+	Parent       string
+	PathToParent []string
+	// May be nil, as there may be no parent bucket aggregation.
+	// Also, it's always nil at start (after constructor), it's set later during pancake transformation.
+	parentBucketAggregation model.QueryType
+	isCount                 bool // count is a special case, `bucketsPath` is not a path to another aggregation, but path-to-aggregation>_count
 }
 
 func newPipelineAggregation(ctx context.Context, bucketsPath string) *PipelineAggregation {

--- a/quesma/model/pipeline_aggregations/serial_diff.go
+++ b/quesma/model/pipeline_aggregations/serial_diff.go
@@ -9,17 +9,12 @@ import (
 )
 
 type SerialDiff struct {
-	ctx context.Context
 	lag int
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewSerialDiff(ctx context.Context, bucketsPath string, lag int) SerialDiff {
-	return SerialDiff{
-		ctx:                 ctx,
-		lag:                 lag,
-		PipelineAggregation: newPipelineAggregation(ctx, bucketsPath),
-	}
+	return SerialDiff{lag: lag, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query SerialDiff) AggregationType() model.AggregationType {

--- a/quesma/model/pipeline_aggregations/sum_bucket.go
+++ b/quesma/model/pipeline_aggregations/sum_bucket.go
@@ -12,12 +12,11 @@ import (
 )
 
 type SumBucket struct {
-	ctx context.Context
-	PipelineAggregation
+	*PipelineAggregation
 }
 
 func NewSumBucket(ctx context.Context, bucketsPath string) SumBucket {
-	return SumBucket{ctx: ctx, PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
+	return SumBucket{PipelineAggregation: newPipelineAggregation(ctx, bucketsPath)}
 }
 
 func (query SumBucket) AggregationType() model.AggregationType {

--- a/quesma/model/pipeline_query_type.go
+++ b/quesma/model/pipeline_query_type.go
@@ -21,4 +21,6 @@ type PipelineQueryType interface {
 	GetParent() string
 	GetPathToParent() []string
 	IsCount() bool
+
+	SetParentBucketAggregation(parentBucketAggregation QueryType)
 }

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -55,9 +55,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 			if filters(test.TestName) {
 				t.Skip("Fix filters")
 			}
-			if test.TestName == "Max/Sum bucket with some null buckets. Reproduce: Visualize -> Vertical Bar: Metrics: Max (Sum) Bucket (Aggregation: Date Histogram, Metric: Min)(file:opensearch-visualize/pipeline_agg_req,nr:18)" {
-				t.Skip("Need fix with date keys in pipeline aggregations.")
-			}
 
 			if test.TestName == "complex sum_bucket. Reproduce: Visualize -> Vertical Bar: Metrics: Sum Bucket (Bucket: Date Histogram, Metric: Average), Buckets: X-Asis: Histogram(file:opensearch-visualize/pipeline_agg_req,nr:22)" {
 				t.Skip("error: filter(s)/range/dataRange aggregation must be the last bucket aggregation")

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -190,7 +190,6 @@ func (a *pancakeTransformer) createLayer(previousAggrNames []string, childAggreg
 			}
 
 		case model.PipelineMetricsAggregation, model.PipelineBucketAggregation:
-
 			pipeline, err := a.pipelineAggregationToLayer(previousAggrNames, childAgg)
 			if err != nil {
 				return nil, err

--- a/quesma/queryparser/pancake_transformer.go
+++ b/quesma/queryparser/pancake_transformer.go
@@ -190,6 +190,7 @@ func (a *pancakeTransformer) createLayer(previousAggrNames []string, childAggreg
 			}
 
 		case model.PipelineMetricsAggregation, model.PipelineBucketAggregation:
+
 			pipeline, err := a.pipelineAggregationToLayer(previousAggrNames, childAgg)
 			if err != nil {
 				return nil, err
@@ -271,6 +272,9 @@ func (a *pancakeTransformer) connectPipelineAggregations(layers []*pancakeModelL
 			if err != nil {
 				logger.WarnWithCtx(a.ctx).Err(err).Msg("could not find parent bucket layer")
 				continue
+			}
+			if parentBucketLayer.nextBucketAggregation != nil {
+				pipeline.queryType.SetParentBucketAggregation(parentBucketLayer.nextBucketAggregation.queryType)
 			}
 			parentBucketLayer.childrenPipelineAggregations = append(parentBucketLayer.childrenPipelineAggregations, pipeline)
 		}

--- a/quesma/testdata/opensearch-visualize/pipeline_aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/pipeline_aggregation_requests.go
@@ -3329,7 +3329,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 			"aggregations": {
 				"1": {
 					"keys": [
-						"2024-05-21T05:20:00.000+02:00"
+						"2024-05-21T07:30:00.000"
 					],
 					"value": 121360.0
 				},


### PR DESCRIPTION
Unskips one test.

We had a problem when generating results for pipeline aggregations, because if bucket's key was a date, pipeline aggregation only had what it received from DB (usually some random int, result of `date_field.ToUnixTimestamp() / interval_duration`, let's call it `X` (`originalKey` in the new code)), and had no idea how to transform it into a valid date in response.

I fixed that by connecting pipeline aggregation to its parent bucket aggregation, so now pipeline aggregation knows that its parent is a date_histogram, and if it is, it asks it to transform `X -> proper date`