### PR TITLE
Fix `ids` query DSL

### DIFF
--- a/quesma/model/base_visitor.go
+++ b/quesma/model/base_visitor.go
@@ -5,6 +5,7 @@ package model
 type BaseExprVisitor struct {
 	OverrideVisitFunction       func(b *BaseExprVisitor, e FunctionExpr) interface{}
 	OverrideVisitLiteral        func(b *BaseExprVisitor, l LiteralExpr) interface{}
+	OverrideVisitTuple          func(b *BaseExprVisitor, t TupleExpr) interface{}
 	OverrideVisitInfix          func(b *BaseExprVisitor, e InfixExpr) interface{}
 	OverrideVisitColumnRef      func(b *BaseExprVisitor, e ColumnRef) interface{}
 	OverrideVisitPrefixExpr     func(b *BaseExprVisitor, e PrefixExpr) interface{}
@@ -43,6 +44,14 @@ func (v *BaseExprVisitor) VisitLiteral(e LiteralExpr) interface{} {
 
 	return NewLiteral(e.Value)
 }
+
+func (v *BaseExprVisitor) VisitTuple(e TupleExpr) interface{} {
+	if v.OverrideVisitTuple != nil {
+		return v.OverrideVisitTuple(v, e)
+	}
+	return NewTupleExpr(v.VisitChildren(e.Exprs)...)
+}
+
 func (v *BaseExprVisitor) VisitInfix(e InfixExpr) interface{} {
 	if v.OverrideVisitInfix != nil {
 		return v.OverrideVisitInfix(v, e)

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -12,6 +12,7 @@ type Expr interface {
 var (
 	InvalidExpr = Expr(nil)
 	TrueExpr    = NewLiteral(true)
+	FalseExpr   = NewLiteral(false)
 )
 
 // ColumnRef is a reference to a column in a table, we can enrich it with more information (e.g. type used) as we go
@@ -84,6 +85,18 @@ type LiteralExpr struct {
 
 func (e LiteralExpr) Accept(v ExprVisitor) interface{} {
 	return v.VisitLiteral(e)
+}
+
+type TupleExpr struct {
+	Exprs []Expr
+}
+
+func NewTupleExpr(exprs ...Expr) TupleExpr {
+	return TupleExpr{Exprs: exprs}
+}
+
+func (e TupleExpr) Accept(v ExprVisitor) interface{} {
+	return v.VisitTuple(e)
 }
 
 type InfixExpr struct {
@@ -278,6 +291,7 @@ func (e CTE) Accept(v ExprVisitor) interface{} {
 type ExprVisitor interface {
 	VisitFunction(e FunctionExpr) interface{}
 	VisitLiteral(l LiteralExpr) interface{}
+	VisitTuple(t TupleExpr) interface{}
 	VisitInfix(e InfixExpr) interface{}
 	VisitColumnRef(e ColumnRef) interface{}
 	VisitPrefixExpr(e PrefixExpr) interface{}

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -4,6 +4,7 @@ package model
 
 import (
 	"fmt"
+	"quesma/logger"
 	"quesma/quesma/types"
 	"regexp"
 	"sort"
@@ -66,6 +67,22 @@ func (v *renderer) VisitFunction(e FunctionExpr) interface{} {
 
 func (v *renderer) VisitLiteral(l LiteralExpr) interface{} {
 	return fmt.Sprintf("%v", l.Value)
+}
+
+func (v *renderer) VisitTuple(t TupleExpr) interface{} {
+	switch len(t.Exprs) {
+	case 0:
+		logger.WarnWithThrottling("VisitTuple", "TupleExpr with no expressions")
+		return "()"
+	case 1:
+		return t.Exprs[0].Accept(v)
+	default:
+		args := make([]string, len(t.Exprs))
+		for i, arg := range t.Exprs {
+			args[i] = arg.Accept(v).(string)
+		}
+		return fmt.Sprintf("tuple(%s)", strings.Join(args, ", ")) // can omit "tuple", but I think SQL's more readable with it
+	}
 }
 
 func (v *renderer) VisitInfix(e InfixExpr) interface{} {

--- a/quesma/model/simple_query.go
+++ b/quesma/model/simple_query.go
@@ -28,6 +28,10 @@ func NewSimpleQuery(whereClause Expr, canParse bool) SimpleQuery {
 	return SimpleQuery{WhereClause: whereClause, CanParse: canParse}
 }
 
+func NewSimpleQueryInvalid() SimpleQuery {
+	return SimpleQuery{CanParse: false}
+}
+
 // LimitForCount returns (limit, true) if we need count(*) with limit,
 // (not-important, false) if we don't need count/limit
 func (s *SimpleQuery) LimitForCount() (limit int, doWeNeedLimit bool) {

--- a/quesma/queryparser/query_parser_test.go
+++ b/quesma/queryparser/query_parser_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"quesma/clickhouse"
+	"quesma/logger"
 	"quesma/model"
 	"quesma/model/typical_queries"
 	"quesma/persistence"
@@ -27,6 +28,7 @@ import (
 //     what should be? According to docs, I think so... Maybe test in Kibana?
 //     OK, Kibana disagrees, it is indeed wrong.
 func TestQueryParserStringAttrConfig(t *testing.T) {
+	logger.InitSimpleLoggerForTestsWarnLevel()
 	tableName := "logs-generic-default"
 	table, err := clickhouse.NewTable(`CREATE TABLE `+tableName+`
 		( "message" String, "@timestamp" DateTime64(3, 'UTC'), "attributes_values" Map(String,String))

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -2321,7 +2321,47 @@ var TestsSearch = []SearchTestCase{
 		[]string{},
 	},
 	{ // [40]
-		"ids",
+		"ids, 0 values",
+		`{
+			"query": {
+				"ids": {
+					 "values": []
+				}
+			},
+			"track_total_hits": false
+		}`,
+		[]string{`false`},
+		model.ListAllFields,
+		[]string{
+			`SELECT "message" ` +
+				`FROM ` + TableName + ` ` +
+				`WHERE false ` +
+				`LIMIT 10`,
+		},
+		[]string{},
+	},
+	{ // [41]
+		"ids, 1 value",
+		`{
+			"query": {
+				"ids": {
+					 "values": ["323032342d31322d32312030373a32393a30332e333637202b3030303020555443q1"]
+				}
+			},
+			"track_total_hits": false
+		}`,
+		[]string{`"@timestamp" = toDateTime64('2024-12-21 07:29:03.367',3)`},
+		model.ListAllFields,
+		[]string{
+			`SELECT "message" ` +
+				`FROM ` + TableName + ` ` +
+				`WHERE "@timestamp" = toDateTime64('2024-12-21 07:29:03.367',3) ` +
+				`LIMIT 10`,
+		},
+		[]string{},
+	},
+	{ // [42]
+		"ids, 2+ values",
 		`{
 			"query": {
 				"ids": {
@@ -2333,12 +2373,12 @@ var TestsSearch = []SearchTestCase{
 			},
 			"track_total_hits": false
 		}`,
-		[]string{`"field" REGEXP 'a?'`},
+		[]string{`"@timestamp" IN tuple(toDateTime64('2024-12-21 07:29:03.367',3), toDateTime64('2024-12-21 07:29:02.992',3))`},
 		model.ListAllFields,
 		[]string{
 			`SELECT "message" ` +
 				`FROM ` + TableName + ` ` +
-				`WHERE "field" REGEXP 'a\?' ` +
+				`WHERE "@timestamp" IN tuple(toDateTime64('2024-12-21 07:29:03.367',3), toDateTime64('2024-12-21 07:29:02.992',3)) ` +
 				`LIMIT 10`,
 		},
 		[]string{},

--- a/quesma/testdata/requests.go
+++ b/quesma/testdata/requests.go
@@ -2320,6 +2320,29 @@ var TestsSearch = []SearchTestCase{
 		},
 		[]string{},
 	},
+	{ // [40]
+		"ids",
+		`{
+			"query": {
+				"ids": {
+					 "values": [
+						"323032342d31322d32312030373a32393a30332e333637202b3030303020555443q1",
+						"323032342d31322d32312030373a32393a30322e393932202b3030303020555443q3"
+					]
+				}
+			},
+			"track_total_hits": false
+		}`,
+		[]string{`"field" REGEXP 'a?'`},
+		model.ListAllFields,
+		[]string{
+			`SELECT "message" ` +
+				`FROM ` + TableName + ` ` +
+				`WHERE "field" REGEXP 'a\?' ` +
+				`LIMIT 10`,
+		},
+		[]string{},
+	},
 }
 
 var TestSearchRuntimeMappings = []SearchTestCase{


### PR DESCRIPTION
By accident I noticed our SQL generated for `ids` looks quite nonsensical, e.g. that's what's generated for my new very simple request:
```
WHERE "@timestamp" IN toDateTime64('2024-12-21 07:29:03.367', '2024-12-21 07:29:02.992', 3)
```
Also noticed we have 0 tests for this query. Fixing those 2 things here.
(adding `TupleExpr` for just this 1 usecase might seem unnecessary, but it's needed in my 2 other open PRs, so I'd do that)

Also, minor: changed `return model.NewSimpleQuery(nil, false)` to more descriptive `return model.NewSimpleQueryInvalid()` everywhere.