### PR TITLE
Make secure cookies working

### DIFF
--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -31,6 +31,10 @@ var uiFs embed.FS
 const quesmaSessionName = "quesma-session"
 
 func init() {
+
+	// Here we generate a random key for the session store
+	// TODO We should use a secure key from the environment on production.
+	// 32 - is a default key length, taken for example
 	gothic.Store = sessions.NewCookieStore(securecookie.GenerateRandomKey(32))
 }
 
@@ -252,6 +256,9 @@ func (qmc *QuesmaManagementConsole) initPprof(router *mux.Router) {
 	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
+// Here we generate keys for the session store.
+// TODO We should use a secure key from the environment on production.
+// 32,64 are default key lengths.
 var authKey = securecookie.GenerateRandomKey(64)
 var encryptionKey = securecookie.GenerateRandomKey(32)
 var store = sessions.NewCookieStore(authKey, encryptionKey)

--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
@@ -28,6 +29,10 @@ const (
 var uiFs embed.FS
 
 const quesmaSessionName = "quesma-session"
+
+func init() {
+	gothic.Store = sessions.NewCookieStore(securecookie.GenerateRandomKey(32))
+}
 
 func authCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	user, err := gothic.CompleteUserAuth(w, r)
@@ -247,7 +252,9 @@ func (qmc *QuesmaManagementConsole) initPprof(router *mux.Router) {
 	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
-var store = sessions.NewCookieStore([]byte("test"))
+var authKey = securecookie.GenerateRandomKey(64)
+var encryptionKey = securecookie.GenerateRandomKey(32)
+var store = sessions.NewCookieStore(authKey, encryptionKey)
 
 func authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
We must provide keys for session storage (gothic and guerillla) to work with SSL.  Both frameworks switch to secure cookies on SSL. 

The solution is to generate keys on on start. This is for now.  This is not a final solution.