### PR TITLE
Don't send Slack notifications on manual IT runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: go test -v
 
       - name: Send Slack notification on failure
-        if: failure()
+        if: ${{ failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@v1.27.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
@@ -82,7 +82,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Send Slack notification on success
-        if: success()
+        if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@v1.27.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
Add a condition to "Send Slack notification" steps to be triggered only if the job originated from a push to `main` branch (and not manual triggering of a job).