### PR TITLE
A couple small fixes to ITs

### DIFF
--- a/ci/it/configs/quesma-ab.yml.template
+++ b/ci/it/configs/quesma-ab.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: QP
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-as-transparent-proxy.yml.template
+++ b/ci/it/configs/quesma-as-transparent-proxy.yml.template
@@ -14,6 +14,11 @@ backendConnectors:
       url: "http://{{ .elasticsearch_host }}:{{ .elasticsearch_port }}"
       user: elastic
       password: quesmaquesma
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: noop-query-processor
     type: quesma-v1-processor-noop

--- a/ci/it/configs/quesma-ingest.yml.template
+++ b/ci/it/configs/quesma-ingest.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: my-query-processor
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-now-reads-clickhouse-tables.yml.template
+++ b/ci/it/configs/quesma-now-reads-clickhouse-tables.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: my-query-processor
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-wildcard-clickhouse.yml.template
+++ b/ci/it/configs/quesma-wildcard-clickhouse.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: my-query-processor
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-wildcard-disabled.yml.template
+++ b/ci/it/configs/quesma-wildcard-disabled.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: my-query-processor
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-with-dual-writes-and-common-table.yml.template
+++ b/ci/it/configs/quesma-with-dual-writes-and-common-table.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: QP
     type: quesma-v1-processor-query

--- a/ci/it/configs/quesma-with-two-pipelines.yml.template
+++ b/ci/it/configs/quesma-with-two-pipelines.yml.template
@@ -18,7 +18,11 @@ backendConnectors:
     type: clickhouse-os
     config:
       url: clickhouse://{{ .clickhouse_host }}:{{ .clickhouse_port }}
-ingestStatistics: true
+logging:
+  path: "logs"
+  level: "info"
+  disableFileLogging: false
+  enableSQLTracing: true
 processors:
   - name: my-query-processor
     type: quesma-v1-processor-query

--- a/ci/it/go.mod
+++ b/ci/it/go.mod
@@ -1,6 +1,6 @@
 module quesma.com/its
 
-go 1.21.6
+go 1.23.2
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.20.0
@@ -61,7 +61,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect

--- a/ci/it/go.sum
+++ b/ci/it/go.sum
@@ -174,8 +174,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/ci/it/integration_test.go
+++ b/ci/it/integration_test.go
@@ -11,7 +11,9 @@ import (
 
 func runIntegrationTest(t *testing.T, testCase testcases.TestCase) {
 	ctx := context.Background()
-	defer testCase.Cleanup(ctx, t)
+	t.Cleanup(func() {
+		testCase.Cleanup(ctx, t)
+	})
 	if err := testCase.SetupContainers(ctx); err != nil {
 		t.Fatalf("Failed to setup containers: %s", err)
 	}


### PR DESCRIPTION
- Bump go to 1.23.2 in `ci/it` to be in line with go version in other modules in the repo
- Update `golang.org/x/net` to v0.33.0 to get rid of the "Security advisory" warning (https://github.com/QuesmaOrg/quesma/security/dependabot/6)
- Turn on SQL tracing in ITs
- Use `testing.T.Cleanup()` instead of `defer` - `testing.T.Cleanup()` will run even if a test panics/fails/timeouts