### PR TITLE
Handle empty body `PUT /:index` request

### DIFF
--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -301,6 +301,10 @@ func configureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 
 	router.Register(routes.IndexPath, and(method("PUT"), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
 		index := req.Params["index"]
+		if req.Body == "" {
+			logger.Warn().Msgf("empty body in PUT /%s request, Quesma is not doing anything", index)
+			return putIndexResult(index)
+		}
 
 		body, err := types.ExpectJSON(req.ParsedBody)
 		if err != nil {


### PR DESCRIPTION
Previously it resulted in:
```
curl -XPUT localhost:8080/test2
Q1001: Invalid request body. We're expecting JSON here.
Request ID: 0192b9db-b87f-7553-b7de-8d108e2f326d
```

Now it's still just an internal no-op and positive response to the client
```
curl -XPUT localhost:8080/test2
{"acknowledged":true,"shards_acknowledged":true,"index":"test2"}%
```

**Context:** In Elasticsearch world, just creating index using  `PUT /indexName` request (without mappings or settings) is pretty standard practice, so we should respect that, even though that's a no-op in our realm .