### PR TITLE
Fix NOTICE.MD generator for quesma_v2 "dependency"

### DIFF
--- a/.github/workflows/generate-notice.yml
+++ b/.github/workflows/generate-notice.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           go mod tidy
           go mod download all
-          go list -m -json all | go-licence-detector -includeIndirect -noticeTemplate=../.github/go-licence-detector/templates/NOTICE.MD.tmpl -noticeOut=../NOTICE.MD -depsTemplate=../.github/go-licence-detector/templates/dependencies.asciidoc.tmpl -depsOut=dependencies.asciidoc -overrides=../.github/go-licence-detector/overrides.ndjson
+          go list -m -json all | jq 'select(.Path != "quesma_v2")' | go-licence-detector -includeIndirect -noticeTemplate=../.github/go-licence-detector/templates/NOTICE.MD.tmpl -noticeOut=../NOTICE.MD -depsTemplate=../.github/go-licence-detector/templates/dependencies.asciidoc.tmpl -depsOut=dependencies.asciidoc -overrides=../.github/go-licence-detector/overrides.ndjson
           rm dependencies.asciidoc
 
       - name: Print NOTICE.MD


### PR DESCRIPTION
We are in the process of an internal code refactor and we have introduced a new module `quesma_v2` for this refactor.

Unfortunately, the `go-licence-detector` (generating `NOTICE.MD`) tries to find a licence for `quesma_v2` module and it fails.

We could inform it that `quesma_v2` is licensed under "Elastic-2.0", however that licence is not allowed in the default `go-licence-detector` configuration. I wasn't sure if we should allow "Elastic-2.0" dependencies generally, therefore this change works around this issue by just filtering out `quesma_v2` from dependency list.