### PR TITLE
Adding middleware handling API

### DIFF
--- a/quesma/frontend_connectors/basic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/basic_http_frontend_connector.go
@@ -92,12 +92,14 @@ func (h *BasicHTTPFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.
 			middleware := h.middlewares[index]
 			index++
 			middleware.ServeHTTP(w, req) // Automatically proceeds to the next middleware
-			runMiddleware()
+			if w.Header().Get("Content-Length") == "" {
+				runMiddleware()
+			}
+
 		} else {
 			h.finalHandler(w, req)
 		}
 	}
-
 	runMiddleware()
 }
 

--- a/quesma/frontend_connectors/basic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/basic_http_frontend_connector.go
@@ -103,6 +103,7 @@ func (h *BasicHTTPFrontendConnector) ServeHTTP(w http.ResponseWriter, req *http.
 			index++
 			responseWriter := &ResponseWriterWithStatusCode{w, 0}
 			middleware.ServeHTTP(responseWriter, req) // Automatically proceeds to the next middleware
+			// Only if the middleware did not set a status code, we proceed to the next middleware
 			if responseWriter.statusCode == 0 {
 				runMiddleware()
 			}

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -209,7 +209,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = true
+		const quesma_v2 = false
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -209,7 +209,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = false
+		const quesma_v2 = true
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/main_test.go
+++ b/quesma/main_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
@@ -161,29 +160,29 @@ func Test_scenario1(t *testing.T) {
 	q1.Stop(context.Background())
 }
 
+var middleWareCalled int32 = 0
+
 type Middleware struct {
+	emitError bool
 }
 
 func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "middleware", http.StatusInternalServerError)
-	w.Header().Set("Delak", "delak")
-
-	fmt.Println("middleware")
+	atomic.AddInt32(&middleWareCalled, 1)
+	if m.emitError {
+		http.Error(w, "middleware", http.StatusInternalServerError)
+	}
 }
 
 type Middleware2 struct {
 }
 
 func (m *Middleware2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	//http.Error(w, "middleware", http.StatusInternalServerError)
-	fmt.Println("middleware2:", w.Header().Get("Delak"))
-
+	atomic.AddInt32(&middleWareCalled, 1)
 	w.WriteHeader(200)
 }
 
 func Test_middleware(t *testing.T) {
-	var quesmaBuilder quesma_api.QuesmaBuilder = quesma_api.NewQuesma()
-	quesmaBuilder.SetDependencies(quesma_api.EmptyDependencies())
+	var quesmaBuilder quesma_api.QuesmaBuilder = quesma_api.NewQuesma(quesma_api.EmptyDependencies())
 
 	cfg := &config.QuesmaConfiguration{
 		DisableAuth: true,
@@ -193,25 +192,53 @@ func Test_middleware(t *testing.T) {
 			Password: "",
 		},
 	}
+	{
+		frontendConnector := frontend_connectors.NewBasicHTTPFrontendConnector(":8888", cfg)
+		HTTPRouter := quesma_api.NewPathRouter()
+		var fallback quesma_api.HTTPFrontendHandler = fallback
+		HTTPRouter.AddFallbackHandler(fallback)
+		frontendConnector.AddRouter(HTTPRouter)
+		frontendConnector.AddMiddleware(&Middleware{emitError: true})
+		frontendConnector.AddMiddleware(&Middleware2{})
 
-	frontendConnector := frontend_connectors.NewBasicHTTPFrontendConnector(":8888", cfg)
-	HTTPRouter := quesma_api.NewPathRouter()
-	var fallback quesma_api.HTTPFrontendHandler = fallback
-	HTTPRouter.AddFallbackHandler(fallback)
-	frontendConnector.AddRouter(HTTPRouter)
-	frontendConnector.AddMiddleware(&Middleware{})
-	frontendConnector.AddMiddleware(&Middleware2{})
+		var pipeline quesma_api.PipelineBuilder = quesma_api.NewPipeline()
+		pipeline.AddFrontendConnector(frontendConnector)
+		var ingestProcessor quesma_api.Processor = NewIngestProcessor()
+		pipeline.AddProcessor(ingestProcessor)
+		quesmaBuilder.AddPipeline(pipeline)
 
-	var pipeline quesma_api.PipelineBuilder = quesma_api.NewPipeline()
-	pipeline.AddFrontendConnector(frontendConnector)
-	var ingestProcessor quesma_api.Processor = NewIngestProcessor()
-	pipeline.AddProcessor(ingestProcessor)
-	quesmaBuilder.AddPipeline(pipeline)
+		quesmaBuilder.Build()
+		quesmaBuilder.Start()
+		stop := make(chan os.Signal, 1)
+		emitRequests(stop)
+		<-stop
+		quesmaBuilder.Stop(context.Background())
+		atomic.LoadInt32(&middleWareCalled)
+		assert.Equal(t, int32(4), middleWareCalled)
+	}
+	middleWareCalled = 0
+	{
+		frontendConnector := frontend_connectors.NewBasicHTTPFrontendConnector(":8888", cfg)
+		HTTPRouter := quesma_api.NewPathRouter()
+		var fallback quesma_api.HTTPFrontendHandler = fallback
+		HTTPRouter.AddFallbackHandler(fallback)
+		frontendConnector.AddRouter(HTTPRouter)
+		frontendConnector.AddMiddleware(&Middleware{emitError: false})
+		frontendConnector.AddMiddleware(&Middleware2{})
 
-	quesmaBuilder.Build()
-	quesmaBuilder.Start()
-	stop := make(chan os.Signal, 1)
-	emitRequests(stop)
-	<-stop
-	quesmaBuilder.Stop(context.Background())
+		var pipeline quesma_api.PipelineBuilder = quesma_api.NewPipeline()
+		pipeline.AddFrontendConnector(frontendConnector)
+		var ingestProcessor quesma_api.Processor = NewIngestProcessor()
+		pipeline.AddProcessor(ingestProcessor)
+		quesmaBuilder.AddPipeline(pipeline)
+
+		quesmaBuilder.Build()
+		quesmaBuilder.Start()
+		stop := make(chan os.Signal, 1)
+		emitRequests(stop)
+		<-stop
+		quesmaBuilder.Stop(context.Background())
+		atomic.LoadInt32(&middleWareCalled)
+		assert.Equal(t, int32(8), middleWareCalled)
+	}
 }

--- a/quesma/main_test.go
+++ b/quesma/main_test.go
@@ -221,7 +221,7 @@ func Test_middleware(t *testing.T) {
 		atomic.LoadInt32(&middleWareCalled)
 		assert.Equal(t, int32(4), middleWareCalled)
 	}
-	middleWareCalled = 0
+	atomic.StoreInt32(&middleWareCalled, 0)
 	{
 		quesmaBuilder := createMiddleWareScenario(false, cfg)
 		quesmaBuilder.Build()

--- a/quesma/main_test.go
+++ b/quesma/main_test.go
@@ -160,14 +160,14 @@ func Test_scenario1(t *testing.T) {
 	q1.Stop(context.Background())
 }
 
-var middleWareCalled int32 = 0
+var middlewareCallCount int32 = 0
 
 type Middleware struct {
 	emitError bool
 }
 
 func (m *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	atomic.AddInt32(&middleWareCalled, 1)
+	atomic.AddInt32(&middlewareCallCount, 1)
 	if m.emitError {
 		http.Error(w, "middleware", http.StatusInternalServerError)
 	}
@@ -177,7 +177,7 @@ type Middleware2 struct {
 }
 
 func (m *Middleware2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	atomic.AddInt32(&middleWareCalled, 1)
+	atomic.AddInt32(&middlewareCallCount, 1)
 	w.WriteHeader(200)
 }
 
@@ -218,10 +218,10 @@ func Test_middleware(t *testing.T) {
 		emitRequests(stop)
 		<-stop
 		quesmaBuilder.Stop(context.Background())
-		atomic.LoadInt32(&middleWareCalled)
-		assert.Equal(t, int32(4), middleWareCalled)
+		atomic.LoadInt32(&middlewareCallCount)
+		assert.Equal(t, int32(4), middlewareCallCount)
 	}
-	atomic.StoreInt32(&middleWareCalled, 0)
+	atomic.StoreInt32(&middlewareCallCount, 0)
 	{
 		quesmaBuilder := createMiddleWareScenario(false, cfg)
 		quesmaBuilder.Build()
@@ -230,7 +230,7 @@ func Test_middleware(t *testing.T) {
 		emitRequests(stop)
 		<-stop
 		quesmaBuilder.Stop(context.Background())
-		atomic.LoadInt32(&middleWareCalled)
-		assert.Equal(t, int32(8), middleWareCalled)
+		atomic.LoadInt32(&middlewareCallCount)
+		assert.Equal(t, int32(8), middlewareCallCount)
 	}
 }

--- a/quesma/quesma/auth_middleware.go
+++ b/quesma/quesma/auth_middleware.go
@@ -24,11 +24,12 @@ type authMiddleware struct {
 	authHeaderCache   sync.Map
 	cacheWipeInterval time.Duration
 	esClient          elasticsearch.SimpleClient
+	v2                bool
 }
 
 func NewAuthMiddleware(next http.Handler, esConf config.ElasticsearchConfiguration) http.Handler {
 	esClient := elasticsearch.NewSimpleClient(&esConf)
-	middleware := &authMiddleware{nextHttpHandler: next, esClient: *esClient, cacheWipeInterval: cacheWipeInterval}
+	middleware := &authMiddleware{nextHttpHandler: next, esClient: *esClient, cacheWipeInterval: cacheWipeInterval, v2: false}
 	go middleware.startCacheWipeScheduler()
 	return middleware
 }
@@ -49,7 +50,9 @@ func (a *authMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if _, ok := a.authHeaderCache.Load(auth); ok {
 		logger.Debug().Msgf("[AUTH] [%s] called by [%s] - credentials loaded from cache", r.URL, userName)
-		a.nextHttpHandler.ServeHTTP(w, r)
+		if !a.v2 {
+			a.nextHttpHandler.ServeHTTP(w, r)
+		}
 		return
 	}
 
@@ -61,8 +64,9 @@ func (a *authMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-
-	a.nextHttpHandler.ServeHTTP(w, r)
+	if !a.v2 {
+		a.nextHttpHandler.ServeHTTP(w, r)
+	}
 }
 
 func (a *authMiddleware) startCacheWipeScheduler() {
@@ -85,4 +89,11 @@ func (a *authMiddleware) wipeCache() {
 		a.authHeaderCache.Delete(key)
 		return true
 	})
+}
+
+func NewAuthMiddlewareV2(esConf config.ElasticsearchConfiguration) http.Handler {
+	esClient := elasticsearch.NewSimpleClient(&esConf)
+	middleware := &authMiddleware{esClient: *esClient, cacheWipeInterval: cacheWipeInterval, v2: true}
+	go middleware.startCacheWipeScheduler()
+	return middleware
 }

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -35,9 +35,9 @@ type HTTPFrontendConnector interface {
 	// AddRouter adds a router to the HTTPFrontendConnector
 	AddRouter(router Router)
 	GetRouter() Router
-	// AddMiddleware adds a middleware to the HTTPFrontendConnector
-	// The middleware chain is executed in the order they are added
-	// and before the router is executed
+	// AddMiddleware adds a middleware to the HTTPFrontendConnector.
+	// The middleware chain is executed in the order it is added
+	// and before the router is executed.
 	AddMiddleware(middleware http.Handler)
 }
 

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -5,6 +5,7 @@ package quesma_api
 import (
 	"context"
 	"net"
+	"net/http"
 )
 
 type InstanceNamer interface {
@@ -31,8 +32,13 @@ type FrontendConnector interface {
 
 type HTTPFrontendConnector interface {
 	FrontendConnector
+	// AddRouter adds a router to the HTTPFrontendConnector
 	AddRouter(router Router)
 	GetRouter() Router
+	// AddMiddleware adds a middleware to the HTTPFrontendConnector
+	// The middleware chain is executed in the order they are added
+	// and before the router is executed
+	AddMiddleware(middleware http.Handler)
 }
 
 type TCPFrontendConnector interface {


### PR DESCRIPTION
This PR adds a new API call for registering middlewares into the HTTP FrontendConnector.