### PR TITLE
Fix `bin/build-image.sh` on Linux

### DIFF
--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -7,4 +7,6 @@ QUESMA_BUILD_SHA=$(git rev-parse HEAD)
 QUESMA_BUILD_DATE=$(git --no-pager log -1 --date=format:'%Y-%m-%d' --format="%ad")
 QUESMA_VERSION="development"
 
+export DOCKER_BUILDKIT=1
+
 docker build --build-arg QUESMA_BUILD_DATE="$QUESMA_BUILD_DATE" --build-arg QUESMA_VERSION="$QUESMA_VERSION" --build-arg QUESMA_BUILD_SHA="$QUESMA_BUILD_SHA" -f quesma/Dockerfile -t quesma/quesma:nightly quesma


### PR DESCRIPTION
Without the `DOCKER_BUILDKIT` environment variable the image fails to build on Linux (note: this doesn't affect CI because CI doesn't use this helper script).