### PR TITLE
Add split_time_range optimizer

### DIFF
--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -11,6 +11,7 @@ import (
 	"quesma/end_user_errors"
 	"quesma/logger"
 	"quesma/model"
+	"quesma/quesma/recovery"
 	tracing "quesma_v2/core/tracing"
 	"strconv"
 	"strings"
@@ -234,6 +235,7 @@ func read(ctx context.Context, rows *sql.Rows, selectFields []string, rowToScan 
 		return nil, fmt.Errorf("clickhouse: iterating over rows failed:  %v", rows.Err())
 	}
 	go func() {
+		recovery.LogPanicWithCtx(ctx)
 		err := rows.Close()
 		if err != nil {
 			logger.ErrorWithCtx(ctx).Msgf("clickhouse: closing rows failed: %v", err)

--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -59,10 +59,11 @@ func (lm *LogManager) ProcessQuery(ctx context.Context, table *Table, query *mod
 			colName = col.Alias
 		case model.LiteralExpr:
 
-			// This should be moved to the SchemaCheck pipeline. It'll require to change a lot of tests.
+			// There's now a AliasColumnsTransformation transformation that handles this,
+			// but it's not fully complete as it'll require to change a lot more tests.
 			//
-			// It can be removed just after the pancake will be the only way to generate SQL.
-			// Pancake SQL are aliased properly.
+			// The only remaining issue is that Pancake SQLs sometimes generate LiteralExpr in SELECT
+			// instead of ColumnRef (nested SQLs case).
 
 			if str, isStr := col.Value.(string); isStr {
 				if unquoted, err := strconv.Unquote(str); err == nil {
@@ -71,11 +72,15 @@ func (lm *LogManager) ProcessQuery(ctx context.Context, table *Table, query *mod
 					colName = str
 				}
 			} else {
+				// AliasColumnsTransformation should have handled this
+				logger.Warn().Msgf("Unexpected unaliased literal: %v", col.Value)
 				if colName == "" {
 					colName = fmt.Sprintf("column_%d", count)
 				}
 			}
 		default:
+			// AliasColumnsTransformation should have handled this
+			logger.Warn().Msgf("Unexpected unaliased literal: %v", col)
 			if colName == "" {
 				colName = fmt.Sprintf("column_%d", count)
 			}
@@ -188,7 +193,7 @@ func executeQuery(ctx context.Context, lm *LogManager, query *model.Query, field
 		performanceResult.Error = err
 		return nil, performanceResult, end_user_errors.GuessClickhouseErrorType(err).InternalDetails("clickhouse: query failed. err: %v, query: %v", err, queryAsString)
 	}
-	res, err = read(rows, fields, rowToScan)
+	res, err = read(ctx, rows, fields, rowToScan, query.SelectCommand.Limit)
 
 	elapsed := span.End(nil)
 	performanceResult.Duration = elapsed
@@ -204,7 +209,7 @@ func executeQuery(ctx context.Context, lm *LogManager, query *model.Query, field
 
 // 'selectFields' are all values that we return from the query, both columns and non-schema fields,
 // like e.g. count(), or toInt8(boolField)
-func read(rows *sql.Rows, selectFields []string, rowToScan []interface{}) ([]model.QueryResultRow, error) {
+func read(ctx context.Context, rows *sql.Rows, selectFields []string, rowToScan []interface{}, limit int) ([]model.QueryResultRow, error) {
 
 	// read selected fields from the metadata
 
@@ -213,7 +218,8 @@ func read(rows *sql.Rows, selectFields []string, rowToScan []interface{}) ([]mod
 		rowDb = append(rowDb, &rowToScan[i])
 	}
 	resultRows := make([]model.QueryResultRow, 0)
-	for rows.Next() {
+	// If a limit is set (limit != 0) then collect only the first 'limit' rows
+	for (len(resultRows) < limit || limit == 0) && rows.Next() {
 		err := rows.Scan(rowDb...)
 		if err != nil {
 			return nil, fmt.Errorf("clickhouse: scan failed: %v", err)
@@ -227,9 +233,11 @@ func read(rows *sql.Rows, selectFields []string, rowToScan []interface{}) ([]mod
 	if rows.Err() != nil {
 		return nil, fmt.Errorf("clickhouse: iterating over rows failed:  %v", rows.Err())
 	}
-	err := rows.Close()
-	if err != nil {
-		return nil, fmt.Errorf("clickhouse: closing rows failed: %v", err)
-	}
+	go func() {
+		err := rows.Close()
+		if err != nil {
+			logger.ErrorWithCtx(ctx).Msgf("clickhouse: closing rows failed: %v", err)
+		}
+	}()
 	return resultRows, nil
 }

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -84,7 +84,7 @@ func (v *renderer) VisitInfix(e InfixExpr) interface{} {
 	// I think in the future every infix op should be in braces.
 	if strings.HasPrefix(e.Op, "_") || e.Op == "AND" || e.Op == "OR" {
 		return fmt.Sprintf("(%v %v %v)", lhs, e.Op, rhs)
-	} else if strings.Contains(e.Op, "LIKE") || e.Op == "IS" || e.Op == "IN" || e.Op == "REGEXP" {
+	} else if strings.Contains(e.Op, "LIKE") || e.Op == "IS" || e.Op == "IN" || e.Op == "REGEXP" || strings.Contains(e.Op, "UNION") {
 		return fmt.Sprintf("%v %v %v", lhs, e.Op, rhs)
 	} else {
 		return fmt.Sprintf("%v%v%v", lhs, e.Op, rhs)
@@ -191,13 +191,17 @@ func (v *renderer) VisitSelectCommand(c SelectCommand) interface{} {
 		sb.WriteString(" FROM ")
 	}
 	/* HACK ALERT END */
-	if c.FromClause != nil { // here we have to handle nested
-		if nestedCmd, isNested := c.FromClause.(SelectCommand); isNested {
-			sb.WriteString(fmt.Sprintf("(%s)", AsString(nestedCmd)))
-		} else if nestedCmdPtr, isNested := c.FromClause.(*SelectCommand); isNested {
-			sb.WriteString(fmt.Sprintf("(%s)", AsString(nestedCmdPtr)))
-		} else {
+	if c.FromClause != nil {
+		// Non-nested FROM clauses don't have to be wrapped in parentheses
+		if _, isTableRef := c.FromClause.(TableRef); isTableRef {
 			sb.WriteString(AsString(c.FromClause))
+		} else if _, isLiteral := c.FromClause.(LiteralExpr); isLiteral {
+			sb.WriteString(AsString(c.FromClause))
+		} else if _, isJoinExpr := c.FromClause.(JoinExpr); isJoinExpr {
+			sb.WriteString(AsString(c.FromClause))
+		} else {
+			// Nested sub-query
+			sb.WriteString(fmt.Sprintf("(%s)", AsString(c.FromClause)))
 		}
 	}
 	if c.WhereClause != nil {

--- a/quesma/optimize/pipeline.go
+++ b/quesma/optimize/pipeline.go
@@ -31,6 +31,7 @@ func NewOptimizePipeline(config *config.QuesmaConfiguration) model.QueryTransfor
 			&truncateDate{truncateTo: 5 * time.Minute},
 			&cacheQueries{},
 			&materializedViewReplace{},
+			&splitTimeRange{},
 		},
 	}
 }

--- a/quesma/optimize/split_time_range.go
+++ b/quesma/optimize/split_time_range.go
@@ -1,0 +1,287 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package optimize
+
+import (
+	"fmt"
+	"quesma/logger"
+	"quesma/model"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Context: We noticed that for some schemas (that don't ORDER BY time), the "Discover" view in Kibana
+// over long time ranges can be very slow, even though it only shows 500 results. Changing the time range
+// to a shorter one can make the query faster. (See this issue in ClickHouse for a similar example:
+// https://github.com/ClickHouse/ClickHouse/issues/69315)
+//
+// This optimization therefore splits the time range into parts: a short time range, on which we bet that the query
+// will be fast (and still return LIMIT many results) and a long time range, which will be used to get the rest of the
+// results (in case the short time range didn't return enough results).
+type splitTimeRange struct{}
+
+var defaultShorterTimeRangesMinutes = []int64{15}
+
+type timeRangeLimit struct {
+	value    int64
+	funcName string // for example fromUnixTimestamp64Milli
+}
+
+type timeRange struct {
+	columnName string
+	lowerLimit timeRangeLimit
+	upperLimit timeRangeLimit
+	direction  model.OrderByDirection
+}
+
+func (s splitTimeRange) validateSelectedColumns(columns []model.Expr) bool {
+	// The main purpose is to disallow window functions for which this optimization might be hard to reason about
+	// (and could be invalid). The allowed Expr types are whitelisted here rather than blacklisted (window functions)
+	// to be less error-prone in the future.
+	for i, column := range columns {
+		if _, ok := column.(model.ColumnRef); ok {
+			continue
+		}
+		if _, ok := column.(model.LiteralExpr); ok {
+			continue
+		}
+		if aliasedExpr, ok := column.(model.AliasedExpr); ok && s.validateSelectedColumns([]model.Expr{aliasedExpr.Expr}) {
+			continue
+		}
+		if functionExpr, ok := column.(model.FunctionExpr); ok && s.validateSelectedColumns(functionExpr.Args) {
+			continue
+		}
+
+		logger.Debug().Msgf("Query not eligible for time range optimization: column at index %d is an unsupported %T", i, column)
+		return false
+	}
+	return true
+}
+
+func (s splitTimeRange) findOrderByColumn(selectCommand *model.SelectCommand) (string, model.OrderByDirection, bool) {
+	if len(selectCommand.OrderBy) != 1 {
+		logger.Debug().Msg("Query not eligible for time range optimization: ORDER BY longer than 1")
+		return "", model.DefaultOrder, false
+	}
+
+	if orderByColumn, ok := selectCommand.OrderBy[0].Expr.(model.ColumnRef); ok {
+		return orderByColumn.ColumnName, selectCommand.OrderBy[0].Direction, true
+	}
+
+	logger.Debug().Msg("Query not eligible for time range optimization: ORDER BY not a column reference")
+	return "", model.DefaultOrder, false
+}
+
+func (s splitTimeRange) checkAndFindTimeLimits(selectCommand *model.SelectCommand, orderByColumnName string) (*timeRangeLimit, *timeRangeLimit) {
+	var lowerLimit, upperLimit *timeRangeLimit
+
+	visitor := model.NewBaseVisitor()
+	visitor.OverrideVisitInfix = func(b *model.BaseExprVisitor, e model.InfixExpr) interface{} {
+		if columnName, ok := e.Left.(model.ColumnRef); ok && columnName.ColumnName == orderByColumnName {
+			switch e.Op {
+			case "<", "<=":
+				if functionExpr, ok := e.Right.(model.FunctionExpr); ok &&
+					(functionExpr.Name == "fromUnixTimestamp64Milli" || functionExpr.Name == "fromUnixTimestamp") {
+					upperBoundValue := functionExpr.Args[0].(model.LiteralExpr).Value.(int64)
+					upperLimit = &timeRangeLimit{value: upperBoundValue, funcName: functionExpr.Name}
+				}
+			case ">", ">=":
+				if functionExpr, ok := e.Right.(model.FunctionExpr); ok &&
+					(functionExpr.Name == "fromUnixTimestamp64Milli" || functionExpr.Name == "fromUnixTimestamp") {
+					lowerBoundValue := functionExpr.Args[0].(model.LiteralExpr).Value.(int64)
+					lowerLimit = &timeRangeLimit{value: lowerBoundValue, funcName: functionExpr.Name}
+				}
+			}
+		} else if e.Op == "AND" {
+			e.Left.Accept(b)
+			e.Right.Accept(b)
+		}
+		return e
+	}
+	selectCommand.Accept(visitor)
+
+	return lowerLimit, upperLimit
+}
+
+func (s splitTimeRange) findTimeRange(selectCommand *model.SelectCommand) *timeRange {
+	// The optimization is not possible for all queries.
+	// Some of those restrictions are not strictly necessary, but added here conservatively to avoid potential issues.
+	if selectCommand.Limit == 0 {
+		logger.Debug().Msg("Query not eligible for time range optimization: LIMIT 0")
+		return nil
+	}
+	if len(selectCommand.LimitBy) != 0 {
+		logger.Debug().Msg("Query not eligible for time range optimization: LIMIT BY")
+		return nil
+	}
+	if selectCommand.SampleLimit != 0 {
+		logger.Debug().Msg("Query not eligible for time range optimization: SAMPLE LIMIT")
+		return nil
+	}
+	if selectCommand.IsDistinct {
+		logger.Debug().Msg("Query not eligible for time range optimization: DISTINCT")
+		return nil
+	}
+	if selectCommand.GroupBy != nil {
+		logger.Debug().Msg("Query not eligible for time range optimization: GROUP BY")
+		return nil
+	}
+	if len(selectCommand.NamedCTEs) != 0 {
+		logger.Debug().Msg("Query not eligible for time range optimization: CTEs")
+		return nil
+	}
+
+	if !s.validateSelectedColumns(selectCommand.Columns) {
+		return nil
+	}
+
+	orderByColumnName, direction, found := s.findOrderByColumn(selectCommand)
+	if !found {
+		return nil
+	}
+	if direction != model.DescOrder {
+		logger.Debug().Msg("Query not eligible for time range optimization: ORDER BY not DESC")
+		return nil
+	}
+
+	lowerLimit, upperLimit := s.checkAndFindTimeLimits(selectCommand, orderByColumnName)
+	if lowerLimit == nil || upperLimit == nil {
+		logger.Debug().Msg("Query not eligible for time range optimization: missing time limits (both lower and upper)")
+		return nil
+	}
+
+	logger.Debug().Msgf("Query eligible for time range optimization on table '%s'", model.AsString(selectCommand.FromClause))
+	return &timeRange{columnName: orderByColumnName, lowerLimit: *lowerLimit, upperLimit: *upperLimit, direction: direction}
+}
+
+func (s splitTimeRange) getSplitPoints(foundTimeRange timeRange, properties map[string]string) []timeRangeLimit {
+	shorterTimeRangesMinutes := defaultShorterTimeRangesMinutes
+	if shorterTimeRangesMinutesStr, ok := properties["ranges"]; ok {
+		shorterTimeRangesMinutesStrList := strings.Split(shorterTimeRangesMinutesStr, ",")
+
+		shorterTimeRangesMinutes = []int64{}
+		for _, shorterTimeRangeMinutesStr := range shorterTimeRangesMinutesStrList {
+			parsedTimeRange, err := strconv.Atoi(shorterTimeRangeMinutesStr)
+			if err != nil {
+				logger.Error().Msgf("Failed to parse time range: %s", err)
+			}
+			shorterTimeRangesMinutes = append(shorterTimeRangesMinutes, int64(parsedTimeRange))
+		}
+	}
+
+	result := []timeRangeLimit{foundTimeRange.lowerLimit}
+
+	for _, shorterTimeRangeMinute := range shorterTimeRangesMinutes {
+		var splitPoint timeRangeLimit
+		if foundTimeRange.upperLimit.funcName == "fromUnixTimestamp64Milli" {
+			splitPoint = timeRangeLimit{value: foundTimeRange.upperLimit.value - shorterTimeRangeMinute*time.Minute.Milliseconds(), funcName: foundTimeRange.upperLimit.funcName}
+		} else {
+			splitPoint = timeRangeLimit{value: foundTimeRange.upperLimit.value - shorterTimeRangeMinute*int64(time.Minute.Seconds()), funcName: foundTimeRange.upperLimit.funcName}
+		}
+		if splitPoint.value >= foundTimeRange.lowerLimit.value && splitPoint.value <= foundTimeRange.upperLimit.value {
+			result = append(result, splitPoint)
+		}
+	}
+
+	result = append(result, foundTimeRange.upperLimit)
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].value >= result[j].value
+	})
+	return result
+}
+
+func (s splitTimeRange) transformQuery(query *model.Query, properties map[string]string) (*model.Query, error) {
+	foundTimeRange := s.findTimeRange(&query.SelectCommand)
+	if foundTimeRange == nil {
+		return query, nil
+	}
+
+	splitPoints := s.getSplitPoints(*foundTimeRange, properties)
+	if len(splitPoints) <= 2 {
+		return query, nil
+	}
+
+	var namedCTEs []*model.CTE
+	var subqueries []model.SelectCommand
+
+	for i := 0; i < len(splitPoints)-1; i++ {
+		subquery := query.SelectCommand
+
+		var whereClause model.Expr
+		if i == 0 {
+			// (splitPoint[1], inf)
+			whereClause = model.NewInfixExpr(model.NewColumnRef(foundTimeRange.columnName), ">", model.NewFunction(splitPoints[i+1].funcName, model.NewLiteral(splitPoints[i+1].value)))
+		} else if i == len(splitPoints)-2 {
+			// (-inf, splitPoint[i]]
+			whereClause = model.NewInfixExpr(model.NewColumnRef(foundTimeRange.columnName), "<=", model.NewFunction(splitPoints[i].funcName, model.NewLiteral(splitPoints[i].value)))
+		} else {
+			// (splitPoint[i], splitPoint[i+1]]
+			whereClause = model.NewInfixExpr(model.NewInfixExpr(model.NewColumnRef(foundTimeRange.columnName), "<=", model.NewFunction(splitPoints[i].funcName, model.NewLiteral(splitPoints[i].value))), "AND",
+				model.NewInfixExpr(model.NewColumnRef(foundTimeRange.columnName), ">", model.NewFunction(splitPoints[i+1].funcName, model.NewLiteral(splitPoints[i+1].value))))
+		}
+		subquery.WhereClause = model.NewInfixExpr(whereClause, "AND", subquery.WhereClause)
+
+		namedCTEs = append(namedCTEs, &model.CTE{
+			Name:          fmt.Sprintf("split_time_range_subquery_%d", i),
+			SelectCommand: &subquery,
+		})
+		subqueries = append(subqueries, model.SelectCommand{
+			Columns:    []model.Expr{model.NewLiteral("*")},
+			FromClause: model.NewLiteral(fmt.Sprintf("split_time_range_subquery_%d", i)),
+		})
+	}
+
+	unionExpr := model.NewInfixExpr(subqueries[0], "UNION ALL", subqueries[1])
+	for i := 2; i < len(subqueries); i++ {
+		unionExpr = model.NewInfixExpr(unionExpr, "UNION ALL", subqueries[i])
+	}
+
+	selectedColumns := make([]model.Expr, len(namedCTEs[0].SelectCommand.Columns))
+	for i, column := range namedCTEs[0].SelectCommand.Columns {
+		switch column := (column).(type) {
+		case model.ColumnRef:
+			selectedColumns[i] = model.NewColumnRef(column.ColumnName)
+		case model.LiteralExpr:
+			selectedColumns[i] = model.NewColumnRef(column.Value.(string))
+		case model.AliasedExpr:
+			selectedColumns[i] = model.NewColumnRef(column.Alias)
+		}
+	}
+
+	query.SelectCommand = model.SelectCommand{
+		IsDistinct:  false,
+		Columns:     selectedColumns,
+		FromClause:  unionExpr,
+		WhereClause: nil,
+		GroupBy:     nil,
+		OrderBy:     nil,
+		LimitBy:     nil,
+		Limit:       namedCTEs[0].SelectCommand.Limit,
+		SampleLimit: 0,
+		NamedCTEs:   namedCTEs,
+	}
+
+	return query, nil
+}
+
+func (s splitTimeRange) Transform(queries []*model.Query, properties map[string]string) ([]*model.Query, error) {
+	for i, query := range queries {
+		transformedQuery, err := s.transformQuery(query, properties)
+		if err != nil {
+			return nil, err
+		}
+		queries[i] = transformedQuery
+	}
+	return queries, nil
+}
+
+func (s splitTimeRange) Name() string {
+	return "split_time_range"
+}
+
+func (s splitTimeRange) IsEnabledByDefault() bool {
+	return true
+}

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -625,7 +625,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 				if len(processedConfig.QueryTarget) == 2 {
 					// Turn on A/B testing
-					processedConfig.Optimizers = make(map[string]OptimizerConfiguration)
+					if processedConfig.Optimizers == nil {
+						processedConfig.Optimizers = make(map[string]OptimizerConfiguration)
+					}
 					processedConfig.Optimizers[ElasticABOptimizerName] = OptimizerConfiguration{
 						Disabled:   false,
 						Properties: map[string]string{},
@@ -764,7 +766,9 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 
 			if len(processedConfig.QueryTarget) == 2 {
 				// Turn on A/B testing
-				processedConfig.Optimizers = make(map[string]OptimizerConfiguration)
+				if processedConfig.Optimizers == nil {
+					processedConfig.Optimizers = make(map[string]OptimizerConfiguration)
+				}
 				processedConfig.Optimizers[ElasticABOptimizerName] = OptimizerConfiguration{
 					Disabled:   false,
 					Properties: map[string]string{},

--- a/quesma/quesma/schema_transformer.go
+++ b/quesma/quesma/schema_transformer.go
@@ -845,6 +845,41 @@ func (s *SchemaCheckPass) checkAggOverUnsupportedType(indexSchema schema.Schema,
 
 }
 
+func columnsToAliasedColumns(columns []model.Expr) []model.Expr {
+	aliasedColumns := make([]model.Expr, len(columns))
+	for i, column := range columns {
+		if columnRef, ok := column.(model.ColumnRef); ok {
+			aliasedColumns[i] = columnRef
+			continue
+		}
+		if col, ok := column.(model.LiteralExpr); ok {
+			if _, isStr := col.Value.(string); !isStr {
+				aliasedColumns[i] = model.NewAliasedExpr(column, fmt.Sprintf("column_%d", i))
+			} else {
+				aliasedColumns[i] = col
+			}
+			continue
+		}
+		if aliasedExpr, ok := column.(model.AliasedExpr); ok {
+			aliasedColumns[i] = aliasedExpr
+			continue
+		}
+		if _, ok := column.(model.FunctionExpr); ok {
+			aliasedColumns[i] = model.NewAliasedExpr(column, fmt.Sprintf("column_%d", i))
+			continue
+		}
+
+		aliasedColumns[i] = model.NewAliasedExpr(column, fmt.Sprintf("column_%d", i))
+		logger.Error().Msgf("Quesma internal error - unreachable code: unsupported column type %T", column)
+	}
+	return aliasedColumns
+}
+
+func (s *SchemaCheckPass) applyAliasColumns(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
+	query.SelectCommand.Columns = columnsToAliasedColumns(query.SelectCommand.Columns)
+	return query, nil
+}
+
 func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, error) {
 
 	transformationChain := []struct {
@@ -855,6 +890,7 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 		{TransformationName: "PhysicalFromExpressionTransformation", Transformation: s.applyPhysicalFromExpression},
 		{TransformationName: "WildcardExpansion", Transformation: s.applyWildcardExpansion},
 		{TransformationName: "RuntimeMappings", Transformation: s.applyRuntimeMappings},
+		{TransformationName: "AliasColumnsTransformation", Transformation: s.applyAliasColumns},
 
 		// Section 2: generic schema based transformations
 		//

--- a/quesma/quesma/schema_transformer_test.go
+++ b/quesma/quesma/schema_transformer_test.go
@@ -487,7 +487,7 @@ func Test_arrayType(t *testing.T) {
 					FromClause: model.NewTableRef("kibana_sample_data_ecommerce"),
 					Columns: []model.Expr{
 						model.NewColumnRef("order_date"),
-						model.NewFunction("sumOrNull", model.NewFunction("arrayJoin", model.NewColumnRef("products_quantity"))),
+						model.NewAliasedExpr(model.NewFunction("sumOrNull", model.NewFunction("arrayJoin", model.NewColumnRef("products_quantity"))), "column_1"),
 					},
 					GroupBy: []model.Expr{model.NewColumnRef("order_date")},
 				},
@@ -521,7 +521,7 @@ func Test_arrayType(t *testing.T) {
 					FromClause: model.NewTableRef("kibana_sample_data_ecommerce"),
 					Columns: []model.Expr{
 						model.NewColumnRef("order_date"),
-						model.NewCountFunc(),
+						model.NewAliasedExpr(model.NewCountFunc(), "column_1"),
 					},
 					WhereClause: model.NewFunction(
 						"arrayExists",
@@ -559,7 +559,7 @@ func Test_arrayType(t *testing.T) {
 					FromClause: model.NewTableRef("kibana_sample_data_ecommerce"),
 					Columns: []model.Expr{
 						model.NewColumnRef("order_date"),
-						model.NewCountFunc(),
+						model.NewAliasedExpr(model.NewCountFunc(), "column_1"),
 					},
 					WhereClause: model.NewFunction(
 						"has",

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -17,7 +17,6 @@ import (
 	"quesma/optimize"
 	"quesma/painful"
 	"quesma/queryparser"
-	"quesma/queryparser/query_util"
 	"quesma/quesma/async_search_storage"
 	"quesma/quesma/config"
 	"quesma/quesma/errors"
@@ -191,22 +190,6 @@ func (q *QueryRunner) transformQueries(ctx context.Context, plan *model.Executio
 	return nil
 }
 
-// Deprecated - this method should be examined and potentially removed
-func (q *QueryRunner) checkProperties(ctx context.Context, plan *model.ExecutionPlan, table *clickhouse.Table, queryTranslator IQueryTranslator) ([]byte, error) {
-	queries := plan.Queries
-	if len(queries) > 0 && query_util.IsNonAggregationQuery(queries[0]) {
-		if properties := q.findNonexistingProperties(queries[0], table, queryTranslator); len(properties) > 0 {
-			logger.DebugWithCtx(ctx).Msgf("properties %s not found in table %s", properties, table.Name)
-			if elasticsearch.IsIndexPattern(plan.IndexPattern) {
-				return queryparser.EmptySearchResponse(ctx), nil
-			} else {
-				return nil, fmt.Errorf("properties %s not found in table %s", properties, table.Name)
-			}
-		}
-	}
-	return nil, nil
-}
-
 func (q *QueryRunner) runExecutePlanAsync(ctx context.Context, plan *model.ExecutionPlan, queryTranslator IQueryTranslator, table *clickhouse.Table, doneCh chan asyncSearchWithError, optAsync *AsyncQuery) {
 	go func() {
 		defer recovery.LogAndHandlePanic(ctx, func(err error) {
@@ -260,10 +243,6 @@ func (q *QueryRunner) executePlan(ctx context.Context, plan *model.ExecutionPlan
 	err = q.transformQueries(ctx, plan)
 	if err != nil {
 		return responseBody, err
-	}
-
-	if resp, err := q.checkProperties(ctx, plan, table, queryTranslator); err != nil {
-		return resp, err
 	}
 
 	q.runExecutePlanAsync(ctx, plan, queryTranslator, table, doneCh, optAsync)
@@ -811,30 +790,6 @@ func (q *QueryRunner) searchWorker(ctx context.Context,
 func (q *QueryRunner) Close() {
 	q.cancel()
 	logger.Info().Msg("queryRunner Stopped")
-}
-
-func (q *QueryRunner) findNonexistingProperties(query *model.Query, table *clickhouse.Table, queryTranslator IQueryTranslator) []string {
-	// this is not fully correct, but we keep it backward compatible
-	var results = make([]string, 0)
-	var allReferencedFields = make([]string, 0)
-	for _, col := range query.SelectCommand.Columns {
-		for _, c := range model.GetUsedColumns(col) {
-			allReferencedFields = append(allReferencedFields, c.ColumnName)
-		}
-	}
-	allReferencedFields = append(allReferencedFields, query.SelectCommand.OrderByFieldNames()...)
-
-	// TODO This should be done using query.Schema instead of table
-	for _, property := range allReferencedFields {
-		queryTranslatorValue, ok := queryTranslator.(*queryparser.ClickhouseQueryTranslator)
-		if ok {
-			property = queryTranslatorValue.ResolveField(q.executionCtx, property)
-		}
-		if property != "*" && !table.HasColumn(q.executionCtx, property) {
-			results = append(results, property)
-		}
-	}
-	return results
 }
 
 func (q *QueryRunner) postProcessResults(plan *model.ExecutionPlan, results [][]model.QueryResultRow) ([][]model.QueryResultRow, error) {

--- a/quesma/testdata/full_search_requests.go
+++ b/quesma/testdata/full_search_requests.go
@@ -8,10 +8,10 @@ import (
 )
 
 func selectCnt(limit int) string {
-	return fmt.Sprintf(`SELECT count(*) FROM (SELECT 1 FROM %s LIMIT %d)`, TableName, limit)
+	return fmt.Sprintf(`SELECT count(*) AS "column_0" FROM (SELECT 1 FROM %s LIMIT %d)`, TableName, limit)
 }
 func selectTotalCnt() string {
-	return fmt.Sprintf("SELECT count(*) FROM %s", TableName)
+	return fmt.Sprintf(`SELECT count(*) AS "column_0" FROM %s`, TableName)
 }
 func selectStar(limit int) string {
 	return fmt.Sprintf("SELECT \"message\" FROM %s LIMIT %d", TableName, limit)

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -310,7 +310,7 @@ var TestsAsyncSearch = []AsyncSearchTestCase{
 			  AND "message" iLIKE '%user%') AND "message" IS NOT NULL)
 			ORDER BY "@timestamp" DESC
 			LIMIT 100`,
-			`SELECT count(*)
+			`SELECT count(*) AS "column_0"
 			FROM __quesma_table_name
 			WHERE ((("@timestamp">=fromUnixTimestamp64Milli(1706020999481) AND "@timestamp"<=fromUnixTimestamp64Milli(1706021899481)) 
 			  AND "message" iLIKE '%user%') AND "message" IS NOT NULL)`,
@@ -988,7 +988,7 @@ var TestsSearch = []SearchTestCase{
 		model.ListAllFields,
 		[]string{
 			`SELECT "message" FROM ` + TableName + ` WHERE "type"='task' LIMIT 10`,
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 		},
 		[]string{},
 	},
@@ -1018,7 +1018,7 @@ var TestsSearch = []SearchTestCase{
 		model.ListAllFields,
 		[]string{
 			`SELECT "message" FROM ` + TableName + ` WHERE ("type"='task' AND "task.enabled" IN (true,54)) LIMIT 10`,
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 		},
 		[]string{},
 	},
@@ -1060,7 +1060,7 @@ var TestsSearch = []SearchTestCase{
 			`SELECT "message" FROM ` + TableName + ` WHERE ("message" iLIKE '%user%' ` +
 				`AND ("@timestamp">=fromUnixTimestamp64Milli(1705487298815) AND "@timestamp"<=fromUnixTimestamp64Milli(1705488198815))) ` +
 				`LIMIT 10`,
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 		},
 		[]string{},
 	},
@@ -1099,7 +1099,7 @@ var TestsSearch = []SearchTestCase{
 			`SELECT "message" FROM ` + TableName + ` WHERE ((("user.id"='kimchy' AND "tags"='production') ` +
 				`AND ("tags"='env1' OR "tags"='deployed')) AND NOT (("age".=.0 AND "age".=.0))) ` +
 				`LIMIT 10`,
-			`SELECT count(*) FROM ` + TableName + ` ` +
+			`SELECT count(*) AS "column_0" FROM ` + TableName + ` ` +
 				`WHERE ((("user.id"='kimchy' AND "tags"='production') ` +
 				`AND ("tags"='env1' OR "tags"='deployed')) AND NOT (("age".=.0 AND "age".=.0)))`,
 		},
@@ -1384,7 +1384,7 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListAllFields,
 		[]string{
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 			`SELECT "message" FROM ` + TableName,
 		},
 		[]string{},
@@ -1974,7 +1974,7 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListByField,
 		[]string{
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 			`SELECT "message" FROM ` + TableName + ` LIMIT 500`,
 		},
 		[]string{},
@@ -1993,7 +1993,7 @@ var TestsSearch = []SearchTestCase{
 		[]string{``},
 		model.ListAllFields,
 		[]string{
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 			`SELECT "message" FROM ` + TableName + ` LIMIT 10`,
 		},
 		[]string{},
@@ -2049,7 +2049,7 @@ var TestsSearch = []SearchTestCase{
 		[]string{``},
 		model.ListAllFields,
 		[]string{
-			`SELECT count(*) FROM ` + TableName,
+			`SELECT count(*) AS "column_0" FROM ` + TableName,
 			`SELECT "message" FROM ` + TableName,
 		},
 		[]string{},
@@ -2094,7 +2094,7 @@ var TestsSearch = []SearchTestCase{
 		[]string{""},
 		model.ListAllFields,
 		[]string{
-			`SELECT count(*) FROM (SELECT 1 FROM ` + TableName + ` LIMIT 10000)`,
+			`SELECT count(*) AS "column_0" FROM (SELECT 1 FROM ` + TableName + ` LIMIT 10000)`,
 			`SELECT "message" FROM __quesma_table_name LIMIT 10`,
 		},
 		[]string{},


### PR DESCRIPTION
Context: We noticed that for some schemas (that don't ORDER BY time), the "Discover" view in Kibana over long time ranges can be very slow, even though it only shows 500 results. Changing the time range to a shorter one can make the query faster. (See this issue in ClickHouse for a similar example: https://github.com/ClickHouse/ClickHouse/issues/69315)

This optimization therefore splits the time range into parts: a short time range, on which we bet that the query will be fast (and still return LIMIT many results) and a long time range, which will be used to get the rest of the results (in case the short time range didn't return enough results). The ranges are customizable (potentially even more than 2).

During the development I also fixed two related problems:
- added `AliasColumnsTransformation` which makes sure that the queries we generate have columns with clear names (so that I can reference them when they are in subquery)
- `read` from ClickHouse now only reads `LIMIT` many rows and closes `Rows` asynchronously (don't wait for query completion if we read `LIMIT` many rows)