### PR TITLE
Fix login to admin console on Safari

### DIFF
--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -264,6 +264,12 @@ var authKey = securecookie.GenerateRandomKey(64)
 var encryptionKey = securecookie.GenerateRandomKey(32)
 var store = sessions.NewCookieStore(authKey, encryptionKey)
 
+func init() { // Safari does not allow Secure cookies on localhost
+	store.Options = &sessions.Options{
+		Secure: false,
+	}
+}
+
 func authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !isAlreadyAuthenticated(r) {


### PR DESCRIPTION
Our Set-cookie was pretty legit:
```
quesma-session=...blah...; Path=/; Expires=Thu, 28 Nov 2024 20:59:59 GMT; Max-Age=2592000; Secure; SameSite=None
```
yet it was enigmatically rejected by Safari. Took me while but it turns out that for `localhost` Safari does not allow `Secure` cookie 😕 

So now, `Set-Cookie` will be just `quesma-session=...blah...`. I think for this admin interface it's just fine - at least for now, when we don't really allow custom domains, ssl, etc. 

