### PR TITLE
Add "ClickHouse engine" limitation

### DIFF
--- a/docs/public/docs/limitations.md
+++ b/docs/public/docs/limitations.md
@@ -14,8 +14,13 @@ Quesma has been tested with the following software versions:
 | Docker                           | `24.0.7`        | 
 | Elasticsearch/Kibana             | `8.11.1`        |
 | ClickHouse                       | `24.1`, `23.12` |
+| ClickHouse Cloud                 | `24.5`          |
 | OpenSearch/OpenSearch Dashboards | `2.12.0`        |
 | Hydrolix                         | `v4.8.12`       |
+
+### ClickHouse limitations
+* When using a cluster deployment of ClickHouse, the tables automatically created by Quesma (during [Ingest](/ingest.md)) will use the `MergeTree` engine. If you wish to use the `ReplicatedMergeTree` engine instead, you will have to create the tables manually with  `ReplicatedMergeTree` engine before ingesting data to Quesma.
+  * *Note: On ClickHouse Cloud, the tables automatically created by Quesma will use the `ReplicatedMergeTree` engine (ClickHouse Cloud default engine).* 
 
 ## Functional limitations
 Currently supported:


### PR DESCRIPTION
Currently Quesma auto-creates tables with `MergeTree` engine. It's automatically converted to `ReplicatedMergeTree` in case of ClickHouse Cloud, but not in case of a local multi-node cluster and the user can't control it.

If the user has a local multi-node cluster, the tables automatically created by Quesma won't be replicated - the only solution is to create them manually with the correct `ReplicatedMergeTree` engine.

Refs #934