### PR TITLE
Stop flickering of top errors

### DIFF
--- a/quesma/stats/errorstats/error_statistics.go
+++ b/quesma/stats/errorstats/error_statistics.go
@@ -107,7 +107,12 @@ func (e *ErrorStatisticsStore) ReturnTopErrors(count int) []ErrorStatistics {
 
 	// Sort by count
 	sort.Slice(errorStatistics, func(i, j int) bool {
-		return errorStatistics[i].Count > errorStatistics[j].Count
+		if errorStatistics[i].Count == errorStatistics[j].Count {
+			// We need stable ordering if we have exact match on count
+			return errorStatistics[i].Reason < errorStatistics[j].Reason
+		} else {
+			return errorStatistics[i].Count > errorStatistics[j].Count
+		}
 	})
 
 	// Return top 5


### PR DESCRIPTION
Problem, our dashboard flickers due to undefined order if count is exact:
https://github.com/user-attachments/assets/6b1e5ba3-d219-4b21-b527-adac006dabb6

It looks poorly on demos.
