### PR TITLE
Run integration tests against `nightly` (not `latest`)

### DIFF
--- a/.github/workflows/build-quesma-docker-image.yml
+++ b/.github/workflows/build-quesma-docker-image.yml
@@ -16,6 +16,11 @@ on:
         default: false
         required: false
         type: boolean
+      REF:
+        description: 'The branch, tag or SHA to checkout. By default it will use the default branch'
+        default: ''
+        required: false
+        type: string
     secrets:
       DOCKER_USER:
         required: false
@@ -30,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,9 +10,14 @@ on:
         description: 'Commit hash to run the tests'
         required: true
 jobs:
+  build-quesma-docker-image:
+    uses: ./.github/workflows/build-quesma-docker-image.yml
+    with:
+      REF: ${{inputs.GIT_REF}}
 
   integration-test-run:
     runs-on: ubuntu-latest
+    needs: [build-quesma-docker-image]
     steps:
       - uses: actions/checkout@v4
         with:     ## @TODO REMOVE
@@ -24,11 +29,17 @@ jobs:
           cache-dependency-path: smoke-test/go.sum
           go-version: '1.22'
 
-#     (perhaps prefetching these should be considered)
-#      - name: Download images
-#        uses: actions/download-artifact@v4
-#        with:
-#          path: /tmp/images
+      - name: Download images
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/images
+
+      - name: Load images
+        run: |
+          for file in /tmp/images/*/*.tar; do
+            docker load --input $file
+          done
+          docker image ls -a  
 
       - name: Set environment variable
         run: echo "EXECUTING_ON_GITHUB_CI=true" >> $GITHUB_ENV

--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -95,7 +95,7 @@ func setupQuesma(ctx context.Context, quesmaConfig string) (testcontainers.Conta
 		return nil, err
 	}
 	quesmaReq := testcontainers.ContainerRequest{
-		Image:        "quesma/quesma:latest",
+		Image:        "quesma/quesma:nightly",
 		ExposedPorts: []string{"9999/tcp", "8080/tcp"},
 		Env: map[string]string{
 			"QUESMA_CONFIG_FILE": "/configuration/conf.yaml",


### PR DESCRIPTION
The `latest` tag of `quesma/quesma` is the latest released stable release of Quesma, while `nightly` is the newest build of Quesma. Integration tests used to run against `quesma/quesma:latest` and not the last `nightly` build of Quesma, which meant that we wouldn't catch some failures before release.

Fix this issue by running the integration tests against `nightly` and always building the newest `quesma/quesma:nightly` in the `integration-test.yml` GitHub workflow.