### PR TITLE
Use common table for '*' wildcard

### DIFF
--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -44,12 +44,11 @@ type QuesmaConfiguration struct {
 	DisableAuth                bool
 	AutodiscoveryEnabled       bool
 
-	EnableIngest                 bool // this is computed from the configuration 2.0
-	CreateCommonTable            bool
-	CreateCommonTableForWildcard bool // the meaning of this is to create a common table for wildcard indexes
-	// and is a duplication for now due to some corner cases
-	DefaultIngestTarget []string
-	DefaultQueryTarget  []string
+	EnableIngest              bool // this is computed from the configuration 2.0
+	CreateCommonTable         bool
+	UseCommonTableForWildcard bool //the meaning of this is to use a common table for wildcard (default) indexes
+	DefaultIngestTarget       []string
+	DefaultQueryTarget        []string
 }
 
 func (c *QuesmaConfiguration) AliasFields(indexName string) map[string]string {

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -44,9 +44,10 @@ type QuesmaConfiguration struct {
 	DisableAuth                bool
 	AutodiscoveryEnabled       bool
 
-	EnableIngest      bool // this is computed from the configuration 2.0
-	CreateCommonTable bool
-
+	EnableIngest                 bool // this is computed from the configuration 2.0
+	CreateCommonTable            bool
+	CreateCommonTableForWildcard bool // the meaning of this is to create a common table for wildcard indexes
+	// and is a duplication for now due to some corner cases
 	DefaultIngestTarget []string
 	DefaultQueryTarget  []string
 }

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -641,6 +641,11 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		if len(defaultConfig.QueryTarget) > 1 {
 			errAcc = multierror.Append(errAcc, fmt.Errorf("the target configuration of default index ('%s') of query processor is not currently supported", DefaultWildcardIndexName))
 		}
+
+		if defaultConfig.UseCommonTable != ingestProcessorDefaultIndexConfig.UseCommonTable {
+			errAcc = multierror.Append(errAcc, fmt.Errorf("the target configuration of default index ('%s') of query processor and ingest processor should consistently use quesma common table property", DefaultWildcardIndexName))
+		}
+
 		// No restrictions for ingest target!
 		conf.DefaultIngestTarget = defaultConfig.IngestTarget
 		conf.DefaultQueryTarget = defaultConfig.QueryTarget

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -619,13 +619,23 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 			}
 		}
+		if defaultConfig.UseCommonTable {
+			conf.CreateCommonTable = true
+		}
+
+		ingestProcessorDefaultIndexConfig := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]
 		for _, target := range ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName].Target {
 			if targetType, found := c.getTargetType(target); found {
 				defaultConfig.IngestTarget = append(defaultConfig.IngestTarget, targetType)
+
 			} else {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 			}
 		}
+		if ingestProcessorDefaultIndexConfig.UseCommonTable {
+			conf.CreateCommonTable = true
+		}
+
 		if len(defaultConfig.QueryTarget) > 1 {
 			errAcc = multierror.Append(errAcc, fmt.Errorf("the target configuration of default index ('%s') of query processor is not currently supported", DefaultWildcardIndexName))
 		}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -556,7 +556,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				// We set both flags to true here
 				// as creating common table depends on the first one
 				conf.CreateCommonTable = true
-				conf.CreateCommonTableForWildcard = true
+				conf.UseCommonTableForWildcard = true
 			}
 			if len(defaultConfig.QueryTarget) > 1 {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("the target configuration of default index ('%s') of query processor is not currently supported", DefaultWildcardIndexName))
@@ -629,7 +629,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			// We set both flags to true here
 			// as creating common table depends on the first one
 			conf.CreateCommonTable = true
-			conf.CreateCommonTableForWildcard = true
+			conf.UseCommonTableForWildcard = true
 		}
 
 		ingestProcessorDefaultIndexConfig := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]
@@ -644,7 +644,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			// We set both flags to true here
 			// as creating common table depends on the first one
 			conf.CreateCommonTable = true
-			conf.CreateCommonTableForWildcard = true
+			conf.UseCommonTableForWildcard = true
 		}
 
 		if len(defaultConfig.QueryTarget) > 1 {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -627,7 +627,6 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		for _, target := range ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName].Target {
 			if targetType, found := c.getTargetType(target); found {
 				defaultConfig.IngestTarget = append(defaultConfig.IngestTarget, targetType)
-
 			} else {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 			}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -552,6 +552,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
 			}
+			if defaultConfig.UseCommonTable {
+				conf.CreateCommonTableForWildcard = true
+			}
 			if len(defaultConfig.QueryTarget) > 1 {
 				errAcc = multierror.Append(errAcc, fmt.Errorf("the target configuration of default index ('%s') of query processor is not currently supported", DefaultWildcardIndexName))
 			}
@@ -620,7 +623,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			}
 		}
 		if defaultConfig.UseCommonTable {
-			conf.CreateCommonTable = true
+			conf.CreateCommonTableForWildcard = true
 		}
 
 		ingestProcessorDefaultIndexConfig := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]
@@ -632,7 +635,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			}
 		}
 		if ingestProcessorDefaultIndexConfig.UseCommonTable {
-			conf.CreateCommonTable = true
+			conf.CreateCommonTableForWildcard = true
 		}
 
 		if len(defaultConfig.QueryTarget) > 1 {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -553,6 +553,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				}
 			}
 			if defaultConfig.UseCommonTable {
+				// We set both flags to true here
+				// as creating common table depends on the first one
+				conf.CreateCommonTable = true
 				conf.CreateCommonTableForWildcard = true
 			}
 			if len(defaultConfig.QueryTarget) > 1 {
@@ -623,6 +626,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			}
 		}
 		if defaultConfig.UseCommonTable {
+			// We set both flags to true here
+			// as creating common table depends on the first one
+			conf.CreateCommonTable = true
 			conf.CreateCommonTableForWildcard = true
 		}
 
@@ -635,6 +641,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			}
 		}
 		if ingestProcessorDefaultIndexConfig.UseCommonTable {
+			// We set both flags to true here
+			// as creating common table depends on the first one
+			conf.CreateCommonTable = true
 			conf.CreateCommonTableForWildcard = true
 		}
 

--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -79,7 +79,7 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 			case config.ClickhouseTarget:
 				useConnectors = append(useConnectors, &ConnectorDecisionClickhouse{
 					ClickhouseTableName: input.source,
-					IsCommonTable:       quesmaConf.CreateCommonTableForWildcard,
+					IsCommonTable:       quesmaConf.UseCommonTableForWildcard,
 					ClickhouseTables:    []string{input.source},
 				})
 			case config.ElasticsearchTarget:

--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -79,7 +79,7 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 			case config.ClickhouseTarget:
 				useConnectors = append(useConnectors, &ConnectorDecisionClickhouse{
 					ClickhouseTableName: input.source,
-					IsCommonTable:       quesmaConf.CreateCommonTable,
+					IsCommonTable:       quesmaConf.CreateCommonTableForWildcard,
 					ClickhouseTables:    []string{input.source},
 				})
 			case config.ElasticsearchTarget:

--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -79,6 +79,7 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 			case config.ClickhouseTarget:
 				useConnectors = append(useConnectors, &ConnectorDecisionClickhouse{
 					ClickhouseTableName: input.source,
+					IsCommonTable:       quesmaConf.CreateCommonTable,
 					ClickhouseTables:    []string{input.source},
 				})
 			case config.ElasticsearchTarget:


### PR DESCRIPTION
This PR is about `usingCommonTable` configuration property for `*` wildcard:

```
'*':
  useCommonTable: true
  target: [ my-clickhouse-data-source ]
```