### PR TITLE
Adding global useCommonTable property

### DIFF
--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -528,11 +528,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		conf.Logging.RemoteLogDrainUrl = nil
 	}
 
-	if !c.UseCommonTable {
-		conf.CreateCommonTable = false
-	} else {
-		conf.CreateCommonTable = c.UseCommonTable
-	}
+	conf.CreateCommonTable = c.UseCommonTable
 
 	conf.InstallationId = c.InstallationId
 	conf.LicenseKey = c.LicenseKey

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -48,6 +48,7 @@ type QuesmaNewConfiguration struct {
 	Processors         []Processor          `koanf:"processors"`
 	Pipelines          []Pipeline           `koanf:"pipelines"`
 	DisableTelemetry   bool                 `koanf:"disableTelemetry"`
+	UseCommonTable     bool                 `koanf:"useCommonTable"` // global setting
 }
 
 type LoggingConfiguration struct {
@@ -527,6 +528,12 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		conf.Logging.RemoteLogDrainUrl = nil
 	}
 
+	if !c.UseCommonTable {
+		conf.CreateCommonTable = false
+	} else {
+		conf.CreateCommonTable = c.UseCommonTable
+	}
+
 	conf.InstallationId = c.InstallationId
 	conf.LicenseKey = c.LicenseKey
 
@@ -565,6 +572,10 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				if val, exists := target.properties["useCommonTable"]; exists {
 					conf.CreateCommonTable = val == "true"
 					conf.UseCommonTableForWildcard = val == "true"
+				} else {
+					// inherit global setting
+					conf.CreateCommonTable = c.UseCommonTable
+					conf.UseCommonTableForWildcard = c.UseCommonTable
 				}
 			}
 
@@ -597,6 +608,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 					}
 					if val, exists := target.properties["useCommonTable"]; exists {
 						processedConfig.UseCommonTable = val == "true"
+					} else {
+						// inherit global setting
+						processedConfig.UseCommonTable = c.UseCommonTable
 					}
 					if val, exists := target.properties["tableName"]; exists {
 						processedConfig.Override = val.(string)
@@ -657,6 +671,10 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			if val, exists := target.properties["useCommonTable"]; exists {
 				conf.CreateCommonTable = val == "true"
 				conf.UseCommonTableForWildcard = val == "true"
+			} else {
+				// inherit global setting
+				conf.CreateCommonTable = c.UseCommonTable
+				conf.UseCommonTableForWildcard = c.UseCommonTable
 			}
 		}
 		if defaultConfig.UseCommonTable {
@@ -680,6 +698,10 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			if val, exists := target.properties["useCommonTable"]; exists {
 				conf.CreateCommonTable = val == "true"
 				conf.UseCommonTableForWildcard = val == "true"
+			} else {
+				// inherit global setting
+				conf.CreateCommonTable = c.UseCommonTable
+				conf.UseCommonTableForWildcard = c.UseCommonTable
 			}
 		}
 		if ingestProcessorDefaultIndexConfig.UseCommonTable {
@@ -721,6 +743,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				}
 				if val, exists := target.properties["useCommonTable"]; exists {
 					processedConfig.UseCommonTable = val == true
+				} else {
+					// inherit global setting
+					processedConfig.UseCommonTable = c.UseCommonTable
 				}
 				if val, exists := target.properties["tableName"]; exists {
 					processedConfig.Override = val.(string)
@@ -770,6 +795,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 				}
 				if val, exists := target.properties["useCommonTable"]; exists {
 					processedConfig.UseCommonTable = val == true
+				} else {
+					// inherit global setting
+					processedConfig.UseCommonTable = c.UseCommonTable
 				}
 				if val, exists := target.properties["tableName"]; exists {
 					processedConfig.Override = val.(string)

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -267,3 +267,25 @@ func TestTargetNewVariant(t *testing.T) {
 	const expectedOverride = "new_override"
 	assert.Equal(t, expectedOverride, override.Override)
 }
+
+func TestUseCommonTableGlobalProperty(t *testing.T) {
+	os.Setenv(configFileLocationEnvVar, "./test_configs/use_common_table_global_property.yaml")
+	cfg := LoadV2Config()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("error validating config: %v", err)
+	}
+	legacyConf := cfg.TranslateToLegacyConfig()
+	assert.False(t, legacyConf.TransparentProxy)
+	assert.Equal(t, 2, len(legacyConf.IndexConfig))
+	ecommerce := legacyConf.IndexConfig["kibana_sample_data_ecommerce"]
+	flights := legacyConf.IndexConfig["kibana_sample_data_flights"]
+
+	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.QueryTarget)
+	assert.Equal(t, []string{ClickhouseTarget}, ecommerce.IngestTarget)
+
+	assert.Equal(t, []string{ClickhouseTarget}, flights.QueryTarget)
+	assert.Equal(t, []string{ClickhouseTarget}, flights.IngestTarget)
+
+	assert.Equal(t, true, flights.UseCommonTable)
+	assert.Equal(t, false, ecommerce.UseCommonTable)
+}

--- a/quesma/quesma/config/test_configs/has_common_table.yaml
+++ b/quesma/quesma/config/test_configs/has_common_table.yaml
@@ -32,11 +32,11 @@ processors:
         logs-3:
           target: [ C, E ]
         logs-4:
-          useCommonTable: true
-          target: [ C ]
+          target:
+            - C:
+                useCommonTable: true
         logs-5:
-          useCommonTable: true
-          target: [ C ]
+          target:
         "*":
           target: [ E ]
 
@@ -51,13 +51,13 @@ processors:
         logs-3:
           target: [ C, E ]
         logs-4:
-          useCommonTable: true
-          target: [ C ]
+          target:
+            - C:
+                useCommonTable: true
         "*":
           target: [ E ]
         logs-5:
-          useCommonTable: true
-          target: [  ]
+          target:
 
 pipelines:
   - name: my-elasticsearch-proxy-read

--- a/quesma/quesma/config/test_configs/use_common_table_global_property.yaml
+++ b/quesma/quesma/config/test_configs/use_common_table_global_property.yaml
@@ -1,0 +1,64 @@
+# TEST CONFIGURATION
+licenseKey: "cdd749a3-e777-11ee-bcf8-0242ac150004"
+useCommonTable: true
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: my-minimal-elasticsearch
+    type: elasticsearch
+    config:
+      url: "http://localhost:9200"
+  - name: my-clickhouse-data-source
+    type: clickhouse-os
+    config:
+      url: "clickhouse://localhost:9000"
+ingestStatistics: true
+internalTelemetryUrl: "https://api.quesma.com/phone-home"
+logging:
+  remoteUrl: "https://api.quesma.com/phone-home"
+  path: "logs"
+  level: "info"
+processors:
+  - name: my-query-processor
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+        kibana_sample_data_ecommerce:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: false
+        kibana_sample_data_flights:
+          target:
+            - my-clickhouse-data-source
+        "*":
+          target: [ my-minimal-elasticsearch ]
+
+  - name: my-ingest-processor
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        kibana_sample_data_ecommerce:
+          target:
+            - my-clickhouse-data-source:
+                useCommonTable: false
+        kibana_sample_data_flights:
+          target:
+            - my-clickhouse-data-source
+        "*":
+          target: [ my-minimal-elasticsearch ]
+pipelines:
+  - name: my-pipeline-elasticsearch-query-clickhouse
+    frontendConnectors: [ elastic-query ]
+    processors: [ my-query-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]
+  - name: my-pipeline-elasticsearch-ingest-to-clickhouse
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ my-ingest-processor ]
+    backendConnectors: [ my-minimal-elasticsearch, my-clickhouse-data-source ]


### PR DESCRIPTION
This PR adds global `useCommonTable` flag. This flag will be inherited when it's missing in index configuration