### PR TITLE
Separate test functions into `t.Run()`'s

### DIFF
--- a/ci/it/testcases/test_dual_write_and_common_table.go
+++ b/ci/it/testcases/test_dual_write_and_common_table.go
@@ -34,12 +34,12 @@ func (a *DualWriteAndCommonTableTestcase) SetupContainers(ctx context.Context) e
 }
 
 func (a *DualWriteAndCommonTableTestcase) RunTests(ctx context.Context, t *testing.T) error {
-	a.testBasicRequest(ctx, t)
-	a.testIngestToClickHouseWorks(ctx, t)
-	a.testIngestToCommonTableWorks(ctx, t)
-	a.testDualQueryReturnsDataFromClickHouse(ctx, t)
-	a.testDualWritesWork(ctx, t)
-	a.testWildcardGoesToElastic(ctx, t)
+	t.Run("test basic request", func(t *testing.T) { a.testBasicRequest(ctx, t) })
+	t.Run("test ingest to clickhouse works", func(t *testing.T) { a.testIngestToClickHouseWorks(ctx, t) })
+	t.Run("test ingest to common table works", func(t *testing.T) { a.testIngestToCommonTableWorks(ctx, t) })
+	t.Run("test dual query returns data from clickhouse", func(t *testing.T) { a.testDualQueryReturnsDataFromClickHouse(ctx, t) })
+	t.Run("test dual writes work", func(t *testing.T) { a.testDualWritesWork(ctx, t) })
+	t.Run("test wildcard goes to elastic", func(t *testing.T) { a.testWildcardGoesToElastic(ctx, t) })
 	return nil
 }
 

--- a/ci/it/testcases/test_reading_clickhouse_tables.go
+++ b/ci/it/testcases/test_reading_clickhouse_tables.go
@@ -34,9 +34,9 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) SetupContainers(ctx context
 }
 
 func (a *ReadingClickHouseTablesIntegrationTestcase) RunTests(ctx context.Context, t *testing.T) error {
-	a.testBasicRequest(ctx, t)
-	a.testRandomThing(ctx, t)
-	a.testWildcardGoesToElastic(ctx, t)
+	t.Run("test basic request", func(t *testing.T) { a.testBasicRequest(ctx, t) })
+	t.Run("test random thing", func(t *testing.T) { a.testRandomThing(ctx, t) })
+	t.Run("test wildcard goes to elastic", func(t *testing.T) { a.testWildcardGoesToElastic(ctx, t) })
 	return nil
 }
 

--- a/ci/it/testcases/test_transparent_proxy.go
+++ b/ci/it/testcases/test_transparent_proxy.go
@@ -33,9 +33,9 @@ func (a *TransparentProxyIntegrationTestcase) SetupContainers(ctx context.Contex
 }
 
 func (a *TransparentProxyIntegrationTestcase) RunTests(ctx context.Context, t *testing.T) error {
-	a.testBasicRequest(ctx, t)
-	a.testIfCatHealthRequestReachesElasticsearch(ctx, t)
-	a.testIfIndexCreationWorks(ctx, t)
+	t.Run("test basic request", func(t *testing.T) { a.testBasicRequest(ctx, t) })
+	t.Run("test if cat health request reaches elasticsearch", func(t *testing.T) { a.testIfCatHealthRequestReachesElasticsearch(ctx, t) })
+	t.Run("test if index creation works", func(t *testing.T) { a.testIfIndexCreationWorks(ctx, t) })
 	return nil
 }
 

--- a/ci/it/testcases/test_two_pipelines.go
+++ b/ci/it/testcases/test_two_pipelines.go
@@ -34,10 +34,10 @@ func (a *QueryAndIngestPipelineTestcase) SetupContainers(ctx context.Context) er
 }
 
 func (a *QueryAndIngestPipelineTestcase) RunTests(ctx context.Context, t *testing.T) error {
-	a.testBasicRequest(ctx, t)
-	a.testWildcardGoesToElastic(ctx, t)
-	a.testEmptyTargetDoc(ctx, t)
-	a.testEmptyTargetBulk(ctx, t)
+	t.Run("test basic request", func(t *testing.T) { a.testBasicRequest(ctx, t) })
+	t.Run("test wildcard goes to elastic", func(t *testing.T) { a.testWildcardGoesToElastic(ctx, t) })
+	t.Run("test empty target doc", func(t *testing.T) { a.testEmptyTargetDoc(ctx, t) })
+	t.Run("test empty target bulk", func(t *testing.T) { a.testEmptyTargetBulk(ctx, t) })
 	return nil
 }
 


### PR DESCRIPTION
Using `t.Run(` (see [Go docs](https://pkg.go.dev/testing#T.Run)) to have each function as a separate test.

Looks pretty neat in IDE and will make tracing errors in the future easier 😉  
![image (23)](https://github.com/user-attachments/assets/27fce951-fefe-438b-aa81-106c54ec21e7)
