### PR TITLE
Preserve order of targets in QueryTarget, IngestTarget

### DIFF
--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -126,8 +126,7 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 
 					case QueryPipeline:
 
-						if (targets[0] == config.ClickhouseTarget && targets[1] == config.ElasticsearchTarget) ||
-							(targets[0] == config.ElasticsearchTarget && targets[1] == config.ClickhouseTarget) {
+						if targets[0] == config.ClickhouseTarget && targets[1] == config.ElasticsearchTarget {
 
 							return &Decision{
 								Reason:          "Enabled in the config. A/B testing.",


### PR DESCRIPTION
A user in the configuration of a query/ingest processor can define targets:
```yaml
my_index:
  target: [ elastic-conn, clickhouse-conn ]
```
We subsequently take those values and populate `QueryTarget` and `IngestTarget` arrays based on it, however the code did not preserve the order of the targets. The order is important for A/B testing case and `rules.go` had to incorrectly allow an unsupported scenario for everything to work correctly.

Fix the issue by preserving the same order in `QueryTarget`, `IngestTarget` as in the original `target` user configuration. `rules.go` workaround can be now removed.