### PR TITLE
Always return decision in `findHandler`

### DIFF
--- a/quesma/quesma/mux/mux.go
+++ b/quesma/quesma/mux/mux.go
@@ -105,9 +105,9 @@ func (p *PathRouter) findHandler(req *Request) (handler Handler, decision *table
 		if pathData, pathMatches := m.compiledPath.Match(path); pathMatches {
 			req.Params = pathData.Params
 			predicateResult := m.predicate.Matches(req)
+			decision = predicateResult.Decision
 			if predicateResult.Matched {
 				handler = m.handler
-				decision = predicateResult.Decision
 			}
 		}
 	}


### PR DESCRIPTION
d36b617 changed the logic in `findHandler` when it comes to returning decision: after d36b617, the decision is only filled out if the predicate matched (otherwise it's `nil`).

Previously, the decision would be returned in both scenarios: if predicate matched or if predicate did not match.

d36b617 caused a regression in integration tests: if an index is closed in the configuration, the predicate does not match, but the code still needs a decision (with `IsClosed: true`) to be able to return a correct `index_closed_exception` response. Without a decision (`nil`) it wasn't able to return that expected response.