### PR TITLE
Adding table sanity check

### DIFF
--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -672,6 +672,9 @@ func (ip *IngestProcessor) processInsertQuery(ctx context.Context,
 	} else if !table.Created {
 		createTableCmd = table.CreateTableString()
 	}
+	if table == nil {
+		return nil, fmt.Errorf("table %s not found", tableName)
+	}
 	tableConfig = table.Config
 	var jsonsReadyForInsertion []string
 	var alterCmd []string


### PR DESCRIPTION
This PR adds a sanity check and fixes crash. I plan to work on root cause of the problem is next PR

```
Oct 30 14:15:34.699 INF quesma/functionality/bulk/bulk.go:339 > Ingesting via _bulk API, batch size=6 documents
Oct 30 14:15:35.882 ERR quesma/recovery/recovery_strategies.go:32 > Panic recovered: runtime error: invalid memory address or nil pointer dereference
goroutine 155 [running]:
runtime/debug.Stack()
        /Users/pdelewski/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
quesma/quesma/recovery.commonRecovery({0x102e930a0, 0x103359030}, 0x1400033a380?)
        /Users/pdelewski/Projects/quesma/quesma/quesma/recovery/recovery_strategies.go:32 +0x154
quesma/quesma/recovery.LogPanic()
        /Users/pdelewski/Projects/quesma/quesma/quesma/recovery/recovery_strategies.go:37 +0x34
panic({0x102e930a0?, 0x103359030?})
        /Users/pdelewski/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.darwin-arm64/src/runtime/panic.go:785 +0x124
quesma/ingest.(*IngestProcessor).processInsertQuery(0x140001521b0, {0x102f6ff78, 0x14000706a20}, {0x1400076afd4, 0x26}, {0x14000693830, 0x2, 0x1?}, {0x102f69aa0, 0x1400022e228}, ...)
        /Users/pdelewski/Projects/quesma/quesma/ingest/processor.go:675 +0x31c
quesma/ingest.(*IngestProcessor).processInsertQueryInternal(0x140001521b0, {0x102f6ff78, 0x14000706a20}, {0x1400076afd4?, 0x26?}, {0x14000693830?, 0x10?, 0xa?}, {0x102f69aa0?, 0x1400022e228?}, ...)
        /Users/pdelewski/Projects/quesma/quesma/ingest/processor.go:779 +0x48

```