### PR TITLE
Adding GitHub Workflow for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,5 +32,5 @@ jobs:
 
       - name: Run integration tests
         working-directory: ci/it
-        run: go test -v
+        run: EXECUTING_ON_GITHUB_CI=true go test -v
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,9 +30,12 @@ jobs:
 #        with:
 #          path: /tmp/images
 
+      - name: Set environment variable
+        run: echo "EXECUTING_ON_GITHUB_CI=true" >> $GITHUB_ENV
+
       - name: Run integration tests
         working-directory: ci/it
-        env:
-          EXECUTING_ON_GITHUB_CI: true
+#        env:
+#          EXECUTING_ON_GITHUB_CI: true
         run: go test -v
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,6 @@ jobs:
 
   integration-test-run:
     runs-on: ubuntu-latest
-    needs: [build-quesma-docker-image]
     steps:
       - uses: actions/checkout@v4
         with:     ## @TODO REMOVE

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,5 +32,7 @@ jobs:
 
       - name: Run integration tests
         working-directory: ci/it
-        run: EXECUTING_ON_GITHUB_CI=true go test -v
+        env:
+          EXECUTING_ON_GITHUB_CI: true
+        run: go test -v
 

--- a/ci/it/testcases/base.go
+++ b/ci/it/testcases/base.go
@@ -40,22 +40,25 @@ func (tc *IntegrationTestcaseBase) getQuesmaEndpoint() string {
 	ctx := context.Background()
 	q := *tc.Containers.Quesma
 	p, _ := q.MappedPort(ctx, "8080/tcp")
-	return "http://0.0.0.0:" + p.Port()
+	h, _ := q.Host(ctx)
+	return fmt.Sprintf("http://%s:%s", h, p.Port())
 }
 
 func (tc *IntegrationTestcaseBase) getElasticsearchEndpoint() string {
 	ctx := context.Background()
 	q := *tc.Containers.Elasticsearch
 	p, _ := q.MappedPort(ctx, "9200/tcp")
-	return "http://0.0.0.0:" + p.Port()
+	h, _ := q.Host(ctx)
+	return fmt.Sprintf("http://%s:%s", h, p.Port())
 }
 
 func (tc *IntegrationTestcaseBase) getClickHouseClient() (*sql.DB, error) {
 	ctx := context.Background()
 	q := *tc.Containers.ClickHouse
 	p, _ := q.MappedPort(ctx, "9000/tcp")
+	h, _ := q.Host(ctx)
 	options := clickhouse.Options{
-		Addr: []string{"0.0.0.0:" + p.Port()},
+		Addr: []string{fmt.Sprintf("%s:%s", h, p.Port())},
 		TLS:  nil,
 		Auth: clickhouse.Auth{
 			Username: "default", // Replace with your ClickHouse username

--- a/ci/it/testcases/base.go
+++ b/ci/it/testcases/base.go
@@ -40,14 +40,14 @@ func (tc *IntegrationTestcaseBase) getQuesmaEndpoint() string {
 	ctx := context.Background()
 	q := *tc.Containers.Quesma
 	p, _ := q.MappedPort(ctx, "8080/tcp")
-	return "http://localhost:" + p.Port()
+	return "http://0.0.0.0:" + p.Port()
 }
 
 func (tc *IntegrationTestcaseBase) getElasticsearchEndpoint() string {
 	ctx := context.Background()
 	q := *tc.Containers.Elasticsearch
 	p, _ := q.MappedPort(ctx, "9200/tcp")
-	return "http://localhost:" + p.Port()
+	return "http://0.0.0.0:" + p.Port()
 }
 
 func (tc *IntegrationTestcaseBase) getClickHouseClient() (*sql.DB, error) {
@@ -55,7 +55,7 @@ func (tc *IntegrationTestcaseBase) getClickHouseClient() (*sql.DB, error) {
 	q := *tc.Containers.ClickHouse
 	p, _ := q.MappedPort(ctx, "9000/tcp")
 	options := clickhouse.Options{
-		Addr: []string{"localhost:" + p.Port()},
+		Addr: []string{"0.0.0.0:" + p.Port()},
 		TLS:  nil,
 		Auth: clickhouse.Auth{
 			Username: "default", // Replace with your ClickHouse username

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -18,7 +18,8 @@ const configTemplatesDir = "configs"
 
 func GetInternalDockerHost() string {
 	if check := os.Getenv("EXECUTING_ON_GITHUB_CI"); check != "" {
-		return "localhost"
+		//return "localhost"
+		return "host.testcontainers.internal"
 	}
 	return "host.docker.internal" // `host.testcontainers.internal` doesn't work for Docker Desktop for Mac.
 }

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -53,7 +53,9 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 			"ES_JAVA_OPTS":           "-Xms1024m -Xmx1024m",
 		},
 		HostAccessPorts: []int{9200, 9300},
-		WaitingFor:      wait.ForListeningPort("9200/tcp"),
+		WaitingFor: wait.ForHTTP("/").WithPort("9200").
+			WithBasicAuth("elastic", "quesmaquesma").
+			WithStartupTimeout(2 * time.Minute),
 	}
 	elasticsearch, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -19,8 +19,7 @@ const configTemplatesDir = "configs"
 
 func GetInternalDockerHost() string {
 	if check := os.Getenv("EXECUTING_ON_GITHUB_CI"); check != "" {
-		//return "localhost"
-		return "host.testcontainers.internal"
+		return "localhost-for-github-ci"
 	}
 	return "host.docker.internal" // `host.testcontainers.internal` doesn't work for Docker Desktop for Mac.
 }
@@ -60,7 +59,7 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 			"ES_JAVA_OPTS":           "-Xms1024m -Xmx1024m",
 		},
 		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.ExtraHosts = []string{"host.testcontainers.internal:host-gateway"}
+			hc.ExtraHosts = []string{"localhost-for-github-ci:host-gateway"}
 		},
 		HostAccessPorts: []int{9200, 9300},
 		WaitingFor: wait.ForHTTP("/").WithPort("9200").
@@ -105,7 +104,7 @@ func setupQuesma(ctx context.Context, quesmaConfig string) (testcontainers.Conta
 			WithBasicAuth("elastic", "quesmaquesma").
 			WithStartupTimeout(2 * time.Minute),
 		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.ExtraHosts = []string{"host.testcontainers.internal:host-gateway"}
+			hc.ExtraHosts = []string{"localhost-for-github-ci:host-gateway"}
 		},
 		Files: []testcontainers.ContainerFile{
 			{
@@ -146,7 +145,7 @@ func setupKibana(ctx context.Context, quesmaContainer testcontainers.Container) 
 			"XPACK_SECURITY_ENABLED":                    "true",
 		},
 		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.ExtraHosts = []string{"host.testcontainers.internal:host-gateway"}
+			hc.ExtraHosts = []string{"localhost-for-github-ci:host-gateway"}
 		},
 		WaitingFor: wait.ForLog("http server running at").WithStartupTimeout(4 * time.Minute),
 	}
@@ -165,7 +164,7 @@ func setupClickHouse(ctx context.Context) (testcontainers.Container, error) {
 		Image:        "clickhouse/clickhouse-server:24.5.3.5-alpine",
 		ExposedPorts: []string{"8123/tcp", "9000/tcp"},
 		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.ExtraHosts = []string{"host.testcontainers.internal:host-gateway"}
+			hc.ExtraHosts = []string{"localhost-for-github-ci:host-gateway"}
 		},
 		WaitingFor: wait.ForExposedPort().WithStartupTimeout(2 * time.Minute),
 	}

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -64,8 +64,11 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 	}
 
 	// Set password to Kibana system user
-	if retCode, _, err := elasticsearch.Exec(ctx, []string{"curl", "-H", "Content-type: application/json", "-k", "-u", "elastic:quesmaquesma", "http://localhost:9200/_security/user/kibana_system/_password", "-d", "{\"password\": \"kibanana\"}"}); retCode != 0 || err != nil {
-		panic(fmt.Sprintf("Failed to set password for kibana_system: returned=[%d] err=[%v]", retCode, err))
+	if retCode, reader, errCmd := elasticsearch.Exec(ctx, []string{"curl", "-H", "Content-type: application/json", "-k", "-u", "elastic:quesmaquesma", "http://localhost:9200/_security/user/kibana_system/_password", "-d", "{\"password\": \"kibanana\"}"}); retCode != 0 || errCmd != nil {
+		output := new(bytes.Buffer)
+		output.ReadFrom(reader)
+		log.Printf("Command output: %s", output.String())
+		panic(fmt.Sprintf("Failed to set password for kibana_system: returned=[%d] err=[%v]", retCode, errCmd))
 	}
 
 	return elasticsearch, nil

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -17,7 +17,7 @@ import (
 const configTemplatesDir = "configs"
 
 func GetInternalDockerHost() string {
-	if host := os.Getenv("EXECUTING_ON_GITHUB_CI"); host != "" {
+	if check := os.Getenv("EXECUTING_ON_GITHUB_CI"); check != "" {
 		return "localhost"
 	}
 	return "host.docker.internal" // `host.testcontainers.internal` doesn't work for Docker Desktop for Mac.

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -91,7 +91,9 @@ func setupQuesma(ctx context.Context, quesmaConfig string) (testcontainers.Conta
 		Env: map[string]string{
 			"QUESMA_CONFIG_FILE": "/configuration/conf.yaml",
 		},
-		WaitingFor: wait.ForExposedPort().WithStartupTimeout(2 * time.Minute),
+		WaitingFor: wait.ForHTTP("/").WithPort("8080").
+			WithBasicAuth("elastic", "quesmaquesma").
+			WithStartupTimeout(2 * time.Minute),
 		Files: []testcontainers.ContainerFile{
 			{
 				Reader:            r,

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -65,7 +65,7 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 
 	// Set password to Kibana system user
 	if retCode, _, err := elasticsearch.Exec(ctx, []string{"curl", "-H", "Content-type: application/json", "-k", "-u", "elastic:quesmaquesma", "http://localhost:9200/_security/user/kibana_system/_password", "-d", "{\"password\": \"kibanana\"}"}); retCode != 0 || err != nil {
-		panic(fmt.Sprintf("Failed to set password for kibana_system: returned=[%d] err=[%s]", retCode, err))
+		panic(fmt.Sprintf("Failed to set password for kibana_system: returned=[%d] err=[%v]", retCode, err))
 	}
 
 	return elasticsearch, nil

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -64,7 +64,7 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 	}
 
 	// Set password to Kibana system user
-	if retCode, reader, errCmd := elasticsearch.Exec(ctx, []string{"curl", "-H", "Content-type: application/json", "-k", "-u", "elastic:quesmaquesma", "http://localhost:9200/_security/user/kibana_system/_password", "-d", "{\"password\": \"kibanana\"}"}); retCode != 0 || errCmd != nil {
+	if retCode, reader, errCmd := elasticsearch.Exec(ctx, []string{"curl", "-H", "Content-type: application/json", "-k", "-u", "elastic:quesmaquesma", "http://0.0.0.0:9200/_security/user/kibana_system/_password", "-d", "{\"password\": \"kibanana\"}"}); retCode != 0 || errCmd != nil {
 		output := new(bytes.Buffer)
 		output.ReadFrom(reader)
 		log.Printf("Command output: %s", output.String())


### PR DESCRIPTION
Adding few tweaks so that test **run on CI** (wasn't that straightforward TBH) and are not flaky. 

Overall, those two ITs on GitHub worker have never took more than 3 minutes total, which I think as for IT is pretty decent.
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/e96838cc-5c59-45a5-8e9f-879ab1f3a7eb">


For now, running only `quesma/quesma:latest` docker image upon request. Later we can discuss when/where we want them to be kicked off.
