### PR TITLE
Initialize processors

### DIFF
--- a/quesma/main.go
+++ b/quesma/main.go
@@ -92,18 +92,16 @@ func buildIngestOnlyQuesma() quesma_api.QuesmaBuilder {
 	return quesmaInstance
 }
 
-// /* Example of how to use the v2 module api in main function
+// Example of how to use the v2 module api in main function
+//func main() {
+//	q1 := buildIngestOnlyQuesma()
+//	q1.Start()
+//	stop := make(chan os.Signal, 1)
+//	<-stop
+//	q1.Stop(context.Background())
+//}
+
 func main() {
-	q1 := buildIngestOnlyQuesma()
-	q1.Start()
-	stop := make(chan os.Signal, 1)
-	<-stop
-	q1.Stop(context.Background())
-}
-
-//*/
-
-func main2() {
 	if EnableConcurrencyProfiling {
 		runtime.SetBlockProfileRate(1)
 		runtime.SetMutexProfileFraction(1)

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -92,17 +92,18 @@ func buildIngestOnlyQuesma() quesma_api.QuesmaBuilder {
 	return quesmaInstance
 }
 
-/* Example of how to use the v2 module api in main function
-func main2() {
+// /* Example of how to use the v2 module api in main function
+func main() {
 	q1 := buildIngestOnlyQuesma()
 	q1.Start()
 	stop := make(chan os.Signal, 1)
 	<-stop
 	q1.Stop(context.Background())
 }
-*/
 
-func main() {
+//*/
+
+func main2() {
 	if EnableConcurrencyProfiling {
 		runtime.SetBlockProfileRate(1)
 		runtime.SetMutexProfileFraction(1)

--- a/quesma/processors/base_processor.go
+++ b/quesma/processors/base_processor.go
@@ -21,6 +21,10 @@ func (p *BaseProcessor) AddProcessor(proc quesma_api.Processor) {
 	p.InnerProcessors = append(p.InnerProcessors, proc)
 }
 
+func (p *BaseProcessor) Init() error {
+	return nil
+}
+
 func (p *BaseProcessor) GetProcessors() []quesma_api.Processor {
 	return p.InnerProcessors
 }

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -71,6 +71,7 @@ type Processor interface {
 	SetBackendConnectors(conns map[BackendConnectorType]BackendConnector)
 	GetBackendConnector(connectorType BackendConnectorType) BackendConnector
 	GetSupportedBackendConnectors() []BackendConnectorType
+	Init() error
 }
 
 type Rows interface {

--- a/quesma/v2/core/quesma_builder.go
+++ b/quesma/v2/core/quesma_builder.go
@@ -96,6 +96,9 @@ func (quesma *Quesma) Build() (QuesmaBuilder, error) {
 				}
 			}
 			proc.SetBackendConnectors(backendConnectors)
+			if err := proc.Init(); err != nil {
+				return nil, fmt.Errorf("processor %v failed to initialize: %v", proc.GetId(), err)
+			}
 		}
 
 	}


### PR DESCRIPTION
Two things:
* Temporarily remove embedding of `BasicHTTPFrontendConnector` which caused issues
* Adds `Init()` function to processor where one can perform actions **after** processor has been fully set up - has all the connectors, etc.