### PR TITLE
Remove `quesma/kibana`

### DIFF
--- a/quesma/model/bucket_aggregations/date_histogram.go
+++ b/quesma/model/bucket_aggregations/date_histogram.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"quesma/clickhouse"
-	"quesma/kibana"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/util"
@@ -154,7 +153,7 @@ func (query *DateHistogram) GenerateSQL() model.Expr {
 }
 
 func (query *DateHistogram) generateSQLForFixedInterval() model.Expr {
-	interval, err := kibana.ParseInterval(query.interval)
+	interval, err := util.ParseInterval(query.interval)
 	if err != nil {
 		logger.ErrorWithCtx(query.ctx).Msg(err.Error())
 	}
@@ -257,7 +256,7 @@ func (query *DateHistogram) SetMinDocCountToZero() {
 }
 
 func (query *DateHistogram) NewRowsTransformer() model.QueryRowsTransformer {
-	duration, err := kibana.ParseInterval(query.interval)
+	duration, err := util.ParseInterval(query.interval)
 	var differenceBetweenTwoNextKeys int64
 	if err == nil {
 		differenceBetweenTwoNextKeys = duration.Milliseconds()

--- a/quesma/queryparser/dates.go
+++ b/quesma/queryparser/dates.go
@@ -1,6 +1,7 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package kibana
+
+package queryparser
 
 import (
 	"context"

--- a/quesma/queryparser/dates_test.go
+++ b/quesma/queryparser/dates_test.go
@@ -1,6 +1,7 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package kibana
+
+package queryparser
 
 import (
 	"context"

--- a/quesma/queryparser/pancake_aggregation_parser_buckets.go
+++ b/quesma/queryparser/pancake_aggregation_parser_buckets.go
@@ -6,7 +6,6 @@ package queryparser
 import (
 	"fmt"
 	"quesma/clickhouse"
-	"quesma/kibana"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/model/bucket_aggregations"
@@ -82,7 +81,7 @@ func (cw *ClickhouseQueryTranslator) pancakeTryBucketAggregation(aggregation *pa
 		weAddedMissing := false
 		if missingRaw, exists := dateHistogram["missing"]; exists {
 			if missing, ok := missingRaw.(string); ok {
-				dateManager := kibana.NewDateManager(cw.Ctx)
+				dateManager := NewDateManager(cw.Ctx)
 				if missingExpr, parsingOk := dateManager.ParseDateUsualFormat(missing, dateTimeType); parsingOk {
 					field = model.NewFunction("COALESCE", field, missingExpr)
 					weAddedMissing = true

--- a/quesma/queryparser/query_parser.go
+++ b/quesma/queryparser/query_parser.go
@@ -1,5 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
+
 package queryparser
 
 import (
@@ -9,7 +10,6 @@ import (
 	"fmt"
 	"github.com/k0kubun/pp"
 	"quesma/clickhouse"
-	"quesma/kibana"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/model/bucket_aggregations"
@@ -804,7 +804,7 @@ func (cw *ClickhouseQueryTranslator) parseRange(queryMap QueryMap) model.SimpleQ
 			valueRaw := v.(QueryMap)[op]
 			value := sprint(valueRaw)
 			defaultValue := model.NewLiteral(value)
-			dateManager := kibana.NewDateManager(cw.Ctx)
+			dateManager := NewDateManager(cw.Ctx)
 
 			// Three stages:
 			// 1. dateManager.ParseDateUsualFormat

--- a/quesma/util/intervals.go
+++ b/quesma/util/intervals.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package kibana
+package util
 
 import (
 	"strconv"

--- a/quesma/util/intervals_test.go
+++ b/quesma/util/intervals_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package kibana
+package util
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
I noticed this module depends on `quesma/clickhouse`, which stroke me as little odd when I realized that this is just one util function and part of parsing (specifically date parsing) which naturally belongs there. 

Related: https://github.com/QuesmaOrg/quesma/issues/1017