### PR TITLE
Using `UseCommonTableForWildcard`property for wildcard config

### DIFF
--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -16,7 +16,7 @@ import (
 )
 
 type SchemaCheckPass struct {
-	cfg map[string]config.IndexConfiguration
+	cfg *config.QuesmaConfiguration
 }
 
 func (s *SchemaCheckPass) applyBooleanLiteralLowering(index schema.Schema, query *model.Query) (*model.Query, error) {
@@ -354,10 +354,9 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 
 	var useCommonTable bool
 	if len(query.Indexes) == 1 {
-		if indexConf, ok := s.cfg[query.Indexes[0]]; ok {
+		if indexConf, ok := s.cfg.IndexConfig[query.Indexes[0]]; ok {
 			useCommonTable = indexConf.UseCommonTable
-		} else {
-			// if index configuration is not found, use common table
+		} else if s.cfg.UseCommonTableForWildcard {
 			useCommonTable = true
 		}
 	} else { // we can handle querying multiple indexes from common table only

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -356,6 +356,9 @@ func (s *SchemaCheckPass) applyPhysicalFromExpression(currentSchema schema.Schem
 	if len(query.Indexes) == 1 {
 		if indexConf, ok := s.cfg[query.Indexes[0]]; ok {
 			useCommonTable = indexConf.UseCommonTable
+		} else {
+			// if index configuration is not found, use common table
+			useCommonTable = true
 		}
 	} else { // we can handle querying multiple indexes from common table only
 		useCommonTable = true

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -81,7 +81,7 @@ func Test_ipRangeTransform(t *testing.T) {
 			TableName: "kibana_sample_data_logs_nested", FieldName: "nested.clientip"}: "nested_clientip",
 	}
 	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-	transform := &SchemaCheckPass{cfg: indexConfig}
+	transform := &SchemaCheckPass{cfg: &cfg}
 	s.UpdateFieldEncodings(fieldEncodings)
 
 	selectColumns := []model.Expr{model.NewColumnRef("message")}
@@ -430,7 +430,7 @@ func Test_arrayType(t *testing.T) {
 		Fields: fields,
 	}
 
-	transform := &SchemaCheckPass{cfg: indexConfig}
+	transform := &SchemaCheckPass{cfg: &config.QuesmaConfiguration{IndexConfig: indexConfig}}
 
 	tests := []struct {
 		name     string
@@ -607,7 +607,7 @@ func TestApplyWildCard(t *testing.T) {
 		},
 	}
 
-	transform := &SchemaCheckPass{cfg: indexConfig}
+	transform := &SchemaCheckPass{cfg: &config.QuesmaConfiguration{IndexConfig: indexConfig}}
 
 	tests := []struct {
 		name     string
@@ -697,7 +697,7 @@ func TestApplyPhysicalFromExpression(t *testing.T) {
 	td.Store(tableDefinition.Name, &tableDefinition)
 
 	s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-	transform := &SchemaCheckPass{cfg: indexConfig}
+	transform := &SchemaCheckPass{cfg: &config.QuesmaConfiguration{IndexConfig: indexConfig}}
 
 	tests := []struct {
 		name     string
@@ -958,7 +958,7 @@ func TestFullTextFields(t *testing.T) {
 			}
 
 			s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
-			transform := &SchemaCheckPass{cfg: indexConfig}
+			transform := &SchemaCheckPass{cfg: &config.QuesmaConfiguration{IndexConfig: indexConfig}}
 
 			indexSchema, ok := s.FindSchema("test")
 			if !ok {

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -81,7 +81,7 @@ func NewQueryRunner(lm *clickhouse.LogManager,
 		AsyncQueriesContexts: async_search_storage.NewAsyncQueryContextStorageInMemory(),
 		transformationPipeline: TransformationPipeline{
 			transformers: []model.QueryTransformer{
-				&SchemaCheckPass{cfg: cfg.IndexConfig},
+				&SchemaCheckPass{cfg: cfg},
 			},
 		},
 		schemaRegistry:  schemaRegistry,


### PR DESCRIPTION
This is PR to handle queries  where following configuration is used (no explicit index configuration)

```
'*':
  useCommonTable: true
  target: [ my-clickhouse-data-source ]
```