### PR TITLE
ITs: RequestToQuesma boilerplate cleanup

### DIFF
--- a/ci/it/testcases/base.go
+++ b/ci/it/testcases/base.go
@@ -113,9 +113,13 @@ func (tc *IntegrationTestcaseBase) ExecuteClickHouseStatement(ctx context.Contex
 	return res, nil
 }
 
-func (tc *IntegrationTestcaseBase) RequestToQuesma(ctx context.Context, method, uri string, body []byte) (*http.Response, error) {
+func (tc *IntegrationTestcaseBase) RequestToQuesma(ctx context.Context, t *testing.T, method, uri string, body []byte) *http.Response {
 	endpoint := tc.getQuesmaEndpoint()
-	return tc.doRequest(ctx, method, endpoint+uri, body, nil)
+	resp, err := tc.doRequest(ctx, method, endpoint+uri, body, nil)
+	if err != nil {
+		t.Fatalf("Error sending %s request to the endpoint '%s': %s", method, uri, err)
+	}
+	return resp
 }
 
 func (tc *IntegrationTestcaseBase) RequestToElasticsearch(ctx context.Context, method, uri string, body []byte) (*http.Response, error) {

--- a/ci/it/testcases/base.go
+++ b/ci/it/testcases/base.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -113,13 +114,18 @@ func (tc *IntegrationTestcaseBase) ExecuteClickHouseStatement(ctx context.Contex
 	return res, nil
 }
 
-func (tc *IntegrationTestcaseBase) RequestToQuesma(ctx context.Context, t *testing.T, method, uri string, body []byte) *http.Response {
+func (tc *IntegrationTestcaseBase) RequestToQuesma(ctx context.Context, t *testing.T, method, uri string, requestBody []byte) (*http.Response, []byte) {
 	endpoint := tc.getQuesmaEndpoint()
-	resp, err := tc.doRequest(ctx, method, endpoint+uri, body, nil)
+	resp, err := tc.doRequest(ctx, method, endpoint+uri, requestBody, nil)
 	if err != nil {
 		t.Fatalf("Error sending %s request to the endpoint '%s': %s", method, uri, err)
 	}
-	return resp
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body of %s request to the endpoint '%s': %s", method, uri, err)
+	}
+	return resp, responseBody
 }
 
 func (tc *IntegrationTestcaseBase) RequestToElasticsearch(ctx context.Context, method, uri string, body []byte) (*http.Response, error) {

--- a/ci/it/testcases/test_dual_write_and_common_table.go
+++ b/ci/it/testcases/test_dual_write_and_common_table.go
@@ -44,18 +44,12 @@ func (a *DualWriteAndCommonTableTestcase) RunTests(ctx context.Context, t *testi
 }
 
 func (a *DualWriteAndCommonTableTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 func (a *DualWriteAndCommonTableTestcase) testIngestToCommonTableWorks(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "POST", "/logs-4/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
-	if err != nil {
-		t.Fatalf("Failed to insert document: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/logs-4/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -101,10 +95,7 @@ func (a *DualWriteAndCommonTableTestcase) testIngestToCommonTableWorks(ctx conte
 	assert.Equal(t, 31337, age)
 	assert.Equal(t, "logs-4", quesmaIndexName)
 
-	resp, err = a.RequestToQuesma(ctx, "GET", "/logs-4/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp = a.RequestToQuesma(ctx, t, "GET", "/logs-4/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -117,10 +108,7 @@ func (a *DualWriteAndCommonTableTestcase) testIngestToCommonTableWorks(ctx conte
 }
 
 func (a *DualWriteAndCommonTableTestcase) testDualQueryReturnsDataFromClickHouse(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "POST", "/logs-dual-query/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
-	if err != nil {
-		t.Fatalf("Failed to insert document: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/logs-dual-query/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -166,10 +154,7 @@ func (a *DualWriteAndCommonTableTestcase) testDualQueryReturnsDataFromClickHouse
 		t.Fatalf("Failed to make DELETE request: %s", err)
 	}
 	// FINAL TEST - WHETHER QUESMA RETURNS DATA FROM CLICKHOUSE
-	resp, err = a.RequestToQuesma(ctx, "GET", "/logs-dual-query/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp = a.RequestToQuesma(ctx, t, "GET", "/logs-dual-query/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -182,10 +167,7 @@ func (a *DualWriteAndCommonTableTestcase) testDualQueryReturnsDataFromClickHouse
 }
 
 func (a *DualWriteAndCommonTableTestcase) testIngestToClickHouseWorks(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "POST", "/logs-2/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
-	if err != nil {
-		t.Fatalf("Failed to insert document: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/logs-2/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -241,10 +223,7 @@ func (a *DualWriteAndCommonTableTestcase) testIngestToClickHouseWorks(ctx contex
 }
 
 func (a *DualWriteAndCommonTableTestcase) testDualWritesWork(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "POST", "/logs-3/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
-	if err != nil {
-		t.Fatalf("Failed to insert document: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/logs-3/_doc", []byte(`{"name": "Przemyslaw", "age": 31337}`))
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -313,10 +292,7 @@ func (a *DualWriteAndCommonTableTestcase) testWildcardGoesToElastic(ctx context.
 		t.Fatalf("Failed to refresh index: %s", err)
 	}
 	// When Quesma searches for that document
-	resp, err := a.RequestToQuesma(ctx, "POST", "/unmentioned_index/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/unmentioned_index/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/ci/it/testcases/test_reading_clickhouse_tables.go
+++ b/ci/it/testcases/test_reading_clickhouse_tables.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
-	"io"
 	"net/http"
 	"testing"
 )
@@ -41,8 +40,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) RunTests(ctx context.Contex
 }
 
 func (a *ReadingClickHouseTablesIntegrationTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
-	defer resp.Body.Close()
+	resp, _ := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -60,8 +58,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) testRandomThing(ctx context
 	// This returns 500 Internal Server Error, but will be tackled in separate PR.
 	// (The table has not yet been discovered by Quesma )
 	// ERR quesma/quesma/quesma.go:198 > quesma request failed: Q2002: Missing table. Table: test_table: can't load test_table table opaque_id= path=/test_table/_search reason="Missing table." request_id=01926654-b214-7e1d-944a-a7545cd7d419
-	resp := a.RequestToQuesma(ctx, t, "GET", "/test_table/_search", []byte(`{"query": {"match_all": {}}}`))
-	defer resp.Body.Close()
+	resp, _ := a.RequestToQuesma(ctx, t, "GET", "/test_table/_search", []byte(`{"query": {"match_all": {}}}`))
 	assert.Equal(t, "Clickhouse", resp.Header.Get("X-Quesma-Source"))
 }
 
@@ -78,12 +75,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) testWildcardGoesToElastic(c
 		t.Fatalf("Failed to refresh index: %s", err)
 	}
 	// When Quesma searches for that document
-	resp := a.RequestToQuesma(ctx, t, "POST", "/extra_index/_search", []byte(`{"query": {"match_all": {}}}`))
-	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body: %s", err)
-	}
+	resp, bodyBytes := a.RequestToQuesma(ctx, t, "POST", "/extra_index/_search", []byte(`{"query": {"match_all": {}}}`))
 	var jsonResponse map[string]interface{}
 	if err := json.Unmarshal(bodyBytes, &jsonResponse); err != nil {
 		t.Fatalf("Failed to unmarshal response body: %s", err)

--- a/ci/it/testcases/test_reading_clickhouse_tables.go
+++ b/ci/it/testcases/test_reading_clickhouse_tables.go
@@ -41,10 +41,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) RunTests(ctx context.Contex
 }
 
 func (a *ReadingClickHouseTablesIntegrationTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -63,10 +60,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) testRandomThing(ctx context
 	// This returns 500 Internal Server Error, but will be tackled in separate PR.
 	// (The table has not yet been discovered by Quesma )
 	// ERR quesma/quesma/quesma.go:198 > quesma request failed: Q2002: Missing table. Table: test_table: can't load test_table table opaque_id= path=/test_table/_search reason="Missing table." request_id=01926654-b214-7e1d-944a-a7545cd7d419
-	resp, err := a.RequestToQuesma(ctx, "GET", "/test_table/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "GET", "/test_table/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	assert.Equal(t, "Clickhouse", resp.Header.Get("X-Quesma-Source"))
 }
@@ -84,10 +78,7 @@ func (a *ReadingClickHouseTablesIntegrationTestcase) testWildcardGoesToElastic(c
 		t.Fatalf("Failed to refresh index: %s", err)
 	}
 	// When Quesma searches for that document
-	resp, err := a.RequestToQuesma(ctx, "POST", "/extra_index/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/extra_index/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/ci/it/testcases/test_transparent_proxy.go
+++ b/ci/it/testcases/test_transparent_proxy.go
@@ -40,19 +40,12 @@ func (a *TransparentProxyIntegrationTestcase) RunTests(ctx context.Context, t *t
 }
 
 func (a *TransparentProxyIntegrationTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
-	defer resp.Body.Close()
+	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func (a *TransparentProxyIntegrationTestcase) testIfCatHealthRequestReachesElasticsearch(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "GET", "/_cat/health", nil)
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "GET", "/_cat/health", nil)
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -64,8 +57,8 @@ func (a *TransparentProxyIntegrationTestcase) testIfCatHealthRequestReachesElast
 }
 
 func (a *TransparentProxyIntegrationTestcase) testIfIndexCreationWorks(ctx context.Context, t *testing.T) {
-	_, err := a.RequestToQuesma(ctx, "PUT", "/index_1", nil)
-	_, err = a.RequestToQuesma(ctx, "PUT", "/index_2", nil)
+	_ = a.RequestToQuesma(ctx, t, "PUT", "/index_1", nil)
+	_ = a.RequestToQuesma(ctx, t, "PUT", "/index_2", nil)
 
 	resp, err := a.RequestToElasticsearch(ctx, "GET", "/_cat/indices", nil)
 	if err != nil {

--- a/ci/it/testcases/test_transparent_proxy.go
+++ b/ci/it/testcases/test_transparent_proxy.go
@@ -40,25 +40,20 @@ func (a *TransparentProxyIntegrationTestcase) RunTests(ctx context.Context, t *t
 }
 
 func (a *TransparentProxyIntegrationTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
+	resp, _ := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func (a *TransparentProxyIntegrationTestcase) testIfCatHealthRequestReachesElasticsearch(ctx context.Context, t *testing.T) {
-	resp := a.RequestToQuesma(ctx, t, "GET", "/_cat/health", nil)
-	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body: %s", err)
-	}
+	resp, bodyBytes := a.RequestToQuesma(ctx, t, "GET", "/_cat/health", nil)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "Elasticsearch", resp.Header.Get("X-elastic-product"))
 	assert.Contains(t, string(bodyBytes), "green")
 }
 
 func (a *TransparentProxyIntegrationTestcase) testIfIndexCreationWorks(ctx context.Context, t *testing.T) {
-	_ = a.RequestToQuesma(ctx, t, "PUT", "/index_1", nil)
-	_ = a.RequestToQuesma(ctx, t, "PUT", "/index_2", nil)
+	_, _ = a.RequestToQuesma(ctx, t, "PUT", "/index_1", nil)
+	_, _ = a.RequestToQuesma(ctx, t, "PUT", "/index_2", nil)
 
 	resp, err := a.RequestToElasticsearch(ctx, "GET", "/_cat/indices", nil)
 	if err != nil {

--- a/ci/it/testcases/test_two_pipelines.go
+++ b/ci/it/testcases/test_two_pipelines.go
@@ -42,10 +42,7 @@ func (a *QueryAndIngestPipelineTestcase) RunTests(ctx context.Context, t *testin
 }
 
 func (a *QueryAndIngestPipelineTestcase) testBasicRequest(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "GET", "/", nil)
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "GET", "/", nil)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
@@ -63,10 +60,7 @@ func (a *QueryAndIngestPipelineTestcase) testWildcardGoesToElastic(ctx context.C
 		t.Fatalf("Failed to refresh index: %s", err)
 	}
 	// When Quesma searches for that document
-	resp, err := a.RequestToQuesma(ctx, "POST", "/unmentioned_index/_search", []byte(`{"query": {"match_all": {}}}`))
-	if err != nil {
-		t.Fatalf("Failed to make GET request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/unmentioned_index/_search", []byte(`{"query": {"match_all": {}}}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -88,10 +82,7 @@ func (a *QueryAndIngestPipelineTestcase) testWildcardGoesToElastic(ctx context.C
 }
 
 func (a *QueryAndIngestPipelineTestcase) testEmptyTargetDoc(ctx context.Context, t *testing.T) {
-	resp, err := a.RequestToQuesma(ctx, "POST", "/logs_disabled/_doc", []byte(`{"name": "Alice"}`))
-	if err != nil {
-		t.Fatalf("Error sending POST request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/logs_disabled/_doc", []byte(`{"name": "Alice"}`))
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -112,10 +103,7 @@ func (a *QueryAndIngestPipelineTestcase) testEmptyTargetBulk(ctx context.Context
 		{ "name": "Bob", "age": 25 }
 	
 `)
-	resp, err := a.RequestToQuesma(ctx, "POST", "/_bulk", bulkPayload)
-	if err != nil {
-		t.Fatalf("Error sending POST request: %s", err)
-	}
+	resp := a.RequestToQuesma(ctx, t, "POST", "/_bulk", bulkPayload)
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Since I'll be adding new integration tests, let's do some cleanup of boilerplate of existing tests to make it nicer to write new tests (avoiding further code duplication/boilerplace).

This PR tackles `RequestToQuesma`: move error handling/reading of body into `RequestToQuesma` function itself - no need to duplicate this logic all over the test code.