### PR TITLE
Add license override for oauth library

### DIFF
--- a/.github/go-licence-detector/overrides.ndjson
+++ b/.github/go-licence-detector/overrides.ndjson
@@ -1,2 +1,3 @@
 {"name": "github.com/pascaldekloe/goe", "licenceType": "Public Domain"}
 {"name": "github.com/pascaldekloe/name", "licenceType": "Public Domain"}
+{"name": "github.com/mrjones/oauth", "licenceFile": "MIT-LICENSE.txt"}


### PR DESCRIPTION
`github.com/mrjones/oauth` uses a non-standard-named filename for the `LICENSE.txt` file (`MIT-LICENSE.txt` instead of `LICENSE.txt`). `go-license-detector` cannot handle such a case, as seen here: https://github.com/QuesmaOrg/quesma/actions/runs/11327943230/job/31500069625

The problem was already reported to both the `go-licenses` library (https://github.com/google/go-licenses/issues/142) and the `oauth` library (https://github.com/mrjones/oauth/issues/74), but it's not fixed yet.

Fix the problem by adding an override entry to `overrides.ndjson`.