### PR TITLE
Fix Avg/Sum over Datetime column

### DIFF
--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -724,6 +724,50 @@ func (s *SchemaCheckPass) convertQueryDateTimeFunctionToClickhouse(indexSchema s
 
 }
 
+func (s *SchemaCheckPass) checkAggOverUnsupportedType(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
+
+	aggFunctionPrefixes := []string{"sum", "avg"}
+
+	dbTypes := []string{"DateTime"}
+
+	visitor := model.NewBaseVisitor()
+
+	visitor.OverrideVisitFunction = func(b *model.BaseExprVisitor, e model.FunctionExpr) interface{} {
+
+		fnName := strings.ToLower(e.Name)
+
+		for _, prefix := range aggFunctionPrefixes {
+
+			if strings.HasPrefix(fnName, prefix) {
+				if len(e.Args) > 1 {
+					if columnRef, ok := e.Args[0].(model.ColumnRef); ok {
+						if col, ok := indexSchema.ResolveFieldByInternalName(columnRef.ColumnName); ok {
+							for _, dbType := range dbTypes {
+								if strings.HasPrefix(col.InternalPropertyType, dbType) {
+									logger.Warn().Msgf("Aggregation '%s' over unsupported type %s in column %s", e.Name, dbType, col.InternalPropertyName.AsString())
+									args := b.VisitChildren(e.Args)
+									args[1] = model.NewLiteral("NULL")
+									return model.NewFunction(e.Name, args...)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return model.NewFunction(e.Name, b.VisitChildren(e.Args)...)
+	}
+
+	expr := query.SelectCommand.Accept(visitor)
+
+	if _, ok := expr.(*model.SelectCommand); ok {
+		query.SelectCommand = *expr.(*model.SelectCommand)
+	}
+	return query, nil
+
+}
+
 func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, error) {
 
 	transformationChain := []struct {
@@ -752,6 +796,7 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 		{TransformationName: "ArrayTransformation", Transformation: s.applyArrayTransformations},
 		{TransformationName: "MapTransformation", Transformation: s.applyMapTransformations},
 		{TransformationName: "MatchOperatorTransformation", Transformation: s.applyMatchOperator},
+		{TransformationName: "AggOverUnsupportedType", Transformation: s.checkAggOverUnsupportedType},
 
 		// Section 4: compensations and checks
 		{TransformationName: "BooleanLiteralTransformation", Transformation: s.applyBooleanLiteralLowering},

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -1083,3 +1083,105 @@ func Test_applyMatchOperator(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkAggOverUnsupportedType(t *testing.T) {
+	schemaTable := schema.Table{
+		Columns: map[string]schema.Column{
+			"@timestamp": {Name: "@timestamp", Type: "DateTime64"},
+			"message":    {Name: "message", Type: "String"},
+			"count":      {Name: "count", Type: "Int64"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		query    *model.Query
+		expected *model.Query
+	}{
+		{
+			name: "String",
+			query: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewColumnRef("message"))},
+				},
+			},
+			expected: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewLiteral("NULL"))},
+				},
+			},
+		},
+		{
+			name: "do not int field",
+			query: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewColumnRef("count"))},
+				},
+			},
+			expected: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewColumnRef("count"))},
+				},
+			},
+		},
+		{
+			name: "DateTime",
+			query: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewColumnRef("@timestamp"))},
+				},
+			},
+			expected: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewFunction("sum", model.NewLiteral("NULL"))},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tableDiscovery :=
+				fixedTableProvider{tables: map[string]schema.Table{
+					"test": schemaTable,
+				}}
+
+			indexConfig := map[string]config.IndexConfiguration{
+				"test": {
+					Name: "test",
+				},
+			}
+
+			cfg := config.QuesmaConfiguration{
+				IndexConfig: indexConfig,
+			}
+
+			s := schema.NewSchemaRegistry(tableDiscovery, &cfg, clickhouse.SchemaTypeAdapter{})
+			transform := &SchemaCheckPass{cfg: &cfg}
+
+			indexSchema, ok := s.FindSchema("test")
+			if !ok {
+				t.Fatal("schema not found")
+			}
+
+			actual, err := transform.checkAggOverUnsupportedType(indexSchema, tt.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, model.AsString(tt.expected.SelectCommand), model.AsString(actual.SelectCommand))
+		})
+	}
+}


### PR DESCRIPTION
Our queries fail if we try to do `sum` or `avg`  over a string or date column. This PR detects and compensates (adds a hack) it.