### PR TITLE
More granular locking

### DIFF
--- a/quesma/table_resolver/table_resolver.go
+++ b/quesma/table_resolver/table_resolver.go
@@ -146,14 +146,6 @@ func (r *tableRegistryImpl) Resolve(pipeline string, indexPattern string) *Decis
 }
 
 func (r *tableRegistryImpl) updateIndexes() {
-	r.m.Lock()
-	defer r.m.Unlock()
-
-	defer func() {
-		for _, res := range r.pipelineResolvers {
-			res.recentDecisions = make(map[string]*Decision)
-		}
-	}()
 
 	logger.Info().Msgf("Index registry updating state.")
 
@@ -174,7 +166,6 @@ func (r *tableRegistryImpl) updateIndexes() {
 		return true
 	})
 
-	r.clickhouseIndexes = clickhouseIndexes
 	logger.Info().Msgf("Clickhouse tables updated: %v", clickhouseIndexes)
 
 	elasticIndexes := make(map[string]table)
@@ -193,7 +184,19 @@ func (r *tableRegistryImpl) updateIndexes() {
 	}
 
 	logger.Info().Msgf("Elastic tables updated: %v", elasticIndexes)
+
+	// Let's update the state
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// this is a critical section
+	
 	r.elasticIndexes = elasticIndexes
+	r.clickhouseIndexes = clickhouseIndexes
+	for _, res := range r.pipelineResolvers {
+		res.recentDecisions = make(map[string]*Decision)
+	}
 }
 
 func (r *tableRegistryImpl) updateState() {

--- a/quesma/table_resolver/table_resolver.go
+++ b/quesma/table_resolver/table_resolver.go
@@ -191,7 +191,6 @@ func (r *tableRegistryImpl) updateIndexes() {
 	defer r.m.Unlock()
 
 	// this is a critical section
-	
 	r.elasticIndexes = elasticIndexes
 	r.clickhouseIndexes = clickhouseIndexes
 	for _, res := range r.pipelineResolvers {


### PR DESCRIPTION
This is a result of mutex profiling:

<img width="244" alt="Screenshot 2024-11-22 at 16 13 36" src="https://github.com/user-attachments/assets/626e3f9e-bb13-44d6-be1d-b42294cff588">

Yes, we should keep our critical section as small  as possible
