### PR TITLE
Support auth against OpenSearch

### DIFF
--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -46,8 +46,8 @@ func (es *SimpleClient) RequestWithHeaders(ctx context.Context, method, endpoint
 
 func (es *SimpleClient) Authenticate(ctx context.Context, authHeader string) bool {
 	var authEndpoint string
-	// This is really sub-optimal and we should find a better way to set this systematically (config perhaps?)
-	// OTOH, since we have auth cache in place, this is not a big deal for how.
+	// This is really suboptimal, and we should find a better way to set this systematically (config perhaps?)
+	// OTOH, since we have auth cache in place, I am not concerned about this additional backend call - at least for the time being.
 	r, err := es.doRequest(ctx, "GET", "/", nil, http.Header{"Authorization": {authHeader}})
 	if err != nil {
 		logger.ErrorWithCtx(ctx).Msgf("error sending request: %v", err)

--- a/quesma/elasticsearch/client.go
+++ b/quesma/elasticsearch/client.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"quesma/logger"
 	"quesma/quesma/config"
-	"quesma/util"
 	"time"
 )
 
@@ -56,7 +55,7 @@ func (es *SimpleClient) Authenticate(ctx context.Context, authHeader string) boo
 	}
 	defer r.Body.Close()
 
-	if util.IsResponseFromElasticsearch(r) {
+	if isResponseFromElasticsearch(r) {
 		authEndpoint = elasticsearchSecurityEndpoint
 	} else {
 		authEndpoint = openSearchSecurityEndpoint
@@ -85,4 +84,8 @@ func (es *SimpleClient) doRequest(ctx context.Context, method, endpoint string, 
 		}
 	}
 	return es.client.Do(req)
+}
+
+func isResponseFromElasticsearch(resp *http.Response) bool {
+	return resp.Header.Get("X-Elastic-Product") != ""
 }

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -931,3 +931,7 @@ func TableNamePatternRegexp(indexPattern string) *regexp.Regexp {
 
 	return regexp.MustCompile(fmt.Sprintf("^%s$", builder.String()))
 }
+
+func IsResponseFromElasticsearch(resp *http.Response) bool {
+	return resp.Header.Get("X-Elastic-Product") != ""
+}

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -931,7 +931,3 @@ func TableNamePatternRegexp(indexPattern string) *regexp.Regexp {
 
 	return regexp.MustCompile(fmt.Sprintf("^%s$", builder.String()))
 }
-
-func IsResponseFromElasticsearch(resp *http.Response) bool {
-	return resp.Header.Get("X-Elastic-Product") != ""
-}


### PR DESCRIPTION
Little hackish, as it involves additional call to the backend (in order to decide whether use OpenSearch or Elasticsearch security endpoint) **but** given that we have auth header cache I think we might get away with that 😉 


FWIW,  Elasticsearch 7 uses the same [endpoint (`_security/_authenticate`)](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html) as Elasticsearch 8 for auth (just verified :relieved:)