### PR TITLE
Remove the need for SQL-type backend connector in query/ingest processors and pipelines

### DIFF
--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -313,6 +313,9 @@ func (c *QuesmaNewConfiguration) validatePipelines() error {
 }
 
 func (c *QuesmaNewConfiguration) validateFrontendConnector(fc FrontendConnector) error {
+	if len(fc.Name) == 0 {
+		return fmt.Errorf("frontend connector must have a non-empty name")
+	}
 	if fc.Type != ElasticsearchFrontendIngestConnectorName && fc.Type != ElasticsearchFrontendQueryConnectorName {
 		return fmt.Errorf(fmt.Sprintf("frontend connector's [%s] type not recognized, only `%s` and `%s` are supported at this moment", fc.Name, ElasticsearchFrontendIngestConnectorName, ElasticsearchFrontendQueryConnectorName))
 	}
@@ -344,6 +347,9 @@ func (c *QuesmaNewConfiguration) definedProcessorNames() []string {
 }
 
 func (c *QuesmaNewConfiguration) validateProcessor(p Processor) error {
+	if len(p.Name) == 0 {
+		return fmt.Errorf("processor must have a non-empty name")
+	}
 	if !slices.Contains(getAllowedProcessorTypes(), p.Type) {
 		return fmt.Errorf("processor type not recognized, only `quesma-v1-processor-noop`, `quesma-v1-processor-query` and `quesma-v1-processor-ingest` are supported at this moment")
 	}
@@ -374,6 +380,9 @@ func (c *QuesmaNewConfiguration) validateProcessor(p Processor) error {
 
 func (c *QuesmaNewConfiguration) validatePipeline(pipeline Pipeline) error {
 	var _, errAcc error
+	if len(pipeline.Name) == 0 {
+		errAcc = multierror.Append(errAcc, fmt.Errorf("pipeline must have a non-empty name"))
+	}
 	if len(pipeline.FrontendConnectors) != 1 {
 		errAcc = multierror.Append(errAcc, fmt.Errorf("pipeline must have exactly one frontend connector"))
 	} else if len(pipeline.FrontendConnectors) == 0 {
@@ -711,6 +720,9 @@ func (c *QuesmaNewConfiguration) getRelationalDBConf() (*RelationalDbConfigurati
 func (c *QuesmaNewConfiguration) validateBackendConnectors() error {
 	elasticBackendConnectors, clickhouseBackendConnectors := 0, 0
 	for _, backendConn := range c.BackendConnectors {
+		if len(backendConn.Name) == 0 {
+			return fmt.Errorf("backend connector must have a non-empty name")
+		}
 		if backendConn.Type == ElasticsearchBackendConnectorName {
 			elasticBackendConnectors += 1
 		} else if backendConn.Type == ClickHouseBackendConnectorName || backendConn.Type == ClickHouseOSBackendConnectorName || backendConn.Type == HydrolixBackendConnectorName {

--- a/quesma/quesma/config/test_configs/ingest_with_single_connector.yaml
+++ b/quesma/quesma/config/test_configs/ingest_with_single_connector.yaml
@@ -1,0 +1,59 @@
+# Similar to quesma_adding_two_hydrolix_tables.yaml,
+# but the ingest processor has only a single backend connector.
+
+logging:
+  level: info
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: my-minimal-elasticsearch
+    type: elasticsearch
+    config:
+      url: "http://elasticsearch:9200"
+      user: elastic
+      password: quesmaquesma
+  - name: my-hydrolix-instance
+    type: hydrolix
+    config:
+      url: "clickhouse://localhost:9000"
+      user: "u"
+      password: "p"
+      database: "d"
+ingestStatistics: true
+processors:
+  - name: my-query-processor
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        siem:
+          target: [my-hydrolix-instance]
+        logs:
+          target: [my-hydrolix-instance]
+        "*":
+          target: [ my-minimal-elasticsearch ]
+  - name: my-ingest-processor
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        siem:
+          target: [ my-minimal-elasticsearch ]
+        logs:
+          target: [ my-minimal-elasticsearch ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
+pipelines:
+  - name: my-elasticsearch-proxy-read
+    frontendConnectors: [ elastic-query ]
+    processors: [ my-query-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-hydrolix-instance ]
+  - name: my-elasticsearch-proxy-write
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ my-ingest-processor ]
+    backendConnectors: [ my-minimal-elasticsearch ] # my-hydrolix-instance is not needed here, as we don't ingest to it

--- a/quesma/quesma/config/test_configs/quesma_as_transparent_proxy_without_noop.yml
+++ b/quesma/quesma/config/test_configs/quesma_as_transparent_proxy_without_noop.yml
@@ -1,0 +1,56 @@
+# The recommended way to start Quesma in transparent proxy
+# is to use the noop processor. However, the user can achieve
+# the same thing by specifying query/ingest processors without
+# routing anything to ClickHouse/Hydrolix - that should be supported,
+# even if not recommended.
+
+logging:
+  level: info
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: my-minimal-elasticsearch
+    type: elasticsearch
+    config:
+      url: "http://elasticsearch:9200"
+      user: elastic
+      password: quesmaquesma
+  # No ClickHouse, Hydrolix connector needed!
+ingestStatistics: true
+processors:
+  - name: my-query-processor
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        siem:
+          target: [ my-minimal-elasticsearch ]
+        logs:
+          target: [ my-minimal-elasticsearch ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
+  - name: my-ingest-processor
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        siem:
+          target: [ my-minimal-elasticsearch ]
+        logs:
+          target: [ my-minimal-elasticsearch ]
+        "*":
+          target: [ my-minimal-elasticsearch ]
+pipelines:
+  - name: my-elasticsearch-transparent-proxy-read
+    frontendConnectors: [ elastic-query ]
+    processors: [ my-query-processor ]
+    backendConnectors: [ my-minimal-elasticsearch ]
+  - name: my-elasticsearch-transparent-proxy-write
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ my-ingest-processor ]
+    backendConnectors: [ my-minimal-elasticsearch ]


### PR DESCRIPTION
Previously, the user always had to provide two backend connectors to the query/ingest processor: Elastic connector and SQL-type connector (aka ClickHouse/Hydrolix).

Remove that requirement - now only the Elastic connector is mandatory (for Kibana internal queries) and the user doesn't need to have SQL-type backend connector in the pipeline (in such case they won't be able to use it in `indexes` configuration, thus only targeting queries/ingest to Elastic).

However, this doesn't yet solve the more tricky scenario of completely removing SQL-type backend connector from the entire configuration (it's possible in transparent proxy mode, but not yet in dual pipeline mode). Put another way: ClickHouse/Hydrolix is still required in the `backendConnectors` section (except in no-op transparent proxy), but you can now omit it from `pipelines`/`processors` sections. The more tricky scenario is tested by (currently skipped) `TestQuesmaTransparentProxyWithoutNoopConfiguration`.