### PR TITLE
Add placeholder value for `buildinfo.BuildDate`

### DIFF
--- a/quesma/buildinfo/build.go
+++ b/quesma/buildinfo/build.go
@@ -12,7 +12,7 @@ import (
 
 var Version = "development"
 var BuildHash = ""
-var BuildDate = ""
+var BuildDate = time.Now().Format("2006-01-02")
 
 const GitHubLatestReleaseURL = "https://api.github.com/repos/quesma/quesma/releases/latest"
 


### PR DESCRIPTION
Fixes telemetry date for local builds