### PR TITLE
Fix `nil` pointer panic in `table_discovery.go`

### DIFF
--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -536,6 +536,9 @@ func (td *tableDiscovery) readTables(database string) (map[string]map[string]col
 
 	logger.Debug().Msgf("describing tables: %s", database)
 
+	if td.dbConnPool == nil {
+		return map[string]map[string]columnMetadata{}, fmt.Errorf("database connection pool is nil, cannot describe tables")
+	}
 	rows, err := td.dbConnPool.Query("SELECT table, name, type, comment FROM system.columns WHERE database = ?", database)
 	if err != nil {
 		err = end_user_errors.GuessClickhouseErrorType(err).InternalDetails("reading list of columns from system.columns")


### PR DESCRIPTION
After 7611ebac683e5e2fc326ea3afac8f80b3abf37e1, the table resolver always asks table discovery to refresh table information. However, in the transparent proxy case, Quesma doesn't make any connections to ClickHouse, therefore `td.dbConnPool` can be `nil`, resulting in `nil` pointer panic.

Add missing `nil` check, the existing code now can gracefully handle this situation. 

In the future we might improve Quesma's main to not construct `table_discovery` if there is no ClickHouse connector.