### PR TITLE
Moving FailedRequestsCollector call into BasicHTTPFrontendConnector

### DIFF
--- a/quesma/frontend_connectors/basic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/basic_http_frontend_connector.go
@@ -47,6 +47,9 @@ func (h *BasicHTTPFrontendConnector) GetChildComponents() []interface{} {
 func (h *BasicHTTPFrontendConnector) SetDependencies(deps quesma_api.Dependencies) {
 	h.phoneHomeClient = deps.PhoneHomeAgent()
 	h.debugInfoCollector = deps.DebugInfoCollector()
+	deps.PhoneHomeAgent().FailedRequestsCollector(func() int64 {
+		return h.routerInstance.FailedRequests.Load()
+	})
 }
 
 func NewBasicHTTPFrontendConnector(endpoint string, config *config.QuesmaConfiguration) *BasicHTTPFrontendConnector {

--- a/quesma/quesma/dual_write_proxy_v2.go
+++ b/quesma/quesma/dual_write_proxy_v2.go
@@ -9,7 +9,6 @@ import (
 	"quesma/ab_testing"
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
-	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -79,13 +78,6 @@ func newDualWriteProxyV2(dependencies quesma_api.Dependencies, schemaLoader clic
 
 	// tests should not be run with optimization enabled by default
 	queryProcessor.EnableQueryOptimization(config)
-
-	routerInstance := frontend_connectors.NewRouterV2(config)
-
-	dependencies.PhoneHomeAgent().FailedRequestsCollector(func() int64 {
-
-		return routerInstance.FailedRequests.Load()
-	})
 
 	ingestRouter := ConfigureIngestRouterV2(config, dependencies, ingestProcessor, resolver)
 	searchRouter := ConfigureSearchRouterV2(config, dependencies, registry, logManager, queryProcessor, resolver)


### PR DESCRIPTION
This PR deletes orphaned (not used) router and move this functionality to `BasicHTTPFrontendConnector` where it should be.