### PR TITLE
Fix usage of deprecated `set-output`, give nicer URL to commit

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Get last commit author
         id: get_author
-        run: echo "::set-output name=author::$(git log -1 --pretty=format:'%an <%ae> sha1={%H}')"
+        run: >
+          echo "author=$(git log -1 --pretty=format:'%an <%ae>, commit URL: ${{ github.server_url }}/${{ github.repository }}/commit/%H')" >> $GITHUB_OUTPUT
 
       - name: License Header Verification
         working-directory: ci/it


### PR DESCRIPTION
`set-output` is deprecated (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and the job always printed annoying warning because of that. Fix that to use `$GITHUB_OUTPUT` instead.

Additionally, instead of printing just a hash of the commit, print a (clickable) URL to the commit.