### PR TITLE
Remove string specific array transfomer

### DIFF
--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -789,28 +789,3 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 	}
 	return queries, nil
 }
-
-// ArrayResultTransformer is a transformer that transforms array columns into string representation
-type ArrayResultTransformer struct {
-}
-
-func (g *ArrayResultTransformer) Transform(result [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {
-
-	for i, rows := range result {
-
-		for j, row := range rows {
-			for k, col := range row.Cols {
-
-				if ary, ok := col.Value.([]string); ok {
-					aryStr := make([]string, 0, len(ary))
-					for _, el := range ary {
-						aryStr = append(aryStr, fmt.Sprintf("%v", el))
-					}
-					result[i][j].Cols[k].Value = fmt.Sprintf("[%s]", strings.Join(aryStr, ","))
-				}
-			}
-		}
-
-	}
-	return result, nil
-}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -812,7 +812,6 @@ func (q *QueryRunner) postProcessResults(plan *model.ExecutionPlan, results [][]
 		transformer model.ResultTransformer
 	}{
 		{"replaceColumNamesWithFieldNames", &replaceColumNamesWithFieldNames{indexSchema: indexSchema}},
-		{"arrayResultTransformer", &ArrayResultTransformer{}},
 	}
 
 	var err error


### PR DESCRIPTION
We can remove that `string` specific transformer. We've got a generic solution already.


Before:

Clickhouse on the left. 

<img width="1051" alt="before" src="https://github.com/user-attachments/assets/e1846b40-51d8-47b3-ba89-b9873ef1738a">

<img width="1673" alt="dashboard-before" src="https://github.com/user-attachments/assets/00108e56-f82b-469d-a201-4aea1caf742b">


After:

Clickhouse on the left. 
<img width="909" alt="after" src="https://github.com/user-attachments/assets/afa766ec-8b08-4b32-a69c-07790101a18e">
<img width="1660" alt="dashboard-after" src="https://github.com/user-attachments/assets/1ebd6e66-77b2-48bb-b7b6-99a383f70a79">


