### PR TITLE
Extra `pprof` endpoints

### DIFF
--- a/quesma/main.go
+++ b/quesma/main.go
@@ -28,6 +28,7 @@ import (
 	"quesma/table_resolver"
 	"quesma/telemetry"
 	"quesma/tracing"
+	"runtime"
 	"syscall"
 	"time"
 )
@@ -41,7 +42,15 @@ const banner = `
                       \__>           \/     \/      \/     \/ 
 `
 
+const EnableConcurrencyProfiling = false
+
 func main() {
+
+	if EnableConcurrencyProfiling {
+		runtime.SetBlockProfileRate(1)
+		runtime.SetMutexProfileFraction(1)
+	}
+
 	println(banner)
 	fmt.Printf("Quesma build info: version=[%s], build hash=[%s], build date=[%s]\n",
 		buildinfo.Version, buildinfo.BuildHash, buildinfo.BuildDate)

--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -303,9 +303,13 @@ func (qmc *QuesmaManagementConsole) createRouting() *mux.Router {
 }
 
 func (qmc *QuesmaManagementConsole) initPprof(router *mux.Router) {
+
 	router.HandleFunc("/debug/pprof/", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/heap", pprof.Handler("heap").ServeHTTP)
+	router.HandleFunc("/debug/pprof/block", pprof.Handler("block").ServeHTTP)
+	router.HandleFunc("/debug/pprof/mutex", pprof.Handler("mutex").ServeHTTP)
 	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }

--- a/quesma/quesma/ui/console_routes.go
+++ b/quesma/quesma/ui/console_routes.go
@@ -303,7 +303,6 @@ func (qmc *QuesmaManagementConsole) createRouting() *mux.Router {
 }
 
 func (qmc *QuesmaManagementConsole) initPprof(router *mux.Router) {
-
 	router.HandleFunc("/debug/pprof/", pprof.Index)
 	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	router.HandleFunc("/debug/pprof/profile", pprof.Profile)


### PR DESCRIPTION
This PR adds extra `pprof` endpoints that we can handle. 


So we can profile: 
```
# CPU usage
go tool pprof -http=: http://localhost:9999/debug/pprof/profile

# Heap usage
go tool pprof -http=: http://localhost:9999/debug/pprof/heap

# Concurrency  profiling 
# It requires changing the constant `main.EnableConcurrencyProfiling`
go tool pprof -http=: http://localhost:9999/debug/pprof/mutex
go tool pprof -http=: http://localhost:9999/debug/pprof/block

```
