### PR TITLE
Change `<@channel>` to `<!channel>`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: ":exclamation: *Integration tests failed.* :exclamation: <@channel>\n*Last commit by:* ${{ steps.get_author.outputs.author }}\n*Workflow run URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            text: ":exclamation: *Integration tests failed.* :exclamation: <!channel>\n*Last commit by:* ${{ steps.get_author.outputs.author }}\n*Workflow run URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Send Slack notification on success
         if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
A small fix after 7b55f0df6462fdce615a6c81040c9cb50d5e5ec5:

I followed the syntax in the `slack-github-action@v2.0.0` changelog (`<@channel>`), but it's not actually mentioning the `@channel` group. Bring back the old syntax `<!channel>` which should work correctly.