### PR TITLE
`phone_home` - ignore SSL certificate when calling Elasticsearch

### DIFF
--- a/quesma/telemetry/phone_home.go
+++ b/quesma/telemetry/phone_home.go
@@ -5,6 +5,7 @@ package telemetry
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -202,7 +203,12 @@ func NewPhoneHomeAgent(configuration *config.QuesmaConfiguration, clickHouseDb *
 		ingestCounters:    NewMultiCounter(ctx, nil),
 		userAgentCounters: NewMultiCounter(ctx, processUserAgent),
 		telemetryEndpoint: configuration.QuesmaInternalTelemetryUrl,
-		httpClient:        &http.Client{Timeout: time.Minute},
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+			Timeout: time.Minute,
+		},
 	}
 }
 


### PR DESCRIPTION
Our telemetry collector should ignore SSL certificate validation and just collect the Elasticsearch vitals. 