### PR TITLE
Lucene enhancements

### DIFF
--- a/quesma/queryparser/lucene/expression.go
+++ b/quesma/queryparser/lucene/expression.go
@@ -95,7 +95,7 @@ func (p *luceneParser) buildWhereStatement(addDefaultOperator bool) model.Expr {
 		}
 		currentStatement = model.NewInfixExpr(model.NewColumnRef(fieldName.term), " IS NOT ", model.NewLiteral("NULL"))
 	case leftParenthesisToken:
-		currentStatement = model.NewParenExpr(p.buildWhereStatement(true))
+		currentStatement = model.NewParenExpr(p.buildWhereStatement(false))
 	case rightParenthesisToken:
 		if p.WhereStatement == nil {
 			return invalidStatement

--- a/quesma/queryparser/lucene/expression.go
+++ b/quesma/queryparser/lucene/expression.go
@@ -3,8 +3,6 @@
 package lucene
 
 import (
-	"fmt"
-	"github.com/k0kubun/pp"
 	"quesma/logger"
 	"quesma/model"
 )
@@ -14,9 +12,7 @@ var invalidStatement = model.NewLiteral("false")
 func (p *luceneParser) BuildWhereStatement() model.Expr {
 	for len(p.tokens) > 0 {
 		p.WhereStatement = p.buildWhereStatement(true)
-		fmt.Println("PETLA", p.WhereStatement)
 	}
-	pp.Println(p.WhereStatement)
 	if p.WhereStatement == nil {
 		return model.NewLiteral("true")
 	}
@@ -51,10 +47,11 @@ func (p *luceneParser) buildWhereStatement(addDefaultOperator bool) model.Expr {
 	if len(p.tokens) == 0 {
 		return invalidStatement
 	}
-	fmt.Printf("p.tokens: %v %T\n", p.tokens, p.tokens[0])
+
 	tok := p.tokens[0]
 	p.tokens = p.tokens[1:]
 	var currentStatement model.Expr
+
 	switch currentToken := tok.(type) {
 	case fieldNameToken:
 		if len(p.tokens) <= 1 {
@@ -87,7 +84,6 @@ func (p *luceneParser) buildWhereStatement(addDefaultOperator bool) model.Expr {
 		latterExp := p.buildWhereStatement(false)
 		currentStatement = model.NewPrefixExpr("NOT", []model.Expr{latterExp})
 	case existsToken:
-		fmt.Println("p.tokens", p.tokens)
 		fieldName, ok := p.buildValue([]value{}, 0).(termValue)
 		if !ok {
 			logger.Error().Msgf("buildExpression: invalid expression, unexpected token: %#v, tokens: %v", currentToken, p.tokens)
@@ -105,11 +101,11 @@ func (p *luceneParser) buildWhereStatement(addDefaultOperator bool) model.Expr {
 		logger.Error().Msgf("buildExpression: invalid expression, unexpected token: %#v, tokens: %v", currentToken, p.tokens)
 		return invalidStatement
 	}
-	fmt.Println("currentStatement", currentStatement)
+
 	if !addDefaultOperator || p.WhereStatement == nil {
-		pp.Println("in if", addDefaultOperator, p.WhereStatement, currentStatement)
 		return currentStatement
 	}
+
 	switch stmt := currentStatement.(type) {
 	case model.PrefixExpr:
 		if stmt.Op == "NOT" {

--- a/quesma/queryparser/lucene/lucene_parser.go
+++ b/quesma/queryparser/lucene/lucene_parser.go
@@ -24,7 +24,7 @@ import (
 // - escaped " inside quoted fieldnames, so e.g.
 //     * "a\"b" - not supported
 //     * abc"def - supported
-// - +, -, &&, ||, ! operators. But AND, OR, NOT are fully supported and they seem equivalent.
+// - +, -, &&, ||, operators. But AND, OR, NOT are fully supported and they seem equivalent.
 
 // Date ranges are only in format YYYY-MM-DD, as in docs there are no other examples. That can be changed if needed.
 
@@ -68,6 +68,8 @@ var specialOperators = map[string]token{
 	"AND ":                   andToken{},
 	"OR ":                    orToken{},
 	"NOT ":                   notToken{},
+	"!":                      notToken{},
+	"_exists_:":              existsToken{},
 	string(leftParenthesis):  leftParenthesisToken{},
 	string(rightParenthesis): rightParenthesisToken{},
 }

--- a/quesma/queryparser/lucene/lucene_parser_test.go
+++ b/quesma/queryparser/lucene/lucene_parser_test.go
@@ -4,7 +4,6 @@ package lucene
 
 import (
 	"context"
-	"quesma/logger"
 	"quesma/model"
 	"quesma/schema"
 	"strconv"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
-	logger.InitSimpleLoggerForTests()
+	// logger.InitSimpleLoggerForTests()
 	defaultFieldNames := []string{"title", "text"}
 	var properQueries = []struct {
 		query string

--- a/quesma/queryparser/lucene/lucene_parser_test.go
+++ b/quesma/queryparser/lucene/lucene_parser_test.go
@@ -46,7 +46,7 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 		{`"jakarta apache" AND "Apache Lucene"`, `(("title" = 'jakarta apache' OR "text" = 'jakarta apache') AND ("title" = 'Apache Lucene' OR "text" = 'Apache Lucene'))`},
 		{`NOT status:"jakarta apache"`, `NOT ("status" = 'jakarta apache')`},
 		{`"jakarta apache" NOT "Apache Lucene"`, `(("title" = 'jakarta apache' OR "text" = 'jakarta apache') AND NOT (("title" = 'Apache Lucene' OR "text" = 'Apache Lucene')))`},
-		{`(jakarta OR apache) AND website`, `(((("title" = 'jakarta' OR "title" = 'apache')) OR ("text" = 'jakarta' OR "text" = 'apache')) AND ("title" = 'website' OR "text" = 'website'))`},
+		{`(jakarta OR apache) AND website`, `(((("title" = 'jakarta' OR "text" = 'jakarta')) OR ("title" = 'apache' OR "text" = 'apache')) AND ("title" = 'website' OR "text" = 'website'))`},
 		{`title:(return "pink panther")`, `("title" = 'return' OR "title" = 'pink panther')`},
 		{`status:(active OR pending) title:(full text search)^2`, `(("status" = 'active' OR "status" = 'pending') OR (("title" = 'full' OR "title" = 'text') OR "title" = 'search'))`},
 		{`status:(active OR NOT (pending AND in-progress)) title:(full text search)^2`, `(("status" = 'active' OR NOT (("status" = 'pending' AND "status" = 'in-progress'))) OR (("title" = 'full' OR "title" = 'text') OR "title" = 'search'))`},
@@ -54,7 +54,7 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 		{`status:(active OR (pending AND in-progress)) title:(full text search)^2`, `(("status" = 'active' OR ("status" = 'pending' AND "status" = 'in-progress')) OR (("title" = 'full' OR "title" = 'text') OR "title" = 'search'))`},
 		{`status:((a OR (b AND c)) AND d)`, `(("status" = 'a' OR ("status" = 'b' AND "status" = 'c')) AND "status" = 'd')`},
 		{`title:(return [Aida TO Carmen])`, `("title" = 'return' OR ("title" >= 'Aida' AND "title" <= 'Carmen'))`},
-		{`host.name:(NOT active OR NOT (pending OR in-progress)) (full text search)^2`, `((NOT ("host.name" = 'active') OR NOT (("host.name" = 'pending' OR "host.name" = 'in-progress'))) OR ((("title" = 'full' OR "title" = 'text') OR "title" = 'search') OR (("text" = 'full' OR "text" = 'text') OR "text" = 'search')))`},
+		{`host.name:(NOT active OR NOT (pending OR in-progress)) (full text search)^2`, `((((NOT ("host.name" = 'active') OR NOT (("host.name" = 'pending' OR "host.name" = 'in-progress'))) OR (("title" = 'full' OR "text" = 'full'))) OR ("title" = 'text' OR "text" = 'text')) OR ("title" = 'search' OR "text" = 'search'))`},
 		{`host.name:(active AND NOT (pending OR in-progress)) hermes nemesis^2`, `((("host.name" = 'active' AND NOT (("host.name" = 'pending' OR "host.name" = 'in-progress'))) OR ("title" = 'hermes' OR "text" = 'hermes')) OR ("title" = 'nemesis' OR "text" = 'nemesis'))`},
 		{`dajhd \(%&RY#WFDG`, `(("title" = 'dajhd' OR "text" = 'dajhd') OR ("title" = '(%&RY#WFDG' OR "text" = '(%&RY#WFDG'))`},
 		// tests for wildcards
@@ -79,7 +79,7 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 		{``, `true`},
 		{`          `, `true`},
 		{`  2 `, `("title" = '2' OR "text" = '2')`},
-		{`  2df$ ! `, `(("title" = '2df$' OR "text" = '2df$') AND NOT (false)`}, // TODO: this should probably just be "false"
+		{`  2df$ ! `, `(("title" = '2df$' OR "text" = '2df$') AND NOT (false))`}, // TODO: this should probably just be "false"
 		{`title:`, `false`},
 		{`title: abc`, `"title" = 'abc'`},
 		{`title[`, `("title" = 'title[' OR "text" = 'title[')`},
@@ -97,8 +97,6 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 	}
 
 	for i, tt := range append(properQueries, randomQueriesWithPossiblyIncorrectInput...) {
-		if i != 36 {
-		}
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			parser := newLuceneParser(context.Background(), defaultFieldNames, currentSchema)
 			got := model.AsString(parser.translateToSQL(tt.query))

--- a/quesma/queryparser/lucene/lucene_parser_test.go
+++ b/quesma/queryparser/lucene/lucene_parser_test.go
@@ -70,7 +70,7 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 		{`!_exists_:title`, `NOT ("title" IS NOT NULL)`},
 		{"db.str:*weaver*", `"db.str" ILIKE '%weaver%'`},
 		{"(db.str:*weaver*)", `("db.str" ILIKE '%weaver%')`},
-		{"(xdr.emm_type_str:*bearer* OR xdr.emm_type_str:*Bearer*)", `(("xdr.emm_type_str" ILIKE '%bearer%') OR "xdr.emm_type_str" ILIKE '%Bearer%')`},
+		{"(a.type:*ab* OR a.type:*Ab*)", `(("a.type" ILIKE '%ab%') OR "a.type" ILIKE '%Ab%')`},
 	}
 	var randomQueriesWithPossiblyIncorrectInput = []struct {
 		query string

--- a/quesma/queryparser/lucene/lucene_parser_test.go
+++ b/quesma/queryparser/lucene/lucene_parser_test.go
@@ -89,7 +89,7 @@ func TestTranslatingLuceneQueriesToSQL(t *testing.T) {
 		{`  title       `, `("title" = 'title' OR "text" = 'title')`},
 		{`  title : (+a -b c)`, `(("title" = '+a' OR "title" = '-b') OR "title" = 'c')`}, // we don't support '+', '-' operators, but in that case the answer seems good enough + nothing crashes
 		{`title:()`, `false`},
-		{`() a`, `((false) OR ("title" = 'a' OR "text" = 'a'))`}, // a bit weird, but 'false OR false' is OK as I think nothing should match '()'
+		{`() a`, `((false) OR ("title" = 'a' OR "text" = 'a'))`}, // a bit weird, but '(false)' is OK as I think nothing should match '()'
 	}
 
 	currentSchema := schema.Schema{

--- a/quesma/queryparser/lucene/token.go
+++ b/quesma/queryparser/lucene/token.go
@@ -22,6 +22,8 @@ type andToken struct{}
 
 type notToken struct{}
 
+type existsToken struct{}
+
 type leftParenthesisToken struct{}
 
 type rightParenthesisToken struct{}


### PR DESCRIPTION
This Lucene parser seemed to work fine for a subset of Lucene. Now I had to extend this subset a bit, and I'm afraid some weird (and usually incorrect) queries might not work 100% correctly, although I'd have to think for a bit for an example.

But all tests + customer's dashboards work fine, so I'd merge it. I have an idea how to support full Lucene, 90% it'd work. I'll try to do it very soon.

I tried 2 other open-source Lucene parsers, and they both fail on ~20-30 / 60 our tests, so if our passes all, it's more fine than not.
