### PR TITLE
Move ingest transformer earlier in the process

### DIFF
--- a/ci/it/configs/quesma-ingest.yml.template
+++ b/ci/it/configs/quesma-ingest.yml.template
@@ -72,6 +72,26 @@ processors:
                 type: geo_point
               "OriginLocation":
                 type: geo_point
+        ignored_test:
+          target:
+            - my-clickhouse-instance
+          schemaOverrides:
+            fields:
+              "ignored_field1":
+                ignored: true
+              "ignored_field2":
+                ignored: true
+              "nested.ignored_field3":
+                ignored: true
+              "nested.ignored_field4":
+                ignored: true
+              "nested2.ignored_field5":
+                ignored: true
+              "nested2.ignored_field6":
+                ignored: true
+        nested_test:
+          target:
+            - my-clickhouse-instance
         "*":
           target:
             - my-minimal-elasticsearch
@@ -127,6 +147,26 @@ processors:
                 type: geo_point
               "OriginLocation":
                 type: geo_point
+        ignored_test:
+          target:
+            - my-clickhouse-instance
+          schemaOverrides:
+            fields:
+              "ignored_field1":
+                ignored: true
+              "ignored_field2":
+                ignored: true
+              "nested.ignored_field3":
+                ignored: true
+              "nested.ignored_field4":
+                ignored: true
+              "nested2.ignored_field5":
+                ignored: true
+              "nested2.ignored_field6":
+                ignored: true
+        nested_test:
+          target:
+            - my-clickhouse-instance
         "*":
           target:
             - my-minimal-elasticsearch

--- a/quesma/ingest/insert_test.go
+++ b/quesma/ingest/insert_test.go
@@ -171,9 +171,7 @@ func TestAutomaticTableCreationAtInsert(t *testing.T) {
 				t.Run("case insertTest["+strconv.Itoa(index1)+"], config["+strconv.Itoa(index2)+"], ingestProcessor["+strconv.Itoa(index3)+"]", func(t *testing.T) {
 					ip.ip.schemaRegistry = &schema.StaticRegistry{}
 					encodings := populateFieldEncodings([]types.JSON{types.MustJSON(tt.insertJson)}, tableName)
-					ignoredFields := ip.ip.getIgnoredFields(tableName)
-					columnsFromJson := JsonToColumns("", types.MustJSON(tt.insertJson), 1,
-						tableConfig, &columNameFormatter{separator: "::"}, ignoredFields)
+					columnsFromJson := JsonToColumns(types.MustJSON(tt.insertJson), tableConfig)
 					columnsFromSchema := SchemaToColumns(findSchemaPointer(ip.ip.schemaRegistry, tableName), &columNameFormatter{separator: "::"}, tableName, encodings)
 					columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema, encodings, tableName), Indexes(types.MustJSON(tt.insertJson)))
 					query := createTableQuery(tableName, columns, tableConfig)

--- a/quesma/ingest/processor_test.go
+++ b/quesma/ingest/processor_test.go
@@ -145,9 +145,7 @@ func TestAddTimestamp(t *testing.T) {
 	jsonData := types.MustJSON(`{"host.name":"hermes","message":"User password reset requested","service.name":"queue","severity":"info","source":"azure"}`)
 	encodings := populateFieldEncodings([]types.JSON{jsonData}, tableName)
 
-	ignoredFields := ip.getIgnoredFields(tableName)
-	columnsFromJson := JsonToColumns("", jsonData, 1,
-		tableConfig, nameFormatter, ignoredFields)
+	columnsFromJson := JsonToColumns(jsonData, tableConfig)
 
 	columnsFromSchema := SchemaToColumns(findSchemaPointer(ip.schemaRegistry, tableName), nameFormatter, tableName, encodings)
 	columns := columnsWithIndexes(columnsToString(columnsFromJson, columnsFromSchema, encodings, tableName), Indexes(jsonData))


### PR DESCRIPTION
Before this change, the ingest logic looked roughly like this:

1. Initial transformation of JSON ("pre ingest transformer", field encodings, ...)
2. Generating CH table schema based on JSON + config (for "CREATE TABLE" or "ALTER TABLE"s)
3. Transformation of JSON (transformer object: flattening map and removing ignored fields)
4. Executing SQL query with the JSON data (after both initial and second transformation)

The issue with this logic is that the transformation (step 3) removes ignored fields, but the step 2 operated on a JSON with those fields present.

Rather than introducing additional logic to step 2 to handle ignored fields, this PR takes another approach: it moves the step 3 before the step 2. This way the CREATE TABLE/ALTER TABLE statements don't take into account the ignored fields.

Moving the transformation earlier allowed for simplifying `JsonToColumns`. Added two new integration tests.