### PR TITLE
Add test for "A/B testing" `table_resolver` bug (in case of pattern)

### DIFF
--- a/quesma/table_resolver/table_resolver_test.go
+++ b/quesma/table_resolver/table_resolver_test.go
@@ -339,6 +339,20 @@ func TestTableResolver(t *testing.T) {
 			indexConf: indexConf,
 		},
 		{
+			name:     "A/B testing (pattern)",
+			pipeline: QueryPipeline,
+			pattern:  "logs*",
+			expected: Decision{
+				EnableABTesting: true,
+				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+					ClickhouseTableName: "logs",
+					ClickhouseTables:    []string{"logs"},
+				},
+					&ConnectorDecisionElastic{}},
+			},
+			indexConf: indexConf,
+		},
+		{
 			name:              "query both connectors",
 			pipeline:          QueryPipeline,
 			pattern:           "logs,index1",
@@ -379,8 +393,11 @@ func TestTableResolver(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if i == 24 {
+				t.Skip("bug: A/B testing doesn't work with patterns")
+			}
 
 			tableDiscovery := clickhouse.NewEmptyTableDiscovery()
 


### PR DESCRIPTION
A/B testing is turned on in the configuration by specifying two targets: ClickHouse and Elastic (`target: [ch, es]`). `table_resolver` correctly handles it for single index case (e.g. `logs`), but it's not working correctly for the pattern case (e.g. `logs*`, even if the pattern matches only a single index with A/B testing requested). It fails with:

```
  Reason:          "Both Elastic and Clickhouse matched.",
  ResolverName:    "searchAcrossConnectors",
  originError:     &errors.errorString{
    s: "index pattern [[logs*]] resolved to both elasticsearch indices: [[logs]] and clickhouse tables: [[logs]]",
  },
```


Adding a (skipped) test for such case (a proper fix needs some discussion with @nablaone).