### PR TITLE
Wait for HTTP 200 OK in integration tests

### DIFF
--- a/ci/it/testcases/utils.go
+++ b/ci/it/testcases/utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +68,8 @@ func setupElasticsearch(ctx context.Context) (testcontainers.Container, error) {
 		HostAccessPorts: []int{9200, 9300},
 		WaitingFor: wait.ForHTTP("/").WithPort("9200").
 			WithBasicAuth("elastic", "quesmaquesma").
-			WithStartupTimeout(2 * time.Minute),
+			WithStartupTimeout(2 * time.Minute).
+			WithStatusCodeMatcher(func(status int) bool { return status == http.StatusOK }),
 	}
 	elasticsearch, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
@@ -105,7 +107,8 @@ func setupQuesma(ctx context.Context, quesmaConfig string) (testcontainers.Conta
 		},
 		WaitingFor: wait.ForHTTP("/").WithPort("8080").
 			WithBasicAuth("elastic", "quesmaquesma").
-			WithStartupTimeout(2 * time.Minute),
+			WithStartupTimeout(2 * time.Minute).
+			WithStatusCodeMatcher(func(status int) bool { return status == http.StatusOK }),
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.ExtraHosts = []string{"localhost-for-github-ci:host-gateway"}
 		},


### PR DESCRIPTION
We sometimes see integration tests failing, because Quesma returns HTTP 503 Service Unavailable and the test tries to use Quesma in such a unhealthy state. (The only place that 503 could originate from is the golang's http library code - in a case that a handler timeouts. I didn't think it was worthwhile to investigate it further, we only saw this issue in integration tests, not ever in a normal operation of Quesma).

This PR fixes the `WaitingFor` condition to wait for HTTP 200 OK for Elastic and Quesma containers. This should prevent the test from starting when the container is not yet fully ready.