### PR TITLE
Integrate v1 reroute logic with v2 APIs

### DIFF
--- a/quesma/frontend_connectors/basic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/basic_http_frontend_connector.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/ucarion/urlpath"
 	"io"
 	"net/http"
 	"quesma/quesma/recovery"
@@ -83,17 +82,6 @@ func (h *BasicHTTPFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.
 			fmt.Printf("Error writing response: %s\n", err)
 		}
 	}).ServeHTTP(w, req)
-}
-
-func getMatchingHandler(requestPath string, handlers map[string]quesma_api.HandlersPipe) *quesma_api.HandlersPipe {
-	for path, handler := range handlers {
-		urlPath := urlpath.New(path)
-		_, matches := urlPath.Match(requestPath)
-		if matches {
-			return &handler
-		}
-	}
-	return nil
 }
 
 func (h *BasicHTTPFrontendConnector) Listen() error {

--- a/quesma/frontend_connectors/basic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/basic_http_frontend_connector.go
@@ -42,8 +42,6 @@ func (h *BasicHTTPFrontendConnector) GetRouter() quesma_api.Router {
 }
 
 func (h *BasicHTTPFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	handlers := h.router.GetHandlers()
-
 	defer recovery.LogPanic()
 	reqBody, err := PeekBodyV2(req)
 	if err != nil {
@@ -60,8 +58,6 @@ func (h *BasicHTTPFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.
 		Body:        string(reqBody),
 	}
 	handlerWrapper, _ := h.router.Matches(quesmaRequest)
-	_ = handlerWrapper
-	handlerWrapper = getMatchingHandler(req.URL.Path, handlers)
 	dispatcher := &quesma_api.Dispatcher{}
 	w = h.responseMutator(w)
 	if handlerWrapper == nil {

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -208,7 +208,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(phoneHomeAgent, cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = true
+		const quesma_v2 = false
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -208,7 +208,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(phoneHomeAgent, cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = false
+		const quesma_v2 = true
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/v2/core/mux.go
+++ b/quesma/v2/core/mux.go
@@ -202,17 +202,23 @@ func (p *PathRouter) GetHandlers() map[string]HandlersPipe {
 	return callInfos
 }
 func (p *PathRouter) SetHandlers(handlers map[string]HandlersPipe) {
-	p.mappings = make([]mapping, 0)
+	newHandlers := make(map[string]HandlersPipe, 0)
 	for path, handler := range handlers {
-		if _, ok := handler.Predicate.(*predicateAlways); ok { // in order to pass processors we have to make this alignment (predicates aren't present in the old API
-			p.mappings = append(p.mappings, mapping{pattern: path,
-				compiledPath: urlpath.New(path),
-				predicate:    handler.Predicate,
-				handler: &HandlersPipe{Handler: handler.Handler,
-					Predicate:  handler.Predicate,
-					Processors: handler.Processors}})
-		} else {
-			p.Register(path, handler.Predicate, handler.Handler)
+		for index := range p.mappings {
+			if p.mappings[index].pattern == path {
+				p.mappings[index].handler.Processors = handler.Processors
+				p.mappings[index].handler.Predicate = handler.Predicate
+			} else {
+				newHandlers[path] = handler
+			}
 		}
+	}
+	for path, handler := range newHandlers {
+		p.mappings = append(p.mappings, mapping{pattern: path,
+			compiledPath: urlpath.New(path),
+			predicate:    handler.Predicate,
+			handler: &HandlersPipe{Handler: handler.Handler,
+				Predicate:  handler.Predicate,
+				Processors: handler.Processors}})
 	}
 }

--- a/quesma/v2/core/mux.go
+++ b/quesma/v2/core/mux.go
@@ -202,10 +202,12 @@ func (p *PathRouter) GetHandlers() map[string]HandlersPipe {
 	return callInfos
 }
 func (p *PathRouter) SetHandlers(handlers map[string]HandlersPipe) {
+	p.mappings = make([]mapping, 0)
 	for path, handler := range handlers {
 		if _, ok := handler.Predicate.(*predicateAlways); ok { // in order to pass processors we have to make this alignment (predicates aren't present in the old API
 			p.mappings = append(p.mappings, mapping{pattern: path,
 				compiledPath: urlpath.New(path),
+				predicate:    handler.Predicate,
 				handler: &HandlersPipe{Handler: handler.Handler,
 					Predicate:  handler.Predicate,
 					Processors: handler.Processors}})


### PR DESCRIPTION
This PR implements first step of integration, it calls `router.Matches` from request handler as in v1 version