### PR TITLE
Remove `internalTelemetryUrl` and `logging.remoteUrl` from quickstart demo config

### DIFF
--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -21,11 +21,9 @@ backendConnectors:
       url: "clickhouse://clickhouse:9000"
       adminUrl: "http://localhost:8123/play"
 ingestStatistics: true
-internalTelemetryUrl: "https://api.quesma.com/phone-home"
 logging:
   path: "logs"
   level: "info"
-  remoteUrl: "https://api.quesma.com/phone-home"
   disableFileLogging: false
 processors:
   - name: my-query-processor


### PR DESCRIPTION
These are by default set per [config_v2.go#L99-L100](https://github.com/QuesmaOrg/quesma/blob/main/quesma/quesma/config/config_v2.go#L99-L100) so there's no point in explicitly listing them in the demo conf.