### PR TITLE
Fix array transformation panic 

### DIFF
--- a/quesma/quesma/schema_array_transformer.go
+++ b/quesma/quesma/schema_array_transformer.go
@@ -144,7 +144,7 @@ func checkIfGroupingByArrayColumn(selectCommand model.SelectCommand, resolver ar
 			cte.Accept(b)
 		}
 
-		return e
+		return &e
 	}
 
 	visitor.OverrideVisitFunction = func(b *model.BaseExprVisitor, e model.FunctionExpr) interface{} {


### PR DESCRIPTION
It fixes this panel: 

<img width="1074" alt="Screenshot 2024-10-11 at 16 15 05" src="https://github.com/user-attachments/assets/283f474b-3c06-48b7-92fb-83a8d1a1e43e">


```
2024-10-11 16:32:13 Oct 11 14:32:13.599 ERR quesma/quesma/recovery/recovery_strategies.go:32 > Panic recovered: interface conversion: interface {} is model.SelectCommand, not *model.SelectCommand
2024-10-11 16:32:13 goroutine 482 [running]:
2024-10-11 16:32:13 runtime/debug.Stack()
2024-10-11 16:32:13     /usr/local/go/src/runtime/debug/stack.go:26 +0x64
2024-10-11 16:32:13 quesma/quesma/recovery.commonRecovery({0x6857e0, 0x40005f0990}, 0x4000875da8?)
2024-10-11 16:32:13     /quesma/quesma/recovery/recovery_strategies.go:32 +0x154
2024-10-11 16:32:13 quesma/quesma/recovery.LogAndHandlePanic({0x8e22b0, 0x40005f8690}, 0x4000877940)
2024-10-11 16:32:13     /quesma/quesma/recovery/recovery_strategies.go:51 +0x68
2024-10-11 16:32:13 panic({0x6857e0?, 0x40005f0990?})
2024-10-11 16:32:13     /usr/local/go/src/runtime/panic.go:785 +0x124
2024-10-11 16:32:13 quesma/model.(*BaseExprVisitor).VisitCTE(0x40008760e8?, {{0x75ba75?, 0x40005fb950?}, 0x4000b7e2c0?})
2024-10-11 16:32:13     /quesma/model/base_visitor.go:209 +0x110
2024-10-11 16:32:13 quesma/model.CTE.Accept(...)
2024-10-11 16:32:13     /quesma/model/expr.go:272
2024-10-11 16:32:13 quesma/quesma.checkIfGroupingByArrayColumn.func2(0x40005fb950, {0x0, {0x4000b6e880, 0x6, 0x8}, {0x8dc260, 0x40003213d0}, {0x8dc280, 0x40004c86f0}, {0x0, ...}, ...})
2024-10-11 16:32:13     /quesma/quesma/schema_array_transformer.go:144 +0x144
2024-10-11 16:32:13 quesma/model.(*BaseExprVisitor).VisitSelectCommand(0x0?, {0x0, {0x4000b6e880, 0x6, 0x8}, {0x8dc260, 0x40003213d0}, {0x8dc280, 0x40004c86f0}, {0x0, ...}, ...})
2024-10-11 16:32:13     /quesma/model/base_visitor.go:140 +0x8c
2024-10-11 16:32:13 quesma/model.SelectCommand.Accept(...)
2024-10-11 16:32:13     /quesma/model/select.go:40
2024-10-11 16:32:13 quesma/quesma.checkIfGroupingByArrayColumn({0x0, {0x4000b6e880, 0x6, 0x8}, {0x8dc260, 0x40003213d0}, {0x8dc280, 0x40004c86f0}, {0x0, 0x0, ...}, ...}, ...)
2024-10-11 16:32:13     /quesma/quesma/schema_array_transformer.go:167 +0x1d0
2024-10-11 16:32:13 quesma/quesma.(*SchemaCheckPass).applyArrayTransformations(0x4000876608?, {0x40009b4ea0, 0x40009b4f00, 0x1, {0x74c4c7, 0x7}}, 0x4000574480)
2024-10-11 16:32:13     /quesma/quesma/schema_transformer.go:298 +0x14c
2024-10-11 16:32:13 quesma/quesma.(*SchemaCheckPass).Transform(0x400006e108, {0x40003e8858, 0x3, 0x3})
2024-10-11 16:32:13     /quesma/quesma/schema_transformer.go:767 +0x4f8
...
```
