### PR TITLE
Get secrets (Docker login credentials) in `build-quesma-docker-image.yml`

### DIFF
--- a/.github/workflows/build-quesma-docker-image.yml
+++ b/.github/workflows/build-quesma-docker-image.yml
@@ -16,6 +16,11 @@ on:
         default: false
         required: false
         type: boolean
+    secrets:
+      DOCKER_USER:
+        required: false
+      DOCKER_PAT:
+        required: false
 
 jobs:
   build-quesma-docker-image:

--- a/.github/workflows/nightly-docker-build-and-push.yml
+++ b/.github/workflows/nightly-docker-build-and-push.yml
@@ -26,3 +26,6 @@ jobs:
       VERSION: ${{ inputs.VERSION || 'nightly' }} # when called from the main branch, `github.event.inputs.VERSION` doesn't use default value and is just empty
       # Pushes to DockerHub only for `main` branch builds, unless set explicitly in the job input
       PUSH: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.PUSH }}
+    secrets:
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_PAT: ${{ secrets.DOCKER_PAT }}


### PR DESCRIPTION
A hot fix after 0c220f988a947ca63f3ca51c65a4ba05a2162f13. After it was merged, the reusable workflow ("child workflow") doesn't get the secrets (docker credentials) by default, resulting in a job failure.

Fix the issue by specifying the needed secrets for the reusable workflow.

The secrets are not required if `PUSH` doesn't happen and only the `nightly-docker-build-and-push.yml` workflow actually passes those secrets.