### PR TITLE
Get rid of FieldToColumnEncoder call

### DIFF
--- a/quesma/quesma/schema_map_transformation.go
+++ b/quesma/quesma/schema_map_transformation.go
@@ -47,7 +47,9 @@ func (v *mapTypeResolver) isMap(fieldName string) (exists bool, scope searchScop
 	}
 
 	tableColumnName, ok := v.indexSchema.ResolveField(fieldName)
-
+	if !ok {
+		return false, scope, fieldName
+	}
 	col, ok := v.indexSchema.Fields[schema.FieldName(tableColumnName.InternalPropertyName.AsString())]
 
 	if ok {
@@ -56,7 +58,7 @@ func (v *mapTypeResolver) isMap(fieldName string) (exists bool, scope searchScop
 		}
 	}
 
-	return false, scope, tableColumnName.InternalPropertyName.AsString()
+	return false, scope, fieldName
 }
 
 func existsInMap(left model.Expr, op string, mapToArrayFunction string, right model.Expr) model.Expr {

--- a/quesma/quesma/schema_map_transformation.go
+++ b/quesma/quesma/schema_map_transformation.go
@@ -7,7 +7,6 @@ import (
 	"quesma/model"
 	"quesma/quesma/types"
 	"quesma/schema"
-	"quesma/util"
 	"strings"
 )
 
@@ -47,16 +46,17 @@ func (v *mapTypeResolver) isMap(fieldName string) (exists bool, scope searchScop
 		scope = scopeWholeMap
 	}
 
-	tableColumnName := util.FieldToColumnEncoder(fieldName)
-	col, ok := v.indexSchema.Fields[schema.FieldName(tableColumnName)]
+	tableColumnName, ok := v.indexSchema.ResolveField(fieldName)
+
+	col, ok := v.indexSchema.Fields[schema.FieldName(tableColumnName.InternalPropertyName.AsString())]
 
 	if ok {
 		if strings.HasPrefix(col.InternalPropertyType, "Map") {
-			return true, scope, tableColumnName
+			return true, scope, tableColumnName.InternalPropertyName.AsString()
 		}
 	}
 
-	return false, scope, tableColumnName
+	return false, scope, tableColumnName.InternalPropertyName.AsString()
 }
 
 func existsInMap(left model.Expr, op string, mapToArrayFunction string, right model.Expr) model.Expr {


### PR DESCRIPTION
This PR removes a workaround, i.e direct call to `util.FeldToColumnEncoder` and use schema to resolve internal name