### PR TITLE
table_resolver refactor - introduce patternSplitter, decisionMerger

### DIFF
--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -10,7 +10,6 @@ import (
 	"quesma/quesma/config"
 	"quesma/util"
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -76,18 +75,15 @@ func singleIndexSplitter(pattern string) (parsedPattern, *Decision) {
 	}, nil
 }
 
-func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline string) func(input parsedPattern) *Decision {
+func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
 
-	return func(input parsedPattern) *Decision {
-
-		if !input.isPattern {
-			idx, ok := cfg[input.source]
-			if ok {
-				if len(getTargets(idx, pipeline)) == 0 {
-					return &Decision{
-						IsClosed: true,
-						Reason:   "Index is disabled in config.",
-					}
+	return func(part string) *Decision {
+		idx, ok := cfg[part]
+		if ok {
+			if len(getTargets(idx, pipeline)) == 0 {
+				return &Decision{
+					IsClosed: true,
+					Reason:   "Index is disabled in config.",
 				}
 			}
 		}
@@ -96,9 +92,9 @@ func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline s
 	}
 }
 
-func resolveInternalElasticName(pattern parsedPattern) *Decision {
+func resolveInternalElasticName(part string) *Decision {
 
-	if elasticsearch.IsInternalIndex(pattern.source) {
+	if elasticsearch.IsInternalIndex(part) {
 		return &Decision{
 			UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{ManagementCall: true}},
 			Reason:        "It's kibana internals",
@@ -108,8 +104,8 @@ func resolveInternalElasticName(pattern parsedPattern) *Decision {
 	return nil
 }
 
-func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string) func(input parsedPattern) *Decision {
-	return func(input parsedPattern) *Decision {
+func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string) func(part string) *Decision {
+	return func(part string) *Decision {
 		var targets []string
 		var useConnectors []ConnectorDecision
 
@@ -129,9 +125,9 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 			switch target {
 			case config.ClickhouseTarget:
 				useConnectors = append(useConnectors, &ConnectorDecisionClickhouse{
-					ClickhouseTableName: input.source,
+					ClickhouseTableName: part,
 					IsCommonTable:       quesmaConf.UseCommonTableForWildcard,
-					ClickhouseTables:    []string{input.source},
+					ClickhouseTables:    []string{part},
 				})
 			case config.ElasticsearchTarget:
 				useConnectors = append(useConnectors, &ConnectorDecisionElastic{})
@@ -151,15 +147,10 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 	}
 }
 
-func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfiguration, pipeline string) func(input parsedPattern) *Decision {
+func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
 
-	return func(input parsedPattern) *Decision {
-
-		if input.isPattern {
-			return nil
-		}
-
-		if cfg, ok := indexConfig[input.source]; ok {
+	return func(part string) *Decision {
+		if cfg, ok := indexConfig[part]; ok {
 			if !cfg.UseCommonTable {
 
 				targets := getTargets(cfg, pipeline)
@@ -182,8 +173,8 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 						targetDecision = &ConnectorDecisionElastic{}
 					case config.ClickhouseTarget:
 						targetDecision = &ConnectorDecisionClickhouse{
-							ClickhouseTableName: input.source,
-							ClickhouseTables:    []string{input.source},
+							ClickhouseTableName: part,
+							ClickhouseTables:    []string{part},
 						}
 					default:
 						return &Decision{
@@ -203,8 +194,8 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 							Reason: "Enabled in the config. Dual write is enabled.",
 
 							UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-								ClickhouseTableName: input.source,
-								ClickhouseTables:    []string{input.source}},
+								ClickhouseTableName: part,
+								ClickhouseTables:    []string{part}},
 								&ConnectorDecisionElastic{}},
 						}
 
@@ -216,8 +207,8 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 								Reason:          "Enabled in the config. A/B testing.",
 								EnableABTesting: true,
 								UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-									ClickhouseTableName: input.source,
-									ClickhouseTables:    []string{input.source}},
+									ClickhouseTableName: part,
+									ClickhouseTables:    []string{part}},
 									&ConnectorDecisionElastic{}},
 							}
 						} else if targets[0] == config.ElasticsearchTarget && targets[1] == config.ClickhouseTarget {
@@ -228,8 +219,8 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 								UseConnectors: []ConnectorDecision{
 									&ConnectorDecisionElastic{},
 									&ConnectorDecisionClickhouse{
-										ClickhouseTableName: input.source,
-										ClickhouseTables:    []string{input.source}},
+										ClickhouseTableName: part,
+										ClickhouseTables:    []string{part}},
 								},
 							}
 
@@ -260,186 +251,10 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 	}
 }
 
-func (r *tableRegistryImpl) makeCheckIfPatternMatchesAllConnectors(pipeline string) func(input parsedPattern) *Decision {
+func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
 
-	return func(input parsedPattern) *Decision {
-		if input.isPattern {
-
-			var matchedElastic []string
-			var matchedClickhouse []string
-
-			for _, pattern := range input.parts {
-
-				// here we check against the config
-
-				for indexName, index := range r.conf.IndexConfig {
-					targets := getTargets(index, pipeline)
-
-					if util.IndexPatternMatches(pattern, indexName) {
-
-						for _, target := range targets {
-							switch target {
-							case config.ElasticsearchTarget:
-								matchedElastic = append(matchedElastic, indexName)
-							case config.ClickhouseTarget:
-								matchedClickhouse = append(matchedClickhouse, indexName)
-							default:
-								return &Decision{
-									Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported target: %s", target)),
-									Reason: "Unsupported target.",
-								}
-							}
-						}
-					}
-				}
-
-				// but maybe we should also check against the actual indexes ??
-				for indexName := range r.elasticIndexes {
-					if util.IndexPatternMatches(pattern, indexName) {
-						matchedElastic = append(matchedElastic, indexName)
-					}
-				}
-				if r.conf.AutodiscoveryEnabled {
-					for tableName := range r.clickhouseIndexes {
-						if util.IndexPatternMatches(pattern, tableName) {
-							matchedClickhouse = append(matchedClickhouse, tableName)
-						}
-					}
-				}
-
-			}
-
-			matchedElastic = util.Distinct(matchedElastic)
-			matchedClickhouse = util.Distinct(matchedClickhouse)
-
-			nElastic := len(matchedElastic)
-			nClickhouse := len(matchedClickhouse)
-
-			switch {
-
-			case nElastic > 0 && nClickhouse > 0:
-				return &Decision{
-					Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("index pattern [%s] resolved to both elasticsearch indices: [%s] and clickhouse tables: [%s]", input.parts, matchedElastic, matchedClickhouse)),
-					Reason: "Both Elastic and Clickhouse matched.",
-				}
-
-			case nElastic > 0 && nClickhouse == 0:
-
-				return &Decision{
-					UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{}},
-					Reason:        "Only Elastic matched.",
-				}
-
-			case nElastic == 0 && nClickhouse > 0:
-				// it will be resolved by sth else later
-				return nil
-
-			case nElastic == 0 && nClickhouse == 0:
-				return &Decision{
-					IsEmpty: true,
-					Reason:  "No indexes matched. Checked both connectors.",
-				}
-			}
-		}
-
-		return nil
-	}
-
-}
-
-func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexConfiguration, pipeline string) func(input parsedPattern) *Decision {
-
-	return func(input parsedPattern) *Decision {
-
-		if input.isPattern {
-
-			// At this point we should do not have any elastic indexes.
-			// This is because we have already checked if the pattern matches any elastic indexes.
-			for _, pattern := range input.parts {
-				for indexName := range r.elasticIndexes {
-					if util.IndexPatternMatches(pattern, indexName) {
-						return &Decision{
-							Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("index parsedPattern [%s] resolved to elasticsearch indices", input.parts)),
-							Reason: "We're not supporting common tables for Elastic.",
-						}
-					}
-				}
-			}
-
-			var matchedVirtualTables []string
-			var matchedTables []string
-			for _, pattern := range input.parts {
-
-				// here we check against the config
-
-				for indexName, index := range r.conf.IndexConfig {
-					if util.IndexPatternMatches(pattern, indexName) {
-
-						targets := getTargets(index, pipeline)
-
-						if slices.Contains(targets, config.ClickhouseTarget) {
-							if index.UseCommonTable {
-								matchedVirtualTables = append(matchedVirtualTables, indexName)
-							} else {
-								matchedTables = append(matchedTables, indexName)
-							}
-						}
-					}
-				}
-
-				// but maybe we should also check against the actual indexes ??
-				if r.conf.AutodiscoveryEnabled {
-					for indexName, index := range r.clickhouseIndexes {
-						if util.IndexPatternMatches(pattern, indexName) {
-							if index.isVirtual {
-								matchedVirtualTables = append(matchedVirtualTables, indexName)
-							} else {
-								matchedTables = append(matchedTables, indexName)
-							}
-						}
-					}
-				}
-			}
-
-			matchedTables = util.Distinct(matchedTables)
-			matchedVirtualTables = util.Distinct(matchedVirtualTables)
-
-			switch {
-
-			case len(matchedTables) == 0 && len(matchedVirtualTables) == 0:
-				return &Decision{
-					IsEmpty: true,
-					Reason:  "No indexes found.",
-				}
-
-			case len(matchedTables) == 1 && len(matchedVirtualTables) == 0:
-				return &Decision{
-					UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-						ClickhouseTableName: matchedTables[0],
-						ClickhouseTables:    []string{matchedTables[0]},
-					}},
-					Reason: "Pattern matches single standalone table.",
-				}
-
-			case len(matchedTables) == 0 && len(matchedVirtualTables) > 0:
-				return &Decision{
-					UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-						IsCommonTable:       true,
-						ClickhouseTableName: common_table.TableName,
-						ClickhouseTables:    matchedVirtualTables,
-					}},
-					Reason: "Common table will be used. Querying multiple indexes.",
-				}
-
-			default:
-				return &Decision{
-					Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("index pattern [%s] resolved to both standalone table indices: [%s] and common table indices: [%s]", input.source, matchedTables, matchedVirtualTables)),
-					Reason: "Both standalone table and common table indexes matches the pattern",
-				}
-			}
-		}
-
-		if input.source == common_table.TableName {
+	return func(part string) *Decision {
+		if part == common_table.TableName {
 			return &Decision{
 				Err:    fmt.Errorf("common table is not allowed to be queried directly"),
 				Reason: "It's internal table. Not allowed to be queried directly.",
@@ -450,18 +265,18 @@ func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexC
 
 		if r.conf.AutodiscoveryEnabled {
 			for indexName, index := range r.clickhouseIndexes {
-				if index.isVirtual && indexName == input.source {
+				if index.isVirtual && indexName == part {
 					virtualTableExists = true
 					break
 				}
 			}
 		}
 
-		if idxConfig, ok := cfg[input.source]; (ok && idxConfig.UseCommonTable) || (virtualTableExists) {
+		if idxConfig, ok := cfg[part]; (ok && idxConfig.UseCommonTable) || (virtualTableExists) {
 			return &Decision{
 				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
 					ClickhouseTableName: common_table.TableName,
-					ClickhouseTables:    []string{input.source},
+					ClickhouseTables:    []string{part},
 					IsCommonTable:       true,
 				}},
 				Reason: "Common table will be used.",

--- a/quesma/table_resolver/table_resolver.go
+++ b/quesma/table_resolver/table_resolver.go
@@ -11,7 +11,6 @@ import (
 	"quesma/quesma/config"
 	"quesma/quesma/recovery"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 )
@@ -30,36 +29,52 @@ type parsedPattern struct {
 	parts     []string
 }
 
+type patternSplitter struct {
+	name     string
+	resolver func(pattern string) (parsedPattern, *Decision)
+}
+
 type basicResolver struct {
 	name     string
 	resolver func(pattern parsedPattern) *Decision
 }
 
+type decisionMerger struct {
+	name   string
+	merger func(decisions []*Decision) *Decision
+}
+
 type compoundResolver struct {
-	decisionLadder []basicResolver
+	patternSplitter patternSplitter
+	decisionLadder  []basicResolver
+	decisionMerger  decisionMerger
 }
 
 func (ir *compoundResolver) resolve(indexName string) *Decision {
-	patterns := strings.Split(indexName, ",")
-
-	input := parsedPattern{
-		source:    indexName,
-		isPattern: len(patterns) > 1 || strings.Contains(indexName, "*"),
-		parts:     patterns,
+	input, decision := ir.patternSplitter.resolver(indexName)
+	if decision != nil {
+		decision.ResolverName = ir.patternSplitter.name
+		return decision
 	}
 
-	for _, resolver := range ir.decisionLadder {
-		decision := resolver.resolver(input)
+	var decisions []*Decision
+	for _, part := range input.parts {
+		for _, resolver := range ir.decisionLadder {
+			decision := resolver.resolver(parsedPattern{
+				source:    part,
+				isPattern: false,
+				parts:     []string{part},
+			})
 
-		if decision != nil {
-			decision.ResolverName = resolver.name
-			return decision
+			if decision != nil {
+				decision.ResolverName = resolver.name
+				decisions = append(decisions, decision)
+				break
+			}
 		}
 	}
-	return &Decision{
-		Reason: "Could not resolve pattern. This is a bug.",
-		Err:    fmt.Errorf("could not resolve index"), // TODO better error
-	}
+
+	return ir.decisionMerger.merger(decisions)
 }
 
 // HACK: we should have separate config for each pipeline
@@ -281,8 +296,11 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 		pipelineName: IngestPipeline,
 
 		resolver: &compoundResolver{
+			patternSplitter: patternSplitter{
+				name:     "singleIndexSplitter",
+				resolver: singleIndexSplitter,
+			},
 			decisionLadder: []basicResolver{
-				{"patternIsNotAllowed", patternIsNotAllowed},
 				{"kibanaInternal", resolveInternalElasticName},
 				{"disabled", makeIsDisabledInConfig(indexConf, IngestPipeline)},
 
@@ -290,6 +308,10 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 				{"commonTable", res.makeCommonTableResolver(indexConf, IngestPipeline)},
 
 				{"defaultWildcard", makeDefaultWildcard(quesmaConf, IngestPipeline)},
+			},
+			decisionMerger: decisionMerger{
+				name:   "basicDecisionMerger",
+				merger: basicDecisionMerger,
 			},
 		},
 		recentDecisions: make(map[string]*Decision),
@@ -301,6 +323,10 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 		pipelineName: QueryPipeline,
 
 		resolver: &compoundResolver{
+			patternSplitter: patternSplitter{
+				name:     "legacyPatternSplitter",
+				resolver: res.legacyPatternSplitter(QueryPipeline),
+			},
 			decisionLadder: []basicResolver{
 				// checking if we can handle the parsedPattern
 				{"kibanaInternal", resolveInternalElasticName},
@@ -312,6 +338,10 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 
 				// default action
 				{"defaultWildcard", makeDefaultWildcard(quesmaConf, QueryPipeline)},
+			},
+			decisionMerger: decisionMerger{
+				name:   "basicDecisionMerger",
+				merger: basicDecisionMerger,
 			},
 		},
 		recentDecisions: make(map[string]*Decision),

--- a/quesma/table_resolver/table_resolver.go
+++ b/quesma/table_resolver/table_resolver.go
@@ -44,6 +44,10 @@ type decisionMerger struct {
 	merger func(decisions []*Decision) *Decision
 }
 
+// Compound resolver works in the following way:
+// 1. patternSplitter splits a pattern, for example: logs* into concrete single indexes (e.g. logs1, logs2)
+// 2. decisionLadder rules are evaluated on each index separately, resulting in a decision for each index
+// 3. decisionMerger merges those decisions, making sure that the decisions are compatible. It yields a single decision.
 type compoundResolver struct {
 	patternSplitter patternSplitter
 	decisionLadder  []basicResolver
@@ -320,8 +324,8 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 
 		resolver: &compoundResolver{
 			patternSplitter: patternSplitter{
-				name:     "legacyPatternSplitter",
-				resolver: res.legacyPatternSplitter(QueryPipeline),
+				name:     "wildcardPatternSplitter",
+				resolver: res.wildcardPatternSplitter,
 			},
 			decisionLadder: []basicResolver{
 				// checking if we can handle the parsedPattern

--- a/quesma/table_resolver/table_resolver.go
+++ b/quesma/table_resolver/table_resolver.go
@@ -36,7 +36,7 @@ type patternSplitter struct {
 
 type basicResolver struct {
 	name     string
-	resolver func(pattern parsedPattern) *Decision
+	resolver func(part string) *Decision
 }
 
 type decisionMerger struct {
@@ -60,11 +60,7 @@ func (ir *compoundResolver) resolve(indexName string) *Decision {
 	var decisions []*Decision
 	for _, part := range input.parts {
 		for _, resolver := range ir.decisionLadder {
-			decision := resolver.resolver(parsedPattern{
-				source:    part,
-				isPattern: false,
-				parts:     []string{part},
-			})
+			decision := resolver.resolver(part)
 
 			if decision != nil {
 				decision.ResolverName = resolver.name
@@ -330,7 +326,6 @@ func NewTableResolver(quesmaConf config.QuesmaConfiguration, discovery clickhous
 			decisionLadder: []basicResolver{
 				// checking if we can handle the parsedPattern
 				{"kibanaInternal", resolveInternalElasticName},
-				{"searchAcrossConnectors", res.makeCheckIfPatternMatchesAllConnectors(QueryPipeline)},
 				{"disabled", makeIsDisabledInConfig(indexConf, QueryPipeline)},
 
 				{"singleIndex", res.singleIndex(indexConf, QueryPipeline)},

--- a/quesma/table_resolver/table_resolver_test.go
+++ b/quesma/table_resolver/table_resolver_test.go
@@ -9,7 +9,6 @@ import (
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/elasticsearch"
-	"quesma/end_user_errors"
 	"quesma/quesma/config"
 	"reflect"
 	"strings"
@@ -81,7 +80,7 @@ func TestTableResolver(t *testing.T) {
 			pipeline: QueryPipeline,
 			pattern:  "*",
 			expected: Decision{
-				Err: end_user_errors.ErrSearchCondition.New(fmt.Errorf("")),
+				Err: fmt.Errorf("inconsistent A/B testing configuration"),
 			},
 			indexConf: indexConf,
 		},
@@ -91,7 +90,7 @@ func TestTableResolver(t *testing.T) {
 			pattern:           "*",
 			clickhouseIndexes: []string{"index1", "index2"},
 			expected: Decision{
-				Err: end_user_errors.ErrSearchCondition.New(fmt.Errorf("")),
+				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
@@ -102,7 +101,7 @@ func TestTableResolver(t *testing.T) {
 			clickhouseIndexes: []string{"index1", "index2"},
 			elasticIndexes:    []string{"index3"},
 			expected: Decision{
-				Err: end_user_errors.ErrSearchCondition.New(fmt.Errorf("")),
+				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
@@ -217,7 +216,7 @@ func TestTableResolver(t *testing.T) {
 			pattern:        "index1,index2",
 			elasticIndexes: []string{"index3"},
 			expected: Decision{
-				Err: end_user_errors.ErrSearchCondition.New(fmt.Errorf("")),
+				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
@@ -227,11 +226,7 @@ func TestTableResolver(t *testing.T) {
 			pattern:        "index1,index-not-existing",
 			elasticIndexes: []string{"index1,index-not-existing"},
 			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-					ClickhouseTableName: "index1",
-					ClickhouseTables:    []string{"index1"},
-					IsCommonTable:       false,
-				}},
+				Err: fmt.Errorf(""), // index1 in Clickhouse, index-not-existing in Elastic ('*')
 			},
 			indexConf: indexConf,
 		},
@@ -260,20 +255,6 @@ func TestTableResolver(t *testing.T) {
 			name:          "query pattern",
 			pipeline:      QueryPipeline,
 			pattern:       "index2,foo*",
-			virtualTables: []string{"index2"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
-					ClickhouseTableName: common_table.TableName,
-					ClickhouseTables:    []string{"index2"},
-					IsCommonTable:       true,
-				}},
-			},
-			indexConf: indexConf,
-		},
-		{
-			name:          "query pattern",
-			pipeline:      QueryPipeline,
-			pattern:       "indexa,index2",
 			virtualTables: []string{"index2"},
 			expected: Decision{
 				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
@@ -360,7 +341,7 @@ func TestTableResolver(t *testing.T) {
 			clickhouseIndexes: []string{"index1"},
 			elasticIndexes:    []string{"logs"},
 			expected: Decision{
-				Err: end_user_errors.ErrSearchCondition.New(fmt.Errorf("")),
+				Err: fmt.Errorf(""),
 			},
 		},
 		{
@@ -393,12 +374,8 @@ func TestTableResolver(t *testing.T) {
 		},
 	}
 
-	for i, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if i == 24 {
-				t.Skip("bug: A/B testing doesn't work with patterns")
-			}
-
 			tableDiscovery := clickhouse.NewEmptyTableDiscovery()
 
 			for _, index := range tt.clickhouseIndexes {

--- a/quesma/table_resolver/table_resolver_test.go
+++ b/quesma/table_resolver/table_resolver_test.go
@@ -339,6 +339,20 @@ func TestTableResolver(t *testing.T) {
 			indexConf: indexConf,
 		},
 		{
+			name:     "A/B testing (pattern)",
+			pipeline: QueryPipeline,
+			pattern:  "logs*",
+			expected: Decision{
+				EnableABTesting: true,
+				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+					ClickhouseTableName: "logs",
+					ClickhouseTables:    []string{"logs"},
+				},
+					&ConnectorDecisionElastic{}},
+			},
+			indexConf: indexConf,
+		},
+		{
 			name:              "query both connectors",
 			pipeline:          QueryPipeline,
 			pattern:           "logs,index1",
@@ -379,8 +393,11 @@ func TestTableResolver(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if i == 24 {
+				t.Skip("bug: A/B testing doesn't work with patterns")
+			}
 
 			tableDiscovery := clickhouse.NewEmptyTableDiscovery()
 


### PR DESCRIPTION
This PR changes the way patterns (wildcards such as `logs*`) are handled by `table_resolver`. 

Previously, many `table_resolver` rules had two code paths - one code path for a single index (e.g. `logs1`) and one code path for patterns (e.g. `logs1,logs2` or `logs*`), making those rules more complicated. Moreover, one rule `makeCheckIfPatternMatchesAllConnectors` was the primary one to handle patterns and it contained fragments of other rules.

This PR introduces `patternSplitter`, `decisionMerger`. The `table_resolver` now works like this:
1. `patternSplitter` splits a pattern (e.g. `logs*`) into concrete single indexes (e.g. `logs1`, `logs2`)
2. Existing rules are evaluated on each single index separately
3. `decisionMerger` merges decisions of single indexes, making sure that the decisions are compatible. It yields a single decision.