### PR TITLE
Target config extended configuration

### DIFF
--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -575,9 +575,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 					}
-					if _, exists := target.properties["useCommonTable"]; exists {
-						conf.CreateCommonTable = true
-						conf.UseCommonTableForWildcard = true
+					if val, exists := target.properties["useCommonTable"]; exists {
+						conf.CreateCommonTable = val == "true"
+						conf.UseCommonTableForWildcard = val == "true"
 					}
 				}
 			}
@@ -622,8 +622,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 						} else {
 							errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
 						}
-						if _, exists := target.properties["useCommonTable"]; exists {
-							processedConfig.UseCommonTable = true
+						if val, exists := target.properties["useCommonTable"]; exists {
+							processedConfig.UseCommonTable = val == "true"
 						}
 					}
 				}
@@ -691,9 +691,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
-				if _, exists := target.properties["useCommonTable"]; exists {
-					conf.CreateCommonTable = true
-					conf.UseCommonTableForWildcard = true
+				if val, exists := target.properties["useCommonTable"]; exists {
+					conf.CreateCommonTable = val == "true"
+					conf.UseCommonTableForWildcard = val == "true"
 				}
 			}
 		}
@@ -728,9 +728,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
-				if _, exists := target.properties["useCommonTable"]; exists {
-					conf.CreateCommonTable = true
-					conf.UseCommonTableForWildcard = true
+				if val, exists := target.properties["useCommonTable"]; exists {
+					conf.CreateCommonTable = val == "true"
+					conf.UseCommonTableForWildcard = val == "true"
 				}
 			}
 		}
@@ -784,8 +784,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
 					}
-					if _, exists := target.properties["useCommonTable"]; exists {
-						processedConfig.UseCommonTable = true
+					if val, exists := target.properties["useCommonTable"]; exists {
+						processedConfig.UseCommonTable = val == true
 					}
 				}
 			}
@@ -844,8 +844,8 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
 					}
-					if _, exists := target.properties["useCommonTable"]; exists {
-						processedConfig.UseCommonTable = true
+					if val, exists := target.properties["useCommonTable"]; exists {
+						processedConfig.UseCommonTable = val == true
 					}
 				}
 			}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -622,6 +622,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 						} else {
 							errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
 						}
+						if _, exists := target.properties["useCommonTable"]; exists {
+							processedConfig.UseCommonTable = true
+						}
 					}
 				}
 				// fallback to old style, simplified target configuration
@@ -781,6 +784,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
 					}
+					if _, exists := target.properties["useCommonTable"]; exists {
+						processedConfig.UseCommonTable = true
+					}
 				}
 			}
 			// fallback to old style, simplified target configuration
@@ -837,6 +843,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 						processedConfig.IngestTarget = append(processedConfig.IngestTarget, targetType)
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
+					}
+					if _, exists := target.properties["useCommonTable"]; exists {
+						processedConfig.UseCommonTable = true
 					}
 				}
 			}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -391,6 +391,13 @@ func (c *QuesmaNewConfiguration) validateProcessor(p Processor) error {
 			}
 			targets := c.getTargetsExtendedConfig(indexConfig.Target)
 			// fallback to old style, simplified target configuration
+			if len(targets) > 0 {
+				for _, target := range targets {
+					if c.getBackendConnectorByName(target.target) == nil {
+						return fmt.Errorf("invalid target %s in configuration of index %s", target, indexName)
+					}
+				}
+			}
 			if len(targets) == 0 {
 				if _, ok := indexConfig.Target.([]interface{}); ok {
 					for _, target := range indexConfig.Target.([]interface{}) {
@@ -555,6 +562,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			// Handle default index configuration
 			defaultConfig := queryProcessor.Config.IndexConfig[DefaultWildcardIndexName]
 			targets := c.getTargetsExtendedConfig(defaultConfig.Target)
+			if len(targets) > 0 {
+				for _, target := range targets {
+					if targetType, found := c.getTargetType(target.target); found {
+						defaultConfig.QueryTarget = append(defaultConfig.QueryTarget, targetType)
+					} else {
+						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
+					}
+				}
+			}
 			// fallback to old style, simplified target configuration
 			if len(targets) == 0 {
 				if _, ok := defaultConfig.Target.([]interface{}); ok {
@@ -586,6 +602,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				processedConfig := indexConfig
 				processedConfig.Name = indexName
 				targets := c.getTargetsExtendedConfig(indexConfig.Target)
+				if len(targets) > 0 {
+					for _, target := range targets {
+						if targetType, found := c.getTargetType(target.target); found {
+							processedConfig.QueryTarget = append(processedConfig.QueryTarget, targetType)
+						} else {
+							errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
+						}
+					}
+				}
 				// fallback to old style, simplified target configuration
 				if len(targets) == 0 {
 					if _, ok := indexConfig.Target.([]interface{}); ok {
@@ -640,6 +665,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		// Handle default index configuration
 		defaultConfig := queryProcessor.Config.IndexConfig[DefaultWildcardIndexName]
 		targets := c.getTargetsExtendedConfig(defaultConfig.Target)
+		if len(targets) > 0 {
+			for _, target := range targets {
+				if targetType, found := c.getTargetType(target.target); found {
+					defaultConfig.QueryTarget = append(defaultConfig.QueryTarget, targetType)
+				} else {
+					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
+				}
+			}
+		}
 		// fallback to old style, simplified target configuration
 		if len(targets) == 0 {
 			if _, ok := defaultConfig.Target.([]interface{}); ok {
@@ -661,6 +695,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 		ingestProcessorDefaultIndexConfig := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]
 		targets = c.getTargetsExtendedConfig(ingestProcessorDefaultIndexConfig.Target)
+		if len(targets) > 0 {
+			for _, target := range targets {
+				if targetType, found := c.getTargetType(target.target); found {
+					defaultConfig.IngestTarget = append(defaultConfig.IngestTarget, targetType)
+				} else {
+					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
+				}
+			}
+		}
 		// fallback to old style, simplified target configuration
 		if len(targets) == 0 {
 			if _, ok := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName].Target.([]interface{}); ok {
@@ -701,6 +744,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 			processedConfig.IngestTarget = defaultConfig.IngestTarget
 			targets = c.getTargetsExtendedConfig(indexConfig.Target)
+			if len(targets) > 0 {
+				for _, target := range targets {
+					if targetType, found := c.getTargetType(target.target); found {
+						processedConfig.QueryTarget = append(processedConfig.QueryTarget, targetType)
+					} else {
+						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
+					}
+				}
+			}
 			// fallback to old style, simplified target configuration
 			if len(targets) == 0 {
 				if _, ok := indexConfig.Target.([]interface{}); ok {
@@ -746,6 +798,15 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 			processedConfig.IngestTarget = make([]string, 0) // reset previously set defaultConfig.IngestTarget
 			targets = c.getTargetsExtendedConfig(indexConfig.Target)
+			if len(targets) > 0 {
+				for _, target := range targets {
+					if targetType, found := c.getTargetType(target.target); found {
+						processedConfig.IngestTarget = append(processedConfig.IngestTarget, targetType)
+					} else {
+						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of index %s", target, indexName))
+					}
+				}
+			}
 			// fallback to old style, simplified target configuration
 			if len(targets) == 0 {
 				if _, ok := indexConfig.Target.([]interface{}); ok {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -569,6 +569,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 					}
+					if useCommonTable, exists := target.properties["useCommonTable"]; exists {
+						fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
+					}
 				}
 			}
 			// fallback to old style, simplified target configuration
@@ -672,6 +675,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
+				if useCommonTable, exists := target.properties["useCommonTable"]; exists {
+					fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
+				}
 			}
 		}
 		// fallback to old style, simplified target configuration
@@ -701,6 +707,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					defaultConfig.IngestTarget = append(defaultConfig.IngestTarget, targetType)
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
+				}
+				if useCommonTable, exists := target.properties["useCommonTable"]; exists {
+					fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
 				}
 			}
 		}
@@ -940,16 +949,13 @@ func (c *QuesmaNewConfiguration) getTargetsExtendedConfig(target any) []struct {
 		for _, target := range targets {
 			if targetMap, ok := target.(map[string]interface{}); ok {
 				for name, settings := range targetMap {
-					fmt.Printf("Target: %s\n", name)
-					// Type assert `settings` to access UseCommonTable if available.
 					if settingsMap, ok := settings.(map[string]interface{}); ok {
-						if useCommonTable, exists := settingsMap["useCommonTable"]; exists {
-							fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
-						}
 						result = append(result, struct {
 							target     string
 							properties map[string]interface{}
 						}{target: name, properties: settingsMap})
+					} else {
+						// TODO return error
 					}
 				}
 			}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -575,8 +575,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					} else {
 						errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 					}
-					if useCommonTable, exists := target.properties["useCommonTable"]; exists {
-						fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
+					if _, exists := target.properties["useCommonTable"]; exists {
+						conf.CreateCommonTable = true
+						conf.UseCommonTableForWildcard = true
 					}
 				}
 			}
@@ -687,8 +688,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
-				if useCommonTable, exists := target.properties["useCommonTable"]; exists {
-					fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
+				if _, exists := target.properties["useCommonTable"]; exists {
+					conf.CreateCommonTable = true
+					conf.UseCommonTableForWildcard = true
 				}
 			}
 		}
@@ -723,8 +725,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				} else {
 					errAcc = multierror.Append(errAcc, fmt.Errorf("invalid target %s in configuration of %s", target, DefaultWildcardIndexName))
 				}
-				if useCommonTable, exists := target.properties["useCommonTable"]; exists {
-					fmt.Printf("  UseCommonTable: %v\n", useCommonTable)
+				if _, exists := target.properties["useCommonTable"]; exists {
+					conf.CreateCommonTable = true
+					conf.UseCommonTableForWildcard = true
 				}
 			}
 		}

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -238,16 +238,22 @@ func TestTargetNewVariant(t *testing.T) {
 	}
 	legacyConf := cfg.TranslateToLegacyConfig()
 	assert.False(t, legacyConf.TransparentProxy)
-	assert.Equal(t, 2, len(legacyConf.IndexConfig))
+	assert.Equal(t, 3, len(legacyConf.IndexConfig))
 	ecommerce := legacyConf.IndexConfig["kibana_sample_data_ecommerce"]
 	flights := legacyConf.IndexConfig["kibana_sample_data_flights"]
+	logs := legacyConf.IndexConfig["kibana_sample_data_logs"]
 
 	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.QueryTarget)
 	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.IngestTarget)
 
 	assert.Equal(t, []string{ClickhouseTarget}, flights.QueryTarget)
 	assert.Equal(t, []string{ClickhouseTarget}, flights.IngestTarget)
+
+	assert.Equal(t, []string{ClickhouseTarget}, logs.QueryTarget)
+	assert.Equal(t, []string{ClickhouseTarget}, logs.IngestTarget)
+
 	assert.Equal(t, false, flights.UseCommonTable)
-	assert.Equal(t, true, ecommerce.UseCommonTable)
+	assert.Equal(t, false, ecommerce.UseCommonTable)
+	assert.Equal(t, true, logs.UseCommonTable)
 	assert.Equal(t, true, legacyConf.EnableIngest)
 }

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -229,3 +229,25 @@ func TestMatchName(t *testing.T) {
 		})
 	}
 }
+
+func TestTargetNewVariant(t *testing.T) {
+	os.Setenv(configFileLocationEnvVar, "./test_configs/target_new_variant.yaml")
+	cfg := LoadV2Config()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("error validating config: %v", err)
+	}
+	legacyConf := cfg.TranslateToLegacyConfig()
+	assert.False(t, legacyConf.TransparentProxy)
+	assert.Equal(t, 2, len(legacyConf.IndexConfig))
+	ecommerce := legacyConf.IndexConfig["kibana_sample_data_ecommerce"]
+	flights := legacyConf.IndexConfig["kibana_sample_data_flights"]
+
+	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.QueryTarget)
+	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.IngestTarget)
+
+	assert.Equal(t, []string{ClickhouseTarget}, flights.QueryTarget)
+	assert.Equal(t, []string{ClickhouseTarget}, flights.IngestTarget)
+	assert.Equal(t, false, flights.UseCommonTable)
+	assert.Equal(t, true, ecommerce.UseCommonTable)
+	assert.Equal(t, true, legacyConf.EnableIngest)
+}

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -18,7 +18,8 @@ type IndexConfiguration struct {
 	Optimizers      map[string]OptimizerConfiguration `koanf:"optimizers"`
 	Override        string                            `koanf:"override"`
 	UseCommonTable  bool                              `koanf:"useCommonTable"`
-	Target          []string                          `koanf:"target"`
+	Target          any                               `koanf:"target"`
+	Target2         any                               `koanf:"target2"`
 
 	// Computed based on the overall configuration
 	Name         string

--- a/quesma/quesma/config/index_config.go
+++ b/quesma/quesma/config/index_config.go
@@ -19,7 +19,6 @@ type IndexConfiguration struct {
 	Override        string                            `koanf:"override"`
 	UseCommonTable  bool                              `koanf:"useCommonTable"`
 	Target          any                               `koanf:"target"`
-	Target2         any                               `koanf:"target2"`
 
 	// Computed based on the overall configuration
 	Name         string

--- a/quesma/quesma/config/test_configs/target_new_variant.yaml
+++ b/quesma/quesma/config/test_configs/target_new_variant.yaml
@@ -35,7 +35,7 @@ processors:
                 useCommonTable: false
         kibana_sample_data_flights:
           target:
-            - my-clickhouse-data-source: {}
+            - my-clickhouse-data-source
         kibana_sample_data_logs:
           target:
             - my-clickhouse-data-source:
@@ -53,7 +53,7 @@ processors:
                 useCommonTable: false
         kibana_sample_data_flights:
           target:
-            - my-clickhouse-data-source: {}
+            - my-clickhouse-data-source
         kibana_sample_data_logs:
           target:
             - my-clickhouse-data-source:

--- a/quesma/quesma/config/test_configs/target_new_variant.yaml
+++ b/quesma/quesma/config/test_configs/target_new_variant.yaml
@@ -1,0 +1,63 @@
+# TEST CONFIGURATION
+licenseKey: "cdd749a3-e777-11ee-bcf8-0242ac150004"
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: my-minimal-elasticsearch
+    type: elasticsearch
+    config:
+      url: "http://localhost:9200"
+  - name: my-clickhouse-data-source
+    type: clickhouse-os
+    config:
+      url: "clickhouse://localhost:9000"
+ingestStatistics: true
+internalTelemetryUrl: "https://api.quesma.com/phone-home"
+logging:
+  remoteUrl: "https://api.quesma.com/phone-home"
+  path: "logs"
+  level: "info"
+processors:
+  - name: my-query-processor
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        kibana_sample_data_ecommerce:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: true
+        kibana_sample_data_flights:
+          target:
+            - my-clickhouse-data-source: {}
+        "*":
+          target: [ my-minimal-elasticsearch ]
+
+  - name: my-ingest-processor
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        kibana_sample_data_ecommerce:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: true
+        kibana_sample_data_flights:
+          target:
+            - my-clickhouse-data-source: {}
+        "*":
+          target: [ my-minimal-elasticsearch ]
+pipelines:
+  - name: my-pipeline-elasticsearch-query-clickhouse
+    frontendConnectors: [ elastic-query ]
+    processors: [ my-query-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]
+  - name: my-pipeline-elasticsearch-ingest-to-clickhouse
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ my-ingest-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]

--- a/quesma/quesma/config/test_configs/target_new_variant.yaml
+++ b/quesma/quesma/config/test_configs/target_new_variant.yaml
@@ -32,10 +32,14 @@ processors:
         kibana_sample_data_ecommerce:
           target:
             - my-clickhouse-data-source:
-                useCommonTable: true
+                useCommonTable: false
         kibana_sample_data_flights:
           target:
             - my-clickhouse-data-source: {}
+        kibana_sample_data_logs:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: true
         "*":
           target: [ my-minimal-elasticsearch ]
 
@@ -46,10 +50,14 @@ processors:
         kibana_sample_data_ecommerce:
           target:
             - my-clickhouse-data-source:
-                useCommonTable: true
+                useCommonTable: false
         kibana_sample_data_flights:
           target:
             - my-clickhouse-data-source: {}
+        kibana_sample_data_logs:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: true
         "*":
           target: [ my-minimal-elasticsearch ]
 pipelines:


### PR DESCRIPTION
This PR implements new variant of `target` configuration where it's a list not an array and can have more attributes (potentially in the future)

Current variant is still supported and is a fallback in the case extended version is missing

Below
```
  kibana_sample_data_flights:
    target:
    - my-clickhouse-data-source:
        useCommonTable: true
```
is equivalent of 
```
  kibana_sample_data_flights:
    target: [my-clickhouse-data-source]
    useCommonTable: true
```

PR contains a bit of duplicated code, something that I would prefer fix in next PR. 
