### PR TITLE
Using new http frontend connector API

### DIFF
--- a/quesma/main.go
+++ b/quesma/main.go
@@ -160,7 +160,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(phoneHomeAgent, cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = false
+		const quesma_v2 = true
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -160,7 +160,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(phoneHomeAgent, cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = true
+		const quesma_v2 = false
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/quesma/dual_write_proxy_v2.go
+++ b/quesma/quesma/dual_write_proxy_v2.go
@@ -82,23 +82,6 @@ func (q *dualWriteHttpProxyV2) Stop(ctx context.Context) {
 	q.Close(ctx)
 }
 
-func handlerV2(w http.ResponseWriter, req *http.Request,
-	routerInstance *routerV2,
-	searchRouter *mux.PathRouter, ingestRouter *mux.PathRouter,
-	logManager *clickhouse.LogManager, agent telemetry.PhoneHomeAgent) {
-	defer recovery.LogPanic()
-	reqBody, err := peekBodyV2(req)
-	if err != nil {
-		http.Error(w, "Error reading request body", http.StatusInternalServerError)
-		return
-	}
-
-	ua := req.Header.Get("User-Agent")
-	agent.UserAgentCounters().Add(ua, 1)
-
-	routerInstance.reroute(req.Context(), w, req, reqBody, searchRouter, ingestRouter, logManager)
-}
-
 func newDualWriteProxyV2(schemaLoader clickhouse.TableDiscovery, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, registry schema.Registry, config *config.QuesmaConfiguration, quesmaManagementConsole *ui.QuesmaManagementConsole, agent telemetry.PhoneHomeAgent, processor *ingest.IngestProcessor, resolver table_resolver.TableResolver, abResultsRepository ab_testing.Sender) *dualWriteHttpProxyV2 {
 	queryRunner := NewQueryRunner(logManager, config, indexManager, quesmaManagementConsole, registry, abResultsRepository, resolver)
 	// not sure how we should configure our query translator ???

--- a/quesma/quesma/dual_write_proxy_v2.go
+++ b/quesma/quesma/dual_write_proxy_v2.go
@@ -293,6 +293,69 @@ func (*routerV2) closedIndexResponse(ctx context.Context, w http.ResponseWriter,
 
 }
 
+func (r *routerV2) elasticFallback(decision *table_resolver.Decision,
+	ctx context.Context, w http.ResponseWriter,
+	req *http.Request, reqBody []byte, logManager *clickhouse.LogManager) {
+
+	var sendToElastic bool
+
+	if decision != nil {
+
+		if decision.Err != nil {
+			w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
+			addProductAndContentHeaders(req.Header, w.Header())
+			r.errorResponseV2(ctx, decision.Err, w)
+			return
+		}
+
+		if decision.IsClosed {
+			w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
+			addProductAndContentHeaders(req.Header, w.Header())
+			r.closedIndexResponse(ctx, w, decision.IndexPattern)
+			return
+		}
+
+		if decision.IsEmpty {
+			w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
+			addProductAndContentHeaders(req.Header, w.Header())
+			w.WriteHeader(http.StatusNoContent)
+			w.Write(queryparser.EmptySearchResponse(ctx))
+			return
+		}
+
+		for _, connector := range decision.UseConnectors {
+			if _, ok := connector.(*table_resolver.ConnectorDecisionElastic); ok {
+				// this is desired elastic call
+				sendToElastic = true
+				break
+			}
+		}
+
+	} else {
+		// this is fallback case
+		// in case we don't support sth, we should send it to Elastic
+		sendToElastic = true
+	}
+
+	if sendToElastic {
+		feature.AnalyzeUnsupportedCalls(ctx, req.Method, req.URL.Path, req.Header.Get(opaqueIdHeaderKey), logManager.ResolveIndexPattern)
+
+		rawResponse := <-r.sendHttpRequestToElastic(ctx, req, reqBody, true)
+		response := rawResponse.response
+		if response != nil {
+			responseFromElasticV2(ctx, response, w)
+		} else {
+			w.Header().Set(quesmaSourceHeader, quesmaSourceElastic)
+			w.WriteHeader(500)
+			if rawResponse.error != nil {
+				_, _ = w.Write([]byte(rawResponse.error.Error()))
+			}
+		}
+	} else {
+		r.errorResponseV2(ctx, end_user_errors.ErrNoConnector.New(fmt.Errorf("no connector found")), w)
+	}
+}
+
 func (r *routerV2) reroute(ctx context.Context, w http.ResponseWriter, req *http.Request, reqBody []byte, searchRouter *mux.PathRouter, ingestRouter *mux.PathRouter, logManager *clickhouse.LogManager) {
 	defer recovery.LogAndHandlePanic(ctx, func(err error) {
 		w.WriteHeader(500)
@@ -359,64 +422,7 @@ func (r *routerV2) reroute(ctx context.Context, w http.ResponseWriter, req *http
 			r.errorResponseV2(ctx, err, w)
 		}
 	} else {
-
-		var sendToElastic bool
-
-		if decision != nil {
-
-			if decision.Err != nil {
-				w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
-				addProductAndContentHeaders(req.Header, w.Header())
-				r.errorResponseV2(ctx, decision.Err, w)
-				return
-			}
-
-			if decision.IsClosed {
-				w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
-				addProductAndContentHeaders(req.Header, w.Header())
-				r.closedIndexResponse(ctx, w, decision.IndexPattern)
-				return
-			}
-
-			if decision.IsEmpty {
-				w.Header().Set(quesmaSourceHeader, quesmaSourceClickhouse)
-				addProductAndContentHeaders(req.Header, w.Header())
-				w.WriteHeader(http.StatusNoContent)
-				w.Write(queryparser.EmptySearchResponse(ctx))
-				return
-			}
-
-			for _, connector := range decision.UseConnectors {
-				if _, ok := connector.(*table_resolver.ConnectorDecisionElastic); ok {
-					// this is desired elastic call
-					sendToElastic = true
-					break
-				}
-			}
-
-		} else {
-			// this is fallback case
-			// in case we don't support sth, we should send it to Elastic
-			sendToElastic = true
-		}
-
-		if sendToElastic {
-			feature.AnalyzeUnsupportedCalls(ctx, req.Method, req.URL.Path, req.Header.Get(opaqueIdHeaderKey), logManager.ResolveIndexPattern)
-
-			rawResponse := <-r.sendHttpRequestToElastic(ctx, req, reqBody, true)
-			response := rawResponse.response
-			if response != nil {
-				responseFromElasticV2(ctx, response, w)
-			} else {
-				w.Header().Set(quesmaSourceHeader, quesmaSourceElastic)
-				w.WriteHeader(500)
-				if rawResponse.error != nil {
-					_, _ = w.Write([]byte(rawResponse.error.Error()))
-				}
-			}
-		} else {
-			r.errorResponseV2(ctx, end_user_errors.ErrNoConnector.New(fmt.Errorf("no connector found")), w)
-		}
+		r.elasticFallback(decision, ctx, w, req, reqBody, logManager)
 	}
 }
 

--- a/quesma/quesma/elastic_http_frontend_connector.go
+++ b/quesma/quesma/elastic_http_frontend_connector.go
@@ -1,0 +1,41 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package quesma
+
+import (
+	"net/http"
+	"quesma/clickhouse"
+	"quesma/frontend_connectors"
+	"quesma/quesma/mux"
+	"quesma/telemetry"
+)
+
+type ElasticHttpFrontendConnector struct {
+	*frontend_connectors.BasicHTTPFrontendConnector
+	routerInstance *routerV2
+	searchRouter   *mux.PathRouter
+	ingestRouter   *mux.PathRouter
+	logManager     *clickhouse.LogManager
+	agent          telemetry.PhoneHomeAgent
+}
+
+func NewElasticHttpFrontendConnector(endpoint string,
+	routerInstance *routerV2,
+	searchRouter *mux.PathRouter,
+	ingestRouter *mux.PathRouter,
+	logManager *clickhouse.LogManager,
+	agent telemetry.PhoneHomeAgent) *ElasticHttpFrontendConnector {
+	return &ElasticHttpFrontendConnector{
+		BasicHTTPFrontendConnector: frontend_connectors.NewBasicHTTPFrontendConnector(endpoint),
+		routerInstance:             routerInstance,
+		searchRouter:               searchRouter,
+		ingestRouter:               ingestRouter,
+		logManager:                 logManager,
+		agent:                      agent,
+	}
+}
+
+func (h *ElasticHttpFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	handlerV2(w, req, h.routerInstance, h.searchRouter, h.ingestRouter, h.logManager, h.agent)
+}


### PR DESCRIPTION
This PR:
- introduces `ElasticHttpFrontendConnector` and integrate with the existing routing implementation.
- extracts `elasticFallback` function