### PR TITLE
Moving elastic-http-frontend-connector to frontend_connectors package

### DIFF
--- a/quesma/frontend_connectors/elastic_http_frontend_connector.go
+++ b/quesma/frontend_connectors/elastic_http_frontend_connector.go
@@ -1,13 +1,12 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-package quesma
+package frontend_connectors
 
 import (
 	"context"
 	"net/http"
 	"quesma/clickhouse"
-	"quesma/frontend_connectors"
 	"quesma/quesma/config"
 	"quesma/schema"
 	quesma_api "quesma_v2/core"
@@ -15,7 +14,7 @@ import (
 )
 
 type ElasticHttpIngestFrontendConnector struct {
-	*frontend_connectors.BasicHTTPFrontendConnector
+	*BasicHTTPFrontendConnector
 
 	Config *config.QuesmaConfiguration
 
@@ -28,7 +27,7 @@ func NewElasticHttpIngestFrontendConnector(endpoint string,
 	config *config.QuesmaConfiguration, router quesma_api.Router) *ElasticHttpIngestFrontendConnector {
 
 	fc := &ElasticHttpIngestFrontendConnector{
-		BasicHTTPFrontendConnector: frontend_connectors.NewBasicHTTPFrontendConnector(endpoint, config),
+		BasicHTTPFrontendConnector: NewBasicHTTPFrontendConnector(endpoint, config),
 	}
 	fallback := func(ctx context.Context, req *quesma_api.Request, writer http.ResponseWriter) (*quesma_api.Result, error) {
 		fc.BasicHTTPFrontendConnector.GetRouterInstance().ElasticFallback(req.Decision, ctx, writer, req.OriginalRequest, []byte(req.Body), logManager, registry)
@@ -55,7 +54,7 @@ func (h *ElasticHttpIngestFrontendConnector) SetDependencies(deps quesma_api.Dep
 }
 
 type ElasticHttpQueryFrontendConnector struct {
-	*frontend_connectors.BasicHTTPFrontendConnector
+	*BasicHTTPFrontendConnector
 
 	phoneHomeClient diag.PhoneHomeClient
 }
@@ -66,7 +65,7 @@ func NewElasticHttpQueryFrontendConnector(endpoint string,
 	config *config.QuesmaConfiguration, router quesma_api.Router) *ElasticHttpIngestFrontendConnector {
 
 	fc := &ElasticHttpIngestFrontendConnector{
-		BasicHTTPFrontendConnector: frontend_connectors.NewBasicHTTPFrontendConnector(endpoint, config),
+		BasicHTTPFrontendConnector: NewBasicHTTPFrontendConnector(endpoint, config),
 	}
 	fallback := func(ctx context.Context, req *quesma_api.Request, writer http.ResponseWriter) (*quesma_api.Result, error) {
 		fc.BasicHTTPFrontendConnector.GetRouterInstance().ElasticFallback(req.Decision, ctx, writer, req.OriginalRequest, []byte(req.Body), logManager, registry)

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -209,7 +209,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = true
+		const quesma_v2 = false
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -209,7 +209,7 @@ func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscove
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		const quesma_v2 = false
+		const quesma_v2 = true
 		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry, quesma_v2)
 	}
 }

--- a/quesma/quesma/dual_write_proxy_v2.go
+++ b/quesma/quesma/dual_write_proxy_v2.go
@@ -9,6 +9,7 @@ import (
 	"quesma/ab_testing"
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
+	"quesma/frontend_connectors"
 	"quesma/ingest"
 	"quesma/logger"
 	"quesma/queryparser"
@@ -79,10 +80,10 @@ func newDualWriteProxyV2(dependencies quesma_api.Dependencies, schemaLoader clic
 	ingestRouter := ConfigureIngestRouterV2(config, dependencies, ingestProcessor, resolver)
 	searchRouter := ConfigureSearchRouterV2(config, dependencies, registry, logManager, queryProcessor, resolver)
 
-	elasticHttpIngestFrontendConnector := NewElasticHttpIngestFrontendConnector(":"+strconv.Itoa(int(config.PublicTcpPort)),
+	elasticHttpIngestFrontendConnector := frontend_connectors.NewElasticHttpIngestFrontendConnector(":"+strconv.Itoa(int(config.PublicTcpPort)),
 		logManager, registry, config, ingestRouter)
 
-	elasticHttpQueryFrontendConnector := NewElasticHttpQueryFrontendConnector(":"+strconv.Itoa(int(config.PublicTcpPort)),
+	elasticHttpQueryFrontendConnector := frontend_connectors.NewElasticHttpQueryFrontendConnector(":"+strconv.Itoa(int(config.PublicTcpPort)),
 		logManager, registry, config, searchRouter)
 
 	quesmaBuilder := quesma_api.NewQuesma(dependencies)


### PR DESCRIPTION
This PR just moves `ElasticHTTPFrontendConnectors` to the right package (`frontend_connectors`)