### PR TITLE
Moving Decision to frontend_connectors

### DIFF
--- a/quesma/frontend_connectors/decision.go
+++ b/quesma/frontend_connectors/decision.go
@@ -1,0 +1,111 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package frontend_connectors
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Decision struct {
+	// input
+	IndexPattern string "json:\"index_pattern\""
+
+	// obvious fields
+	IsClosed bool  "json:\"is_closed\""
+	Err      error "json:\"error\""
+	IsEmpty  bool  "json:\"is_empty\""
+
+	EnableABTesting bool "json:\"enable_ab_testing\""
+
+	// which connector to use, and how
+	UseConnectors []ConnectorDecision "json:\"use_connectors\""
+
+	// who made the decision and why
+	Reason       string "json:\"reason\""
+	ResolverName string "json:\"resolver_name\""
+}
+
+func (d *Decision) String() string {
+
+	var lines []string
+
+	if d.IsClosed {
+		lines = append(lines, "Returns a closed index message.")
+	}
+
+	if d.IsEmpty {
+		lines = append(lines, "Returns an empty result.")
+	}
+
+	if d.Err != nil {
+		lines = append(lines, fmt.Sprintf("Returns error: '%v'.", d.Err))
+	}
+
+	for _, connector := range d.UseConnectors {
+		lines = append(lines, connector.Message())
+	}
+
+	if d.EnableABTesting {
+		lines = append(lines, "Enable AB testing.")
+	}
+
+	lines = append(lines, fmt.Sprintf("%s (%s).", d.Reason, d.ResolverName))
+
+	return strings.Join(lines, " ")
+}
+
+type ConnectorDecision interface {
+	Message() string
+}
+
+type ConnectorDecisionElastic struct {
+	// TODO  instance of elastic connector
+	ManagementCall bool "json:\"management_call\""
+}
+
+func (d *ConnectorDecisionElastic) Message() string {
+	var lines []string
+	lines = append(lines, "Pass to Elasticsearch.")
+	if d.ManagementCall {
+		lines = append(lines, "Management call.")
+	}
+	return strings.Join(lines, " ")
+}
+
+type ConnectorDecisionClickhouse struct {
+	// TODO  instance of clickhouse connector
+
+	ClickhouseTableName string   "json:\"clickhouse_table_name\""
+	ClickhouseTables    []string "json:\"clickhouse_tables\""
+	IsCommonTable       bool     "json:\"is_common_table\""
+}
+
+func (d *ConnectorDecisionClickhouse) Message() string {
+	var lines []string
+
+	lines = append(lines, "Pass to clickhouse.")
+	if len(d.ClickhouseTableName) > 0 {
+		lines = append(lines, fmt.Sprintf("Table: '%s' .", d.ClickhouseTableName))
+	}
+	if d.IsCommonTable {
+		lines = append(lines, "Common table.")
+	}
+	if len(d.ClickhouseTables) > 0 {
+		lines = append(lines, fmt.Sprintf("Indexes: %v.", d.ClickhouseTables))
+	}
+
+	return strings.Join(lines, " ")
+}
+
+// PatternDecisions is a struct that holds the pattern and the decisions made for that pattern
+type PatternDecisions struct {
+	Pattern   string
+	Decisions map[string]*Decision
+}
+
+// TODO hardcoded pipeline names
+const (
+	QueryPipeline  = "Query"
+	IngestPipeline = "Ingest"
+)

--- a/quesma/ingest/common_table_test.go
+++ b/quesma/ingest/common_table_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"quesma/clickhouse"
 	"quesma/common_table"
+	"quesma/frontend_connectors"
 	"quesma/jsonprocessor"
 	"quesma/persistence"
 	"quesma/quesma/config"
@@ -191,9 +192,9 @@ func TestIngestToCommonTable(t *testing.T) {
 
 			resolver := table_resolver.NewEmptyTableResolver()
 
-			decision := &table_resolver.Decision{
-				UseConnectors: []table_resolver.ConnectorDecision{
-					&table_resolver.ConnectorDecisionClickhouse{
+			decision := &frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{
+					&frontend_connectors.ConnectorDecisionClickhouse{
 						ClickhouseTableName: common_table.TableName,
 						ClickhouseTables:    []string{indexName},
 						IsCommonTable:       true,

--- a/quesma/ingest/ingest_validator_test.go
+++ b/quesma/ingest/ingest_validator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"quesma/clickhouse"
+	"quesma/frontend_connectors"
 	"quesma/quesma/config"
 	"quesma/quesma/types"
 	"quesma/table_resolver"
@@ -171,8 +172,8 @@ func TestIngestValidation(t *testing.T) {
 		ip.tableDiscovery = clickhouse.NewTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tableMap)
 
 		resolver := table_resolver.NewEmptyTableResolver()
-		decision := &table_resolver.Decision{
-			UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+		decision := &frontend_connectors.Decision{
+			UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 				ClickhouseTableName: "test_table",
 			}}}
 		resolver.Decisions["test_table"] = decision

--- a/quesma/ingest/insert_test.go
+++ b/quesma/ingest/insert_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"quesma/clickhouse"
+	"quesma/frontend_connectors"
 	"quesma/jsonprocessor"
 	"quesma/persistence"
 	"quesma/quesma/config"
@@ -239,8 +240,8 @@ func TestProcessInsertQuery(t *testing.T) {
 					db, mock := util.InitSqlMockWithPrettyPrint(t, true)
 					ip.ip.chDb = db
 					resolver := table_resolver.NewEmptyTableResolver()
-					decision := &table_resolver.Decision{
-						UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+					decision := &frontend_connectors.Decision{
+						UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 							ClickhouseTableName: "test_table",
 						}}}
 					resolver.Decisions["test_table"] = decision
@@ -424,8 +425,8 @@ func TestCreateTableIfSomeFieldsExistsInSchemaAlready(t *testing.T) {
 			schemaRegistry.Tables[schema.TableName(indexName)] = indexSchema
 
 			resolver := table_resolver.NewEmptyTableResolver()
-			decision := &table_resolver.Decision{
-				UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+			decision := &frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "test_index",
 				}}}
 			resolver.Decisions["test_index"] = decision

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -12,6 +12,7 @@ import (
 	"quesma/comment_metadata"
 	"quesma/common_table"
 	"quesma/end_user_errors"
+	"quesma/frontend_connectors"
 	"quesma/jsonprocessor"
 	"quesma/logger"
 	"quesma/model"
@@ -695,7 +696,7 @@ func (lm *IngestProcessor) ProcessInsertQuery(ctx context.Context, tableName str
 	jsonData []types.JSON, transformer jsonprocessor.IngestTransformer,
 	tableFormatter TableColumNameFormatter) error {
 
-	decision := lm.tableResolver.Resolve(table_resolver.IngestPipeline, tableName)
+	decision := lm.tableResolver.Resolve(frontend_connectors.IngestPipeline, tableName)
 
 	if decision.Err != nil {
 		return decision.Err
@@ -711,10 +712,10 @@ func (lm *IngestProcessor) ProcessInsertQuery(ctx context.Context, tableName str
 
 	for _, connectorDecision := range decision.UseConnectors {
 
-		var clickhouseDecision *table_resolver.ConnectorDecisionClickhouse
+		var clickhouseDecision *frontend_connectors.ConnectorDecisionClickhouse
 
 		var ok bool
-		if clickhouseDecision, ok = connectorDecision.(*table_resolver.ConnectorDecisionClickhouse); !ok {
+		if clickhouseDecision, ok = connectorDecision.(*frontend_connectors.ConnectorDecisionClickhouse); !ok {
 			continue
 		}
 

--- a/quesma/quesma/dual_write_proxy.go
+++ b/quesma/quesma/dual_write_proxy.go
@@ -15,6 +15,7 @@ import (
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
 	"quesma/feature"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -368,7 +369,7 @@ func (r *router) reroute(ctx context.Context, w http.ResponseWriter, req *http.R
 			}
 
 			for _, connector := range decision.UseConnectors {
-				if _, ok := connector.(*table_resolver.ConnectorDecisionElastic); ok {
+				if _, ok := connector.(*frontend_connectors.ConnectorDecisionElastic); ok {
 					// this is desired elastic call
 					sendToElastic = true
 					break

--- a/quesma/quesma/dual_write_proxy_v2.go
+++ b/quesma/quesma/dual_write_proxy_v2.go
@@ -15,6 +15,7 @@ import (
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
 	"quesma/feature"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -276,7 +277,7 @@ func (*routerV2) closedIndexResponse(ctx context.Context, w http.ResponseWriter,
 
 }
 
-func (r *routerV2) elasticFallback(decision *table_resolver.Decision,
+func (r *routerV2) elasticFallback(decision *frontend_connectors.Decision,
 	ctx context.Context, w http.ResponseWriter,
 	req *http.Request, reqBody []byte, logManager *clickhouse.LogManager) {
 
@@ -307,7 +308,7 @@ func (r *routerV2) elasticFallback(decision *table_resolver.Decision,
 		}
 
 		for _, connector := range decision.UseConnectors {
-			if _, ok := connector.(*table_resolver.ConnectorDecisionElastic); ok {
+			if _, ok := connector.(*frontend_connectors.ConnectorDecisionElastic); ok {
 				// this is desired elastic call
 				sendToElastic = true
 				break
@@ -360,7 +361,7 @@ func (r *routerV2) reroute(ctx context.Context, w http.ResponseWriter, req *http
 
 	quesmaRequest.ParsedBody = types.ParseRequestBody(quesmaRequest.Body)
 	var handler mux.Handler
-	var decision *table_resolver.Decision
+	var decision *frontend_connectors.Decision
 	searchHandler, searchDecision := searchRouter.Matches(quesmaRequest)
 	if searchDecision != nil {
 		decision = searchDecision

--- a/quesma/quesma/functionality/bulk/bulk.go
+++ b/quesma/quesma/functionality/bulk/bulk.go
@@ -11,6 +11,7 @@ import (
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -138,7 +139,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 			}
 		}
 
-		decision := tableResolver.Resolve(table_resolver.IngestPipeline, index)
+		decision := tableResolver.Resolve(frontend_connectors.IngestPipeline, index)
 
 		if decision.Err != nil {
 			return decision.Err
@@ -180,7 +181,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 
 			switch connector.(type) {
 
-			case *table_resolver.ConnectorDecisionElastic:
+			case *frontend_connectors.ConnectorDecisionElastic:
 				// Bulk entry for Elastic - forward the request as-is
 				opBytes, err := rawOp.Bytes()
 				if err != nil {
@@ -198,7 +199,7 @@ func splitBulk(ctx context.Context, defaultIndex *string, bulk types.NDJSON, bul
 
 				elasticBulkEntries = append(elasticBulkEntries, entryWithResponse)
 
-			case *table_resolver.ConnectorDecisionClickhouse:
+			case *frontend_connectors.ConnectorDecisionClickhouse:
 
 				// Bulk entry for Clickhouse
 				if operation != "create" && operation != "index" {

--- a/quesma/quesma/matchers.go
+++ b/quesma/quesma/matchers.go
@@ -3,6 +3,7 @@
 package quesma
 
 import (
+	"quesma/frontend_connectors"
 	"quesma/logger"
 	"quesma/quesma/config"
 	"quesma/quesma/mux"
@@ -33,7 +34,7 @@ func matchedAgainstBulkBody(configuration *config.QuesmaConfiguration, tableReso
 			if idx%2 == 0 {
 				name := extractIndexName(s)
 
-				decision := tableResolver.Resolve(table_resolver.IngestPipeline, name)
+				decision := tableResolver.Resolve(frontend_connectors.IngestPipeline, name)
 
 				if decision.IsClosed {
 					return mux.MatchResult{Matched: true, Decision: decision}
@@ -41,7 +42,7 @@ func matchedAgainstBulkBody(configuration *config.QuesmaConfiguration, tableReso
 
 				// if have any enabled Clickhouse connector, then return true
 				for _, connector := range decision.UseConnectors {
-					if _, ok := connector.(*table_resolver.ConnectorDecisionClickhouse); ok {
+					if _, ok := connector.(*frontend_connectors.ConnectorDecisionClickhouse); ok {
 						return mux.MatchResult{Matched: true, Decision: decision}
 					}
 				}
@@ -56,7 +57,7 @@ func matchedAgainstBulkBody(configuration *config.QuesmaConfiguration, tableReso
 
 // Query path only (looks at QueryTarget)
 func matchedAgainstPattern(indexRegistry table_resolver.TableResolver) mux.RequestMatcher {
-	return matchAgainstTableResolver(indexRegistry, table_resolver.QueryPipeline)
+	return matchAgainstTableResolver(indexRegistry, frontend_connectors.QueryPipeline)
 }
 
 // check whether exact index name is enabled
@@ -70,7 +71,7 @@ func matchAgainstTableResolver(indexRegistry table_resolver.TableResolver, pipel
 			return mux.MatchResult{Matched: false, Decision: decision}
 		}
 		for _, connector := range decision.UseConnectors {
-			if _, ok := connector.(*table_resolver.ConnectorDecisionClickhouse); ok {
+			if _, ok := connector.(*frontend_connectors.ConnectorDecisionClickhouse); ok {
 				return mux.MatchResult{Matched: true, Decision: decision}
 			}
 		}
@@ -79,11 +80,11 @@ func matchAgainstTableResolver(indexRegistry table_resolver.TableResolver, pipel
 }
 
 func matchedExactQueryPath(indexRegistry table_resolver.TableResolver) mux.RequestMatcher {
-	return matchAgainstTableResolver(indexRegistry, table_resolver.QueryPipeline)
+	return matchAgainstTableResolver(indexRegistry, frontend_connectors.QueryPipeline)
 }
 
 func matchedExactIngestPath(indexRegistry table_resolver.TableResolver) mux.RequestMatcher {
-	return matchAgainstTableResolver(indexRegistry, table_resolver.IngestPipeline)
+	return matchAgainstTableResolver(indexRegistry, frontend_connectors.IngestPipeline)
 }
 
 // Returns false if the body contains a Kibana internal search.

--- a/quesma/quesma/mux/mux.go
+++ b/quesma/quesma/mux/mux.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ucarion/urlpath"
 	"net/http"
 	"net/url"
+	"quesma/frontend_connectors"
 	"quesma/logger"
 	"quesma/quesma/types"
-	"quesma/table_resolver"
 	"strings"
 )
 
@@ -45,7 +45,7 @@ type (
 
 	MatchResult struct {
 		Matched  bool
-		Decision *table_resolver.Decision
+		Decision *frontend_connectors.Decision
 	}
 	RequestMatcher interface {
 		Matches(req *Request) MatchResult
@@ -86,7 +86,7 @@ func (p *PathRouter) Register(pattern string, predicate RequestMatcher, handler 
 
 }
 
-func (p *PathRouter) Matches(req *Request) (Handler, *table_resolver.Decision) {
+func (p *PathRouter) Matches(req *Request) (Handler, *frontend_connectors.Decision) {
 	if strings.Contains(req.Path, "fligh") {
 		logger.Debug().Msgf("Matched path: %s", req.Path)
 	}
@@ -102,7 +102,7 @@ func (p *PathRouter) Matches(req *Request) (Handler, *table_resolver.Decision) {
 	}
 }
 
-func (p *PathRouter) findHandler(req *Request) (Handler, *table_resolver.Decision) {
+func (p *PathRouter) findHandler(req *Request) (Handler, *frontend_connectors.Decision) {
 	path := strings.TrimSuffix(req.Path, "/")
 	for _, m := range p.mappings {
 		meta, match := m.compiledPath.Match(path)
@@ -142,7 +142,7 @@ type predicateAnd struct {
 }
 
 func (p *predicateAnd) Matches(req *Request) MatchResult {
-	var lastDecision *table_resolver.Decision
+	var lastDecision *frontend_connectors.Decision
 
 	for _, predicate := range p.predicates {
 		res := predicate.Matches(req)

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -10,6 +10,7 @@ import (
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -383,7 +384,7 @@ func ConfigureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 	router.Register(routes.QuesmaTableResolverPath, method("GET"), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
 		indexPattern := req.Params["index"]
 
-		decisions := make(map[string]*table_resolver.Decision)
+		decisions := make(map[string]*frontend_connectors.Decision)
 		humanReadable := make(map[string]string)
 		for _, pipeline := range tableResolver.Pipelines() {
 			decision := tableResolver.Resolve(pipeline, indexPattern)
@@ -392,9 +393,9 @@ func ConfigureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 		}
 
 		resp := struct {
-			IndexPattern  string                              `json:"index_pattern"`
-			Decisions     map[string]*table_resolver.Decision `json:"decisions"`
-			HumanReadable map[string]string                   `json:"human_readable"`
+			IndexPattern  string                                   `json:"index_pattern"`
+			Decisions     map[string]*frontend_connectors.Decision `json:"decisions"`
+			HumanReadable map[string]string                        `json:"human_readable"`
 		}{
 			IndexPattern:  indexPattern,
 			Decisions:     decisions,

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"quesma/clickhouse"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/quesma/config"
 	"quesma/quesma/mux"
@@ -358,15 +359,15 @@ func (t TestTableResolver) Start() {}
 
 func (t TestTableResolver) Stop() {}
 
-func (t TestTableResolver) Resolve(_ string, indexPattern string) *table_resolver.Decision {
+func (t TestTableResolver) Resolve(_ string, indexPattern string) *frontend_connectors.Decision {
 	if indexPattern == testIndexName {
-		return &table_resolver.Decision{
-			UseConnectors: []table_resolver.ConnectorDecision{
-				&table_resolver.ConnectorDecisionClickhouse{},
+		return &frontend_connectors.Decision{
+			UseConnectors: []frontend_connectors.ConnectorDecision{
+				&frontend_connectors.ConnectorDecisionClickhouse{},
 			},
 		}
 	} else {
-		return &table_resolver.Decision{
+		return &frontend_connectors.Decision{
 			Err:          fmt.Errorf("TestTableResolver err"),
 			Reason:       "TestTableResolver reason",
 			ResolverName: "TestTableResolver",
@@ -376,6 +377,6 @@ func (t TestTableResolver) Resolve(_ string, indexPattern string) *table_resolve
 
 func (t TestTableResolver) Pipelines() []string { return []string{} }
 
-func (t TestTableResolver) RecentDecisions() []table_resolver.PatternDecisions {
-	return []table_resolver.PatternDecisions{}
+func (t TestTableResolver) RecentDecisions() []frontend_connectors.PatternDecisions {
+	return []frontend_connectors.PatternDecisions{}
 }

--- a/quesma/quesma/router_v2.go
+++ b/quesma/quesma/router_v2.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -393,7 +394,7 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, sr schema.Registry
 	router.Register(routes.QuesmaTableResolverPath, method("GET"), func(ctx context.Context, req *mux.Request) (*mux.Result, error) {
 		indexPattern := req.Params["index"]
 
-		decisions := make(map[string]*table_resolver.Decision)
+		decisions := make(map[string]*frontend_connectors.Decision)
 		humanReadable := make(map[string]string)
 		for _, pipeline := range tableResolver.Pipelines() {
 			decision := tableResolver.Resolve(pipeline, indexPattern)
@@ -402,9 +403,9 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, sr schema.Registry
 		}
 
 		resp := struct {
-			IndexPattern  string                              `json:"index_pattern"`
-			Decisions     map[string]*table_resolver.Decision `json:"decisions"`
-			HumanReadable map[string]string                   `json:"human_readable"`
+			IndexPattern  string                                   `json:"index_pattern"`
+			Decisions     map[string]*frontend_connectors.Decision `json:"decisions"`
+			HumanReadable map[string]string                        `json:"human_readable"`
 		}{
 			IndexPattern:  indexPattern,
 			Decisions:     decisions,

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -12,6 +12,7 @@ import (
 	"quesma/common_table"
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
+	"quesma/frontend_connectors"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/optimize"
@@ -101,9 +102,9 @@ func NewQueryRunnerDefaultForTests(db *sql.DB, cfg *config.QuesmaConfiguration,
 	logChan := logger.InitOnlyChannelLoggerForTests()
 
 	resolver := table_resolver.NewEmptyTableResolver()
-	resolver.Decisions[tableName] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{
-			&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions[tableName] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{
+			&frontend_connectors.ConnectorDecisionClickhouse{
 				ClickhouseTableName: tableName,
 				ClickhouseTables:    []string{tableName},
 			},
@@ -295,7 +296,7 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 
 func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern string, body types.JSON, optAsync *AsyncQuery, queryLanguage QueryLanguage) ([]byte, error) {
 
-	decision := q.tableResolver.Resolve(table_resolver.QueryPipeline, indexPattern)
+	decision := q.tableResolver.Resolve(frontend_connectors.QueryPipeline, indexPattern)
 
 	if decision.Err != nil {
 
@@ -324,15 +325,15 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		return nil, end_user_errors.ErrSearchCondition.New(fmt.Errorf("no connectors to use"))
 	}
 
-	var clickhouseConnector *table_resolver.ConnectorDecisionClickhouse
+	var clickhouseConnector *frontend_connectors.ConnectorDecisionClickhouse
 
 	for _, connector := range decision.UseConnectors {
 		switch c := connector.(type) {
 
-		case *table_resolver.ConnectorDecisionClickhouse:
+		case *frontend_connectors.ConnectorDecisionClickhouse:
 			clickhouseConnector = c
 
-		case *table_resolver.ConnectorDecisionElastic:
+		case *frontend_connectors.ConnectorDecisionElastic:
 			// NOP
 
 		default:

--- a/quesma/quesma/search_ab_testing.go
+++ b/quesma/quesma/search_ab_testing.go
@@ -11,6 +11,7 @@ import (
 	"quesma/ab_testing"
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
+	"quesma/frontend_connectors"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/quesma/async_search_storage"
@@ -18,7 +19,6 @@ import (
 	"quesma/quesma/recovery"
 	"quesma/quesma/types"
 	"quesma/quesma/ui"
-	"quesma/table_resolver"
 	"quesma/tracing"
 	"quesma/util"
 	"time"
@@ -112,7 +112,7 @@ func (q *QueryRunner) runABTestingResultsCollector(ctx context.Context, indexPat
 	return optComparePlansCh, backgroundContext
 }
 
-func (q *QueryRunner) executeABTesting(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, optAsync *AsyncQuery, decision *table_resolver.Decision, indexPattern string) ([]byte, error) {
+func (q *QueryRunner) executeABTesting(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, body types.JSON, optAsync *AsyncQuery, decision *frontend_connectors.Decision, indexPattern string) ([]byte, error) {
 
 	optComparePlansCh, backgroundContext := q.runABTestingResultsCollector(ctx, indexPattern, body)
 
@@ -126,13 +126,13 @@ func (q *QueryRunner) executeABTesting(ctx context.Context, plan *model.Executio
 
 		switch connector.(type) {
 
-		case *table_resolver.ConnectorDecisionClickhouse:
+		case *frontend_connectors.ConnectorDecisionClickhouse:
 			planExecutor = func(ctx context.Context) ([]byte, error) {
 				plan.Name = config.ClickhouseTarget
 				return q.executePlan(ctx, plan, queryTranslator, table, body, optAsync, optComparePlansCh, isMainPlan)
 			}
 
-		case *table_resolver.ConnectorDecisionElastic:
+		case *frontend_connectors.ConnectorDecisionElastic:
 			planExecutor = func(ctx context.Context) ([]byte, error) {
 				elasticPlan := &model.ExecutionPlan{
 					IndexPattern:          plan.IndexPattern,

--- a/quesma/quesma/search_common_table_test.go
+++ b/quesma/quesma/search_common_table_test.go
@@ -9,6 +9,7 @@ import (
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/elasticsearch"
+	"quesma/frontend_connectors"
 	"quesma/logger"
 	"quesma/quesma/config"
 	"quesma/quesma/types"
@@ -250,47 +251,47 @@ func TestSearchCommonTable(t *testing.T) {
 
 	resolver := table_resolver.NewEmptyTableResolver()
 
-	resolver.Decisions["logs-1"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["logs-1"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: common_table.TableName,
 			ClickhouseTables:    []string{"logs-1"},
 			IsCommonTable:       true,
 		}},
 	}
 
-	resolver.Decisions["logs-2"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["logs-2"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: common_table.TableName,
 			ClickhouseTables:    []string{"logs-2"},
 			IsCommonTable:       true,
 		}},
 	}
 
-	resolver.Decisions["logs-3"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["logs-3"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: "logs-3",
 			ClickhouseTables:    []string{"logs-3"},
 			IsCommonTable:       false,
 		}},
 	}
 
-	resolver.Decisions["logs-1,logs-2"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["logs-1,logs-2"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: common_table.TableName,
 			ClickhouseTables:    []string{"logs-1", "logs-2"},
 			IsCommonTable:       true,
 		}},
 	}
 
-	resolver.Decisions["logs-*"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["logs-*"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: common_table.TableName,
 			ClickhouseTables:    []string{"logs-1", "logs-2"},
 			IsCommonTable:       true,
 		}},
 	}
-	resolver.Decisions["*"] = &table_resolver.Decision{
-		UseConnectors: []table_resolver.ConnectorDecision{&table_resolver.ConnectorDecisionClickhouse{
+	resolver.Decisions["*"] = &frontend_connectors.Decision{
+		UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 			ClickhouseTableName: common_table.TableName,
 			ClickhouseTables:    []string{"logs-1", "logs-2"},
 			IsCommonTable:       true,

--- a/quesma/table_resolver/empty.go
+++ b/quesma/table_resolver/empty.go
@@ -2,34 +2,37 @@
 // SPDX-License-Identifier: Elastic-2.0
 package table_resolver
 
-import "fmt"
+import (
+	"fmt"
+	"quesma/frontend_connectors"
+)
 
 type EmptyTableResolver struct {
-	Decisions          map[string]*Decision
-	RecentDecisionList []PatternDecisions
+	Decisions          map[string]*frontend_connectors.Decision
+	RecentDecisionList []frontend_connectors.PatternDecisions
 	PipelinesList      []string
 }
 
 func NewEmptyTableResolver() *EmptyTableResolver {
 	return &EmptyTableResolver{
-		Decisions: make(map[string]*Decision),
+		Decisions: make(map[string]*frontend_connectors.Decision),
 	}
 }
 
-func (r *EmptyTableResolver) Resolve(pipeline string, indexPattern string) *Decision {
+func (r *EmptyTableResolver) Resolve(pipeline string, indexPattern string) *frontend_connectors.Decision {
 	d, ok := r.Decisions[indexPattern]
 	if ok {
 		return d
 	}
 	msg := fmt.Sprintf("Could not resolve pattern %v. Fix you test setup first.", indexPattern)
-	return &Decision{
+	return &frontend_connectors.Decision{
 		Err:          fmt.Errorf("%s", msg),
 		Reason:       msg,
 		ResolverName: "EmptyTableResolver.Resolve",
 	}
 }
 
-func (r *EmptyTableResolver) RecentDecisions() []PatternDecisions {
+func (r *EmptyTableResolver) RecentDecisions() []frontend_connectors.PatternDecisions {
 	return r.RecentDecisionList
 }
 

--- a/quesma/table_resolver/model.go
+++ b/quesma/table_resolver/model.go
@@ -1,3 +1,5 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
 package table_resolver
 
 import "quesma/frontend_connectors"

--- a/quesma/table_resolver/model.go
+++ b/quesma/table_resolver/model.go
@@ -1,131 +1,13 @@
-// Copyright Quesma, licensed under the Elastic License 2.0.
-// SPDX-License-Identifier: Elastic-2.0
 package table_resolver
 
-import (
-	"fmt"
-	"quesma/logger"
-	"strings"
-)
-
-type Decision struct {
-	// input
-	IndexPattern string "json:\"index_pattern\""
-
-	// obvious fields
-	IsClosed bool  "json:\"is_closed\""
-	Err      error "json:\"error\""
-	IsEmpty  bool  "json:\"is_empty\""
-
-	EnableABTesting bool "json:\"enable_ab_testing\""
-
-	// which connector to use, and how
-	UseConnectors []ConnectorDecision "json:\"use_connectors\""
-
-	// who made the decision and why
-	Reason       string "json:\"reason\""
-	ResolverName string "json:\"resolver_name\""
-}
-
-func (d *Decision) String() string {
-
-	var lines []string
-
-	if d.IsClosed {
-		lines = append(lines, "Returns a closed index message.")
-	}
-
-	if d.IsEmpty {
-		lines = append(lines, "Returns an empty result.")
-	}
-
-	if d.Err != nil {
-		lines = append(lines, fmt.Sprintf("Returns error: '%v'.", d.Err))
-	}
-
-	for _, connector := range d.UseConnectors {
-		lines = append(lines, connector.Message())
-	}
-
-	if d.EnableABTesting {
-		lines = append(lines, "Enable AB testing.")
-	}
-
-	lines = append(lines, fmt.Sprintf("%s (%s).", d.Reason, d.ResolverName))
-
-	return strings.Join(lines, " ")
-}
-
-type ConnectorDecision interface {
-	Message() string
-}
-
-type ConnectorDecisionElastic struct {
-	// TODO  instance of elastic connector
-	ManagementCall bool "json:\"management_call\""
-}
-
-func (d *ConnectorDecisionElastic) Message() string {
-	var lines []string
-	lines = append(lines, "Pass to Elasticsearch.")
-	if d.ManagementCall {
-		lines = append(lines, "Management call.")
-	}
-	return strings.Join(lines, " ")
-}
-
-type ConnectorDecisionClickhouse struct {
-	// TODO  instance of clickhouse connector
-
-	ClickhouseTableName string   "json:\"clickhouse_table_name\""
-	ClickhouseTables    []string "json:\"clickhouse_tables\""
-	IsCommonTable       bool     "json:\"is_common_table\""
-}
-
-func (d *ConnectorDecisionClickhouse) Message() string {
-	var lines []string
-
-	lines = append(lines, "Pass to clickhouse.")
-	if len(d.ClickhouseTableName) > 0 {
-		lines = append(lines, fmt.Sprintf("Table: '%s' .", d.ClickhouseTableName))
-	}
-	if d.IsCommonTable {
-		lines = append(lines, "Common table.")
-	}
-	if len(d.ClickhouseTables) > 0 {
-		lines = append(lines, fmt.Sprintf("Indexes: %v.", d.ClickhouseTables))
-	}
-
-	return strings.Join(lines, " ")
-}
-
-// PatternDecisions is a struct that holds the pattern and the decisions made for that pattern
-type PatternDecisions struct {
-	Pattern   string
-	Decisions map[string]*Decision
-}
+import "quesma/frontend_connectors"
 
 type TableResolver interface {
 	Start()
 	Stop()
 
-	Resolve(pipeline string, indexPattern string) *Decision
+	Resolve(pipeline string, indexPattern string) *frontend_connectors.Decision
 
 	Pipelines() []string
-	RecentDecisions() []PatternDecisions
+	RecentDecisions() []frontend_connectors.PatternDecisions
 }
-
-// TODO will be removed in the next PR,
-// right now it is used to mark places where we must refactor the code
-func TODO(place string, decision *Decision) {
-	var trace bool
-	if trace {
-		logger.Debug().Msgf("TODO: use table_resolver decision here  %s : %v", place, decision.String())
-	}
-}
-
-// TODO hardcoded pipeline names
-const (
-	QueryPipeline  = "Query"
-	IngestPipeline = "Ingest"
-)

--- a/quesma/table_resolver/rules.go
+++ b/quesma/table_resolver/rules.go
@@ -7,6 +7,7 @@ import (
 	"quesma/common_table"
 	"quesma/elasticsearch"
 	"quesma/end_user_errors"
+	"quesma/frontend_connectors"
 	"quesma/quesma/config"
 	"quesma/util"
 	"reflect"
@@ -16,7 +17,7 @@ import (
 // TODO these rules may be incorrect and incomplete
 // They will be fixed int the next iteration.
 
-func (r *tableRegistryImpl) wildcardPatternSplitter(pattern string) (parsedPattern, *Decision) {
+func (r *tableRegistryImpl) wildcardPatternSplitter(pattern string) (parsedPattern, *frontend_connectors.Decision) {
 	patterns := strings.Split(pattern, ",")
 
 	// Given a (potentially wildcard) pattern, find all non-wildcard index names that match the pattern
@@ -61,10 +62,10 @@ func (r *tableRegistryImpl) wildcardPatternSplitter(pattern string) (parsedPatte
 	}, nil
 }
 
-func singleIndexSplitter(pattern string) (parsedPattern, *Decision) {
+func singleIndexSplitter(pattern string) (parsedPattern, *frontend_connectors.Decision) {
 	patterns := strings.Split(pattern, ",")
 	if len(patterns) > 1 || strings.Contains(pattern, "*") {
-		return parsedPattern{}, &Decision{
+		return parsedPattern{}, &frontend_connectors.Decision{
 			Reason: "Pattern is not allowed.",
 			Err:    fmt.Errorf("pattern is not allowed"),
 		}
@@ -77,13 +78,13 @@ func singleIndexSplitter(pattern string) (parsedPattern, *Decision) {
 	}, nil
 }
 
-func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
+func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *frontend_connectors.Decision {
 
-	return func(part string) *Decision {
+	return func(part string) *frontend_connectors.Decision {
 		idx, ok := cfg[part]
 		if ok {
 			if len(getTargets(idx, pipeline)) == 0 {
-				return &Decision{
+				return &frontend_connectors.Decision{
 					IsClosed: true,
 					Reason:   "Index is disabled in config.",
 				}
@@ -94,11 +95,11 @@ func makeIsDisabledInConfig(cfg map[string]config.IndexConfiguration, pipeline s
 	}
 }
 
-func resolveInternalElasticName(part string) *Decision {
+func resolveInternalElasticName(part string) *frontend_connectors.Decision {
 
 	if elasticsearch.IsInternalIndex(part) {
-		return &Decision{
-			UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{ManagementCall: true}},
+		return &frontend_connectors.Decision{
+			UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{ManagementCall: true}},
 			Reason:        "It's kibana internals",
 		}
 	}
@@ -106,18 +107,18 @@ func resolveInternalElasticName(part string) *Decision {
 	return nil
 }
 
-func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string) func(part string) *Decision {
-	return func(part string) *Decision {
+func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string) func(part string) *frontend_connectors.Decision {
+	return func(part string) *frontend_connectors.Decision {
 		var targets []string
-		var useConnectors []ConnectorDecision
+		var useConnectors []frontend_connectors.ConnectorDecision
 
 		switch pipeline {
-		case IngestPipeline:
+		case frontend_connectors.IngestPipeline:
 			targets = quesmaConf.DefaultIngestTarget
-		case QueryPipeline:
+		case frontend_connectors.QueryPipeline:
 			targets = quesmaConf.DefaultQueryTarget
 		default:
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Reason: "Unsupported configuration",
 				Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported pipeline: %s", pipeline)),
 			}
@@ -126,22 +127,22 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 		for _, target := range targets {
 			switch target {
 			case config.ClickhouseTarget:
-				useConnectors = append(useConnectors, &ConnectorDecisionClickhouse{
+				useConnectors = append(useConnectors, &frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: part,
 					IsCommonTable:       quesmaConf.UseCommonTableForWildcard,
 					ClickhouseTables:    []string{part},
 				})
 			case config.ElasticsearchTarget:
-				useConnectors = append(useConnectors, &ConnectorDecisionElastic{})
+				useConnectors = append(useConnectors, &frontend_connectors.ConnectorDecisionElastic{})
 			default:
-				return &Decision{
+				return &frontend_connectors.Decision{
 					Reason: "Unsupported configuration",
 					Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported target: %s", target)),
 				}
 			}
 		}
 
-		return &Decision{
+		return &frontend_connectors.Decision{
 			UseConnectors: useConnectors,
 			IsClosed:      len(useConnectors) == 0,
 			Reason:        fmt.Sprintf("Using default wildcard ('%s') configuration for %s processor", config.DefaultWildcardIndexName, pipeline),
@@ -149,9 +150,9 @@ func makeDefaultWildcard(quesmaConf config.QuesmaConfiguration, pipeline string)
 	}
 }
 
-func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
+func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfiguration, pipeline string) func(part string) *frontend_connectors.Decision {
 
-	return func(part string) *Decision {
+	return func(part string) *frontend_connectors.Decision {
 		if cfg, ok := indexConfig[part]; ok {
 			if !cfg.UseCommonTable {
 
@@ -163,23 +164,23 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 
 				case 1:
 
-					decision := &Decision{
+					decision := &frontend_connectors.Decision{
 						Reason: "Enabled in the config. ",
 					}
 
-					var targetDecision ConnectorDecision
+					var targetDecision frontend_connectors.ConnectorDecision
 
 					switch targets[0] {
 
 					case config.ElasticsearchTarget:
-						targetDecision = &ConnectorDecisionElastic{}
+						targetDecision = &frontend_connectors.ConnectorDecisionElastic{}
 					case config.ClickhouseTarget:
-						targetDecision = &ConnectorDecisionClickhouse{
+						targetDecision = &frontend_connectors.ConnectorDecisionClickhouse{
 							ClickhouseTableName: part,
 							ClickhouseTables:    []string{part},
 						}
 					default:
-						return &Decision{
+						return &frontend_connectors.Decision{
 							Reason: "Unsupported configuration",
 							Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported target: %s", targets[0])),
 						}
@@ -191,36 +192,36 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 
 					switch pipeline {
 
-					case IngestPipeline:
-						return &Decision{
+					case frontend_connectors.IngestPipeline:
+						return &frontend_connectors.Decision{
 							Reason: "Enabled in the config. Dual write is enabled.",
 
-							UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+							UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 								ClickhouseTableName: part,
 								ClickhouseTables:    []string{part}},
-								&ConnectorDecisionElastic{}},
+								&frontend_connectors.ConnectorDecisionElastic{}},
 						}
 
-					case QueryPipeline:
+					case frontend_connectors.QueryPipeline:
 
 						if targets[0] == config.ClickhouseTarget && targets[1] == config.ElasticsearchTarget {
 
-							return &Decision{
+							return &frontend_connectors.Decision{
 								Reason:          "Enabled in the config. A/B testing.",
 								EnableABTesting: true,
-								UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+								UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 									ClickhouseTableName: part,
 									ClickhouseTables:    []string{part}},
-									&ConnectorDecisionElastic{}},
+									&frontend_connectors.ConnectorDecisionElastic{}},
 							}
 						} else if targets[0] == config.ElasticsearchTarget && targets[1] == config.ClickhouseTarget {
 
-							return &Decision{
+							return &frontend_connectors.Decision{
 								Reason:          "Enabled in the config. A/B testing.",
 								EnableABTesting: true,
-								UseConnectors: []ConnectorDecision{
-									&ConnectorDecisionElastic{},
-									&ConnectorDecisionClickhouse{
+								UseConnectors: []frontend_connectors.ConnectorDecision{
+									&frontend_connectors.ConnectorDecisionElastic{},
+									&frontend_connectors.ConnectorDecisionClickhouse{
 										ClickhouseTableName: part,
 										ClickhouseTables:    []string{part}},
 								},
@@ -229,19 +230,19 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 						}
 
 					default:
-						return &Decision{
+						return &frontend_connectors.Decision{
 							Reason: "Unsupported configuration",
 							Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported pipeline: %s", pipeline)),
 						}
 					}
 
-					return &Decision{
+					return &frontend_connectors.Decision{
 						Reason: "Unsupported configuration",
 						Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("unsupported configuration for pipeline %s, targets: %v", pipeline, targets)),
 					}
 
 				default:
-					return &Decision{
+					return &frontend_connectors.Decision{
 						Reason: "Unsupported configuration",
 						Err:    end_user_errors.ErrSearchCondition.New(fmt.Errorf("too many backend connector")),
 					}
@@ -253,11 +254,11 @@ func (r *tableRegistryImpl) singleIndex(indexConfig map[string]config.IndexConfi
 	}
 }
 
-func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *Decision {
+func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexConfiguration, pipeline string) func(part string) *frontend_connectors.Decision {
 
-	return func(part string) *Decision {
+	return func(part string) *frontend_connectors.Decision {
 		if part == common_table.TableName {
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Err:    fmt.Errorf("common table is not allowed to be queried directly"),
 				Reason: "It's internal table. Not allowed to be queried directly.",
 			}
@@ -275,8 +276,8 @@ func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexC
 		}
 
 		if idxConfig, ok := cfg[part]; (ok && idxConfig.UseCommonTable) || (virtualTableExists) {
-			return &Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			return &frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: common_table.TableName,
 					ClickhouseTables:    []string{part},
 					IsCommonTable:       true,
@@ -289,26 +290,26 @@ func (r *tableRegistryImpl) makeCommonTableResolver(cfg map[string]config.IndexC
 	}
 }
 
-func mergeUseConnectors(lhs []ConnectorDecision, rhs []ConnectorDecision, rhsIndexName string) ([]ConnectorDecision, *Decision) {
+func mergeUseConnectors(lhs []frontend_connectors.ConnectorDecision, rhs []frontend_connectors.ConnectorDecision, rhsIndexName string) ([]frontend_connectors.ConnectorDecision, *frontend_connectors.Decision) {
 	for _, connDecisionRhs := range rhs {
 		foundMatching := false
 		for _, connDecisionLhs := range lhs {
-			if _, ok := connDecisionRhs.(*ConnectorDecisionElastic); ok {
-				if _, ok := connDecisionLhs.(*ConnectorDecisionElastic); ok {
+			if _, ok := connDecisionRhs.(*frontend_connectors.ConnectorDecisionElastic); ok {
+				if _, ok := connDecisionLhs.(*frontend_connectors.ConnectorDecisionElastic); ok {
 					foundMatching = true
 				}
 			}
-			if rhsClickhouse, ok := connDecisionRhs.(*ConnectorDecisionClickhouse); ok {
-				if lhsClickhouse, ok := connDecisionLhs.(*ConnectorDecisionClickhouse); ok {
+			if rhsClickhouse, ok := connDecisionRhs.(*frontend_connectors.ConnectorDecisionClickhouse); ok {
+				if lhsClickhouse, ok := connDecisionLhs.(*frontend_connectors.ConnectorDecisionClickhouse); ok {
 					if lhsClickhouse.ClickhouseTableName != rhsClickhouse.ClickhouseTableName {
-						return nil, &Decision{
+						return nil, &frontend_connectors.Decision{
 							Reason: "Incompatible decisions for two indexes - they use a different ClickHouse table",
 							Err:    fmt.Errorf("incompatible decisions for two indexes (different ClickHouse table) - %s and %s", connDecisionRhs, connDecisionLhs),
 						}
 					}
 					if lhsClickhouse.IsCommonTable {
 						if !rhsClickhouse.IsCommonTable {
-							return nil, &Decision{
+							return nil, &frontend_connectors.Decision{
 								Reason: "Incompatible decisions for two indexes - one uses the common table, the other does not",
 								Err:    fmt.Errorf("incompatible decisions for two indexes (common table usage) - %s and %s", connDecisionRhs, connDecisionLhs),
 							}
@@ -317,7 +318,7 @@ func mergeUseConnectors(lhs []ConnectorDecision, rhs []ConnectorDecision, rhsInd
 						lhsClickhouse.ClickhouseTables = util.Distinct(lhsClickhouse.ClickhouseTables)
 					} else {
 						if !reflect.DeepEqual(lhsClickhouse, rhsClickhouse) {
-							return nil, &Decision{
+							return nil, &frontend_connectors.Decision{
 								Reason: "Incompatible decisions for two indexes - they use ClickHouse tables differently",
 								Err:    fmt.Errorf("incompatible decisions for two indexes (different usage of ClickHouse) - %s and %s", connDecisionRhs, connDecisionLhs),
 							}
@@ -328,7 +329,7 @@ func mergeUseConnectors(lhs []ConnectorDecision, rhs []ConnectorDecision, rhsInd
 			}
 		}
 		if !foundMatching {
-			return nil, &Decision{
+			return nil, &frontend_connectors.Decision{
 				Reason: "Incompatible decisions for two indexes - they use different connectors",
 				Err:    fmt.Errorf("incompatible decisions for two indexes - they use different connectors: could not find connector %s used for index %s in decisions: %s", connDecisionRhs, rhsIndexName, lhs),
 			}
@@ -338,9 +339,9 @@ func mergeUseConnectors(lhs []ConnectorDecision, rhs []ConnectorDecision, rhsInd
 	return lhs, nil
 }
 
-func basicDecisionMerger(decisions []*Decision) *Decision {
+func basicDecisionMerger(decisions []*frontend_connectors.Decision) *frontend_connectors.Decision {
 	if len(decisions) == 0 {
-		return &Decision{
+		return &frontend_connectors.Decision{
 			IsEmpty: true,
 			Reason:  "No indexes matched, no decisions made.",
 		}
@@ -351,7 +352,7 @@ func basicDecisionMerger(decisions []*Decision) *Decision {
 
 	for _, decision := range decisions {
 		if decision == nil {
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Reason: "Got a nil decision. This is a bug.",
 				Err:    fmt.Errorf("could not resolve index"),
 			}
@@ -362,21 +363,21 @@ func basicDecisionMerger(decisions []*Decision) *Decision {
 		}
 
 		if decision.IsEmpty {
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Reason: "Got an empty decision. This is a bug.",
 				Err:    fmt.Errorf("could not resolve index, empty index: %s", decision.IndexPattern),
 			}
 		}
 
 		if decision.EnableABTesting != decisions[0].EnableABTesting {
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Reason: "One of the indexes matching the pattern does A/B testing, while another index does not - inconsistency.",
 				Err:    fmt.Errorf("inconsistent A/B testing configuration - index %s (A/B testing: %v) and index %s (A/B testing: %v)", decision.IndexPattern, decision.EnableABTesting, decisions[0].IndexPattern, decisions[0].EnableABTesting),
 			}
 		}
 	}
 
-	var nonClosedDecisions []*Decision
+	var nonClosedDecisions []*frontend_connectors.Decision
 	for _, decision := range decisions {
 		if !decision.IsClosed {
 			nonClosedDecisions = append(nonClosedDecisions, decision)
@@ -384,7 +385,7 @@ func basicDecisionMerger(decisions []*Decision) *Decision {
 	}
 	if len(nonClosedDecisions) == 0 {
 		// All indexes are closed
-		return &Decision{
+		return &frontend_connectors.Decision{
 			IsClosed: true,
 			Reason:   "All indexes matching the pattern are closed.",
 		}
@@ -399,7 +400,7 @@ func basicDecisionMerger(decisions []*Decision) *Decision {
 			continue
 		}
 		if len(decision.UseConnectors) != len(decisions[0].UseConnectors) {
-			return &Decision{
+			return &frontend_connectors.Decision{
 				Reason: "Inconsistent number of connectors",
 				Err:    fmt.Errorf("inconsistent number of connectors - index %s (%d connectors) and index %s (%d connectors)", decision.IndexPattern, len(decision.UseConnectors), decisions[0].IndexPattern, len(decisions[0].UseConnectors)),
 			}
@@ -412,7 +413,7 @@ func basicDecisionMerger(decisions []*Decision) *Decision {
 		useConnectors = newUseConnectors
 	}
 
-	return &Decision{
+	return &frontend_connectors.Decision{
 		UseConnectors:   useConnectors,
 		EnableABTesting: decisions[0].EnableABTesting,
 		Reason:          "Merged decisions",

--- a/quesma/table_resolver/table_resolver_test.go
+++ b/quesma/table_resolver/table_resolver_test.go
@@ -9,6 +9,7 @@ import (
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/elasticsearch"
+	"quesma/frontend_connectors"
 	"quesma/quesma/config"
 	"reflect"
 	"strings"
@@ -64,105 +65,105 @@ func TestTableResolver(t *testing.T) {
 		clickhouseIndexes []string
 		virtualTables     []string
 		indexConf         map[string]config.IndexConfiguration
-		expected          Decision
+		expected          frontend_connectors.Decision
 	}{
 		{
 			name:     "elastic fallback",
-			pipeline: IngestPipeline,
+			pipeline: frontend_connectors.IngestPipeline,
 			pattern:  "some-index",
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: make(map[string]config.IndexConfiguration),
 		},
 		{
 			name:     "all",
-			pipeline: QueryPipeline,
+			pipeline: frontend_connectors.QueryPipeline,
 			pattern:  "*",
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf("inconsistent A/B testing configuration"),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "empty *",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "*",
 			clickhouseIndexes: []string{"index1", "index2"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "query all, indices in both connectors",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "*",
 			clickhouseIndexes: []string{"index1", "index2"},
 			elasticIndexes:    []string{"index3"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "ingest with a pattern",
-			pipeline:          IngestPipeline,
+			pipeline:          frontend_connectors.IngestPipeline,
 			pattern:           "*",
 			clickhouseIndexes: []string{"index1", "index2"},
 			elasticIndexes:    []string{"index3"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf("pattern is not allowed"),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "query closed index",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "closed",
 			clickhouseIndexes: []string{"closed"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				IsClosed: true,
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "ingest closed index",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "closed",
 			clickhouseIndexes: []string{"closed"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				IsClosed: true,
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "ingest closed index",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "closed-common-table",
 			clickhouseIndexes: []string{"closed"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				IsClosed: true,
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "ingest closed index",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "unknown-target",
 			clickhouseIndexes: []string{"closed"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf("unsupported target"),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "ingest to index1",
-			pipeline:          IngestPipeline,
+			pipeline:          frontend_connectors.IngestPipeline,
 			pattern:           "index1",
 			clickhouseIndexes: []string{"index1"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "index1",
 					ClickhouseTables:    []string{"index1"}},
 				},
@@ -171,11 +172,11 @@ func TestTableResolver(t *testing.T) {
 		},
 		{
 			name:              "query from index1",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "index1",
 			clickhouseIndexes: []string{"index1"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "index1",
 					ClickhouseTables:    []string{"index1"}},
 				},
@@ -184,11 +185,11 @@ func TestTableResolver(t *testing.T) {
 		},
 		{
 			name:              "ingest to index2",
-			pipeline:          IngestPipeline,
+			pipeline:          frontend_connectors.IngestPipeline,
 			pattern:           "index2",
 			clickhouseIndexes: []string{"index2"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: common_table.TableName,
 					ClickhouseTables:    []string{"index2"},
 					IsCommonTable:       true,
@@ -198,11 +199,11 @@ func TestTableResolver(t *testing.T) {
 		},
 		{
 			name:              "query from index2",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "index2",
 			clickhouseIndexes: []string{"index2"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: common_table.TableName,
 					ClickhouseTables:    []string{"index2"},
 					IsCommonTable:       true,
@@ -212,52 +213,52 @@ func TestTableResolver(t *testing.T) {
 		},
 		{
 			name:           "query from index1,index2",
-			pipeline:       QueryPipeline,
+			pipeline:       frontend_connectors.QueryPipeline,
 			pattern:        "index1,index2",
 			elasticIndexes: []string{"index3"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf(""),
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:           "query from index1,index-not-existing",
-			pipeline:       QueryPipeline,
+			pipeline:       frontend_connectors.QueryPipeline,
 			pattern:        "index1,index-not-existing",
 			elasticIndexes: []string{"index1,index-not-existing"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf(""), // index1 in Clickhouse, index-not-existing in Elastic ('*')
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:           "ingest to index3",
-			pipeline:       IngestPipeline,
+			pipeline:       frontend_connectors.IngestPipeline,
 			pattern:        "index3",
 			elasticIndexes: []string{"index3"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:           "query from index3",
-			pipeline:       QueryPipeline,
+			pipeline:       frontend_connectors.QueryPipeline,
 			pattern:        "index3",
 			elasticIndexes: []string{"index3"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 
 		{
 			name:          "query pattern",
-			pipeline:      QueryPipeline,
+			pipeline:      frontend_connectors.QueryPipeline,
 			pattern:       "index2,foo*",
 			virtualTables: []string{"index2"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: common_table.TableName,
 					ClickhouseTables:    []string{"index2"},
 					IsCommonTable:       true,
@@ -267,108 +268,108 @@ func TestTableResolver(t *testing.T) {
 		},
 		{
 			name:     "query kibana internals",
-			pipeline: QueryPipeline,
+			pipeline: frontend_connectors.QueryPipeline,
 			pattern:  ".kibana",
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{ManagementCall: true}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{ManagementCall: true}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:     "ingest kibana internals",
-			pipeline: IngestPipeline,
+			pipeline: frontend_connectors.IngestPipeline,
 			pattern:  ".kibana",
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{ManagementCall: true}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{ManagementCall: true}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:     "ingest not configured index",
-			pipeline: IngestPipeline,
+			pipeline: frontend_connectors.IngestPipeline,
 			pattern:  "not-configured",
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{}},
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:     "double write",
-			pipeline: IngestPipeline,
+			pipeline: frontend_connectors.IngestPipeline,
 			pattern:  "logs",
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "logs",
 					ClickhouseTables:    []string{"logs"},
 				},
-					&ConnectorDecisionElastic{}},
+					&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:     "A/B testing",
-			pipeline: QueryPipeline,
+			pipeline: frontend_connectors.QueryPipeline,
 			pattern:  "logs",
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				EnableABTesting: true,
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "logs",
 					ClickhouseTables:    []string{"logs"},
 				},
-					&ConnectorDecisionElastic{}},
+					&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:     "A/B testing (pattern)",
-			pipeline: QueryPipeline,
+			pipeline: frontend_connectors.QueryPipeline,
 			pattern:  "logs*",
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				EnableABTesting: true,
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionClickhouse{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionClickhouse{
 					ClickhouseTableName: "logs",
 					ClickhouseTables:    []string{"logs"},
 				},
-					&ConnectorDecisionElastic{}},
+					&frontend_connectors.ConnectorDecisionElastic{}},
 			},
 			indexConf: indexConf,
 		},
 		{
 			name:              "query both connectors",
-			pipeline:          QueryPipeline,
+			pipeline:          frontend_connectors.QueryPipeline,
 			pattern:           "logs,index1",
 			indexConf:         indexConf,
 			clickhouseIndexes: []string{"index1"},
 			elasticIndexes:    []string{"logs"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf(""),
 			},
 		},
 		{
 			name:           "query elastic with pattern",
-			pipeline:       QueryPipeline,
+			pipeline:       frontend_connectors.QueryPipeline,
 			pattern:        "some-elastic-logs*",
 			elasticIndexes: []string{"logs"},
-			expected: Decision{
-				UseConnectors: []ConnectorDecision{&ConnectorDecisionElastic{
+			expected: frontend_connectors.Decision{
+				UseConnectors: []frontend_connectors.ConnectorDecision{&frontend_connectors.ConnectorDecisionElastic{
 					ManagementCall: false,
 				}},
 			},
 		},
 		{
 			name:           "non matching pattern",
-			pipeline:       QueryPipeline,
+			pipeline:       frontend_connectors.QueryPipeline,
 			pattern:        "some-non-matching-pattern*",
 			elasticIndexes: []string{"logs"},
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				IsEmpty: true,
 			},
 		},
 		{
 			name:     "query internal index",
-			pipeline: QueryPipeline,
+			pipeline: frontend_connectors.QueryPipeline,
 			pattern:  "quesma_common_table",
-			expected: Decision{
+			expected: frontend_connectors.Decision{
 				Err: fmt.Errorf("common table"),
 			},
 		},


### PR DESCRIPTION
This is prerequisite for moving `mux.PathRouter` to `frontend_connectors` and integrate it with the new API