### PR TITLE
`Terms`: start supporting `exclude` param

### DIFF
--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -136,7 +136,7 @@ func (query Terms) UpdateFieldForIncludeAndExclude(field model.Expr) (updatedFie
 		// Select expr will be: if(field NOT IN (excludeArr[0], excludeArr[1], ...), field, NULL)
 		exprs := make([]model.Expr, 0, len(excludeArr))
 		for _, excludeVal := range excludeArr {
-			exprs = append(exprs, model.NewLiteral(excludeVal))
+			exprs = append(exprs, model.NewLiteralSingleQuoteString(excludeVal))
 		}
 		return ifOrNull(model.NewInfixExpr(field, "NOT IN", model.NewTupleExpr(exprs...))), true
 	case hasExclude:

--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -4,19 +4,31 @@ package bucket_aggregations
 
 import (
 	"context"
+	"fmt"
 	"quesma/logger"
 	"quesma/model"
 	"quesma/util"
+	"quesma/util/regex"
+	"reflect"
 )
 
 type Terms struct {
 	ctx         context.Context
 	significant bool // true <=> significant_terms, false <=> terms
-	OrderByExpr model.Expr
+	// Either:
+	//   - single value: then for strings, it can be a regex.
+	//   - array: then field must match exactly one of the values (never a regex)
+	// Nil if missing in request.
+	include any
+	// Either:
+	//   - single value: then for strings, it can be a regex.
+	//   - array: then field must match exactly one of the values (never a regex)
+	// Nil if missing in request.
+	exclude any
 }
 
-func NewTerms(ctx context.Context, significant bool, orderByExpr model.Expr) Terms {
-	return Terms{ctx: ctx, significant: significant, OrderByExpr: orderByExpr}
+func NewTerms(ctx context.Context, significant bool, include, exclude any) Terms {
+	return Terms{ctx: ctx, significant: significant, include: include, exclude: exclude}
 }
 
 func (query Terms) AggregationType() model.AggregationType {
@@ -105,4 +117,104 @@ func (query Terms) key(row model.QueryResultRow) any {
 
 func (query Terms) parentCount(row model.QueryResultRow) any {
 	return row.Cols[len(row.Cols)-3].Value
+}
+
+func (query Terms) UpdateFieldForIncludeAndExclude(field model.Expr) model.Expr {
+	// We'll use here everywhere Clickhouse 'if' function: if(condition, then, else)
+	// In our case: if(condition that field is not excluded, field, NULL)
+	ifOrNull := func(condition model.Expr) model.FunctionExpr {
+		return model.NewFunction("if", condition, field, model.NullExpr)
+	}
+	hasExclude := query.exclude != nil
+	excludeArr, excludeIsArray := query.exclude.([]any)
+	switch {
+	case hasExclude && excludeIsArray:
+		if len(excludeArr) == 0 {
+			return field
+		}
+
+		// Select expr will be: if(field NOT IN (excludeArr[0], excludeArr[1], ...), field, NULL)
+		exprs := make([]model.Expr, 0, len(excludeArr))
+		for _, excludeVal := range excludeArr {
+			exprs = append(exprs, model.NewLiteral(excludeVal))
+		}
+		return ifOrNull(model.NewInfixExpr(field, "NOT IN", model.NewTupleExpr(exprs...)))
+	case hasExclude:
+		switch exclude := query.exclude.(type) {
+		case string: // hard case, might be regex
+			funcName, patternExpr := regex.ToClickhouseExpr(exclude)
+			return ifOrNull(model.NewInfixExpr(field, funcName, patternExpr))
+		default: // easy case, never regex
+			return ifOrNull(model.NewInfixExpr(field, "!=", model.NewLiteral(query.exclude)))
+		}
+
+	default:
+		return field // TODO implement support for include this in next PR
+	}
+}
+
+// TODO make part of QueryType interface and implement for all aggregations
+// TODO add bad requests to tests
+// Doing so will ensure we see 100% of what we're interested in in our logs (now we see ~95%)
+func CheckParamsTerms(ctx context.Context, paramsRaw any) error {
+	requiredParams := map[string]string{"field": "string"}
+	optionalParams := map[string]string{
+		"size":                      "float64", // TODO should be int, will be fixed
+		"shard_size":                "float64", // TODO should be int, will be fixed
+		"order":                     "order",   // TODO add order type
+		"min_doc_count":             "float64", // TODO should be int, will be fixed
+		"shard_min_doc_count":       "float64", // TODO should be int, will be fixed
+		"show_term_doc_count_error": "bool",
+		"exclude":                   "not-checking-type-rn-complicated",
+		"include":                   "not-checking-type-rn-complicated",
+		"collect_mode":              "string",
+		"execution_hint":            "string",
+		"missing":                   "string",
+		"value_type":                "string",
+	}
+	logIfYouSeeThemParams := []string{
+		"shard_size", "min_doc_count", "shard_min_doc_count",
+		"show_term_doc_count_error", "collect_mode", "execution_hint", "value_type",
+	}
+
+	params, ok := paramsRaw.(model.JsonMap)
+	if !ok {
+		return fmt.Errorf("params is not a map, but %+v", paramsRaw)
+	}
+
+	// check if required are present
+	for paramName, paramType := range requiredParams {
+		paramVal, exists := params[paramName]
+		if !exists {
+			return fmt.Errorf("required parameter %s not found in Terms params", paramName)
+		}
+		if reflect.TypeOf(paramVal).Name() != paramType { // TODO I'll make a small rewrite to not use reflect here
+			return fmt.Errorf("required parameter %s is not of type %s, but %T", paramName, paramType, paramVal)
+		}
+	}
+
+	// check if only required/optional are present
+	for paramName := range params {
+		if _, isRequired := requiredParams[paramName]; !isRequired {
+			wantedType, isOptional := optionalParams[paramName]
+			if !isOptional {
+				return fmt.Errorf("unexpected parameter %s found in Terms params %v", paramName, params)
+			}
+			if wantedType == "not-checking-type-rn-complicated" || wantedType == "order" {
+				continue // TODO: add that later
+			}
+			if reflect.TypeOf(params[paramName]).Name() != wantedType { // TODO I'll make a small rewrite to not use reflect here
+				return fmt.Errorf("optional parameter %s is not of type %s, but %T", paramName, wantedType, params[paramName])
+			}
+		}
+	}
+
+	// log if you see them
+	for _, warnParam := range logIfYouSeeThemParams {
+		if _, exists := params[warnParam]; exists {
+			logger.WarnWithCtxAndThrottling(ctx, "terms", warnParam, "we didn't expect %s in Terms params %v", warnParam, params)
+		}
+	}
+
+	return nil
 }

--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -143,7 +143,7 @@ func (query Terms) UpdateFieldForIncludeAndExclude(field model.Expr) (updatedFie
 		switch exclude := query.exclude.(type) {
 		case string: // hard case, might be regex
 			funcName, patternExpr := regex.ToClickhouseExpr(exclude)
-			return ifOrNull(model.NewInfixExpr(field, funcName, patternExpr)), true
+			return ifOrNull(model.NewInfixExpr(field, "NOT "+funcName, patternExpr)), true
 		default: // easy case, never regex
 			return ifOrNull(model.NewInfixExpr(field, "!=", model.NewLiteral(query.exclude))), true
 		}

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Elastic-2.0
 package model
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // Expr is a generic representation of an expression which is a part of the SQL query.
 type Expr interface {
@@ -125,6 +128,15 @@ var NewWildcardExpr = LiteralExpr{Value: "*"}
 
 func NewLiteral(value any) LiteralExpr {
 	return LiteralExpr{Value: value}
+}
+
+func NewLiteralSingleQuoteString(value any) LiteralExpr {
+	switch v := value.(type) {
+	case string:
+		return LiteralExpr{Value: fmt.Sprintf("'%s'", v)}
+	default:
+		return LiteralExpr{Value: v}
+	}
 }
 
 // DistinctExpr is a representation of DISTINCT keyword in SQL, e.g. `SELECT DISTINCT` ... or `SELECT COUNT(DISTINCT ...)`

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -13,6 +13,7 @@ var (
 	InvalidExpr = Expr(nil)
 	TrueExpr    = NewLiteral(true)
 	FalseExpr   = NewLiteral(false)
+	NullExpr    = NewLiteral("NULL")
 )
 
 // ColumnRef is a reference to a column in a table, we can enrich it with more information (e.g. type used) as we go

--- a/quesma/model/expr.go
+++ b/quesma/model/expr.go
@@ -130,6 +130,7 @@ func NewLiteral(value any) LiteralExpr {
 	return LiteralExpr{Value: value}
 }
 
+// NewLiteralSingleQuoteString simply does: string -> 'string', anything_else -> anything_else
 func NewLiteralSingleQuoteString(value any) LiteralExpr {
 	switch v := value.(type) {
 	case string:

--- a/quesma/model/expr_string_renderer.go
+++ b/quesma/model/expr_string_renderer.go
@@ -101,7 +101,7 @@ func (v *renderer) VisitInfix(e InfixExpr) interface{} {
 	// I think in the future every infix op should be in braces.
 	if strings.HasPrefix(e.Op, "_") || e.Op == "AND" || e.Op == "OR" {
 		return fmt.Sprintf("(%v %v %v)", lhs, e.Op, rhs)
-	} else if strings.Contains(e.Op, "LIKE") || e.Op == "IS" || e.Op == "IN" || e.Op == "REGEXP" || strings.Contains(e.Op, "UNION") {
+	} else if strings.Contains(e.Op, "LIKE") || e.Op == "IS" || e.Op == "IN" || e.Op == "NOT IN" || e.Op == "REGEXP" || strings.Contains(e.Op, "UNION") {
 		return fmt.Sprintf("%v %v %v", lhs, e.Op, rhs)
 	} else {
 		return fmt.Sprintf("%v%v%v", lhs, e.Op, rhs)

--- a/quesma/queryparser/pancake_aggregation_parser_buckets.go
+++ b/quesma/queryparser/pancake_aggregation_parser_buckets.go
@@ -155,12 +155,18 @@ func (cw *ClickhouseQueryTranslator) parseTermsAggregation(aggregation *pancakeA
 
 	const defaultSize = 10
 	size := cw.parseSize(params, defaultSize)
+	
+	terms := bucket_aggregations.NewTerms(
+		cw.Ctx, aggrName == "significant_terms", params["include"], params["exclude"],
+	)
+	field = terms.UpdateFieldForIncludeAndExclude(field)
+
 	orderBy, err := cw.parseOrder(params, []model.Expr{field})
 	if err != nil {
 		return err
 	}
 
-	aggregation.queryType = bucket_aggregations.NewTerms(cw.Ctx, aggrName == "significant_terms", orderBy[0]) // TODO probably full, not [0]
+	aggregation.queryType = terms
 	aggregation.selectedColumns = append(aggregation.selectedColumns, field)
 	aggregation.limit = size
 	aggregation.orderBy = orderBy

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,10 +52,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
-			if i != 73 {
-				t.Skip()
-			}
-
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,6 +52,10 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
+			if i != 70 {
+				t.Skip()
+			}
+
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,6 +52,10 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
+			if i != 73 {
+				t.Skip()
+			}
+
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,10 +52,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
-			if i != 70 {
-				t.Skip()
-			}
-
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -4859,7 +4859,7 @@ var AggregationTests2 = []AggregationTestCase{
 			"aggs": {
 				"1": {
 					"terms": {
-						"field": "agi_birth_year", 
+						"field": "chess_goat", 
 						"size": 1,
 						"exclude": ["abc"]
 					}
@@ -4898,9 +4898,10 @@ var AggregationTests2 = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__1__parent_count",
-			  "agi_birth_year" AS "aggr__1__key_0", count(*) AS "aggr__1__count"
+			  if("chess_goat" NOT IN 'abc', "chess_goat", NULL) AS "aggr__1__key_0",
+			  count(*) AS "aggr__1__count"
 			FROM __quesma_table_name
-			GROUP BY "agi_birth_year" AS "aggr__1__key_0"
+			GROUP BY if("chess_goat" NOT IN 'abc', "chess_goat", NULL) AS "aggr__1__key_0"
 			ORDER BY "aggr__1__count" DESC, "aggr__1__key_0" ASC
 			LIMIT 2`,
 	},
@@ -4951,10 +4952,10 @@ var AggregationTests2 = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__1__parent_count",
-			  if("chess_goat" LIKE 'K%', "chess_goat", NULL) AS "aggr__1__key_0",
+			  if("chess_goat" NOT LIKE 'K%', "chess_goat", NULL) AS "aggr__1__key_0",
 			  count(*) AS "aggr__1__count"
 			FROM __quesma_table_name
-			GROUP BY if("chess_goat" LIKE 'K%', "chess_goat", NULL) AS "aggr__1__key_0"
+			GROUP BY if("chess_goat" NOT LIKE 'K%', "chess_goat", NULL) AS "aggr__1__key_0"
 			ORDER BY "aggr__1__count" DESC, "aggr__1__key_0" ASC
 			LIMIT 2`,
 	},
@@ -5060,7 +5061,7 @@ var AggregationTests2 = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(173)),
 				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 102370.42402648926),
 			}},
-			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=1§
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of terms2's size=1
 				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
 				model.NewQueryResultCol("aggr__terms1__key_0", "Logstash Airways"),
 				model.NewQueryResultCol("aggr__terms1__count", int64(3323)),
@@ -5080,7 +5081,7 @@ var AggregationTests2 = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(167)),
 				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 92215.763779),
 			}},
-			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=1
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of terms2's size=1
 				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
 				model.NewQueryResultCol("aggr__terms1__key_0", "JetBeats"),
 				model.NewQueryResultCol("aggr__terms1__count", int64(3261)),
@@ -5090,7 +5091,7 @@ var AggregationTests2 = []AggregationTestCase{
 				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(147)),
 				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 90242.31663285477),
 			}},
-			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=2
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of terms1's size=2
 				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
 				model.NewQueryResultCol("aggr__terms1__key_0", "Kibana Airlines"),
 				model.NewQueryResultCol("aggr__terms1__count", int64(3219)),
@@ -5138,7 +5139,6 @@ var AggregationTests2 = []AggregationTestCase{
 	},
 	{ // [76]
 		TestName: "terms with exclude, but with branched off aggregation tree",
-		// One simple test, for more regex tests see util/regex unit tests
 		QueryRequestJson: `
 		{
 			"aggs": {

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -4706,24 +4706,9 @@ var AggregationTests2 = []AggregationTestCase{
 			"size": 0,
 			"track_total_hits": true
 		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
 		ExpectedResponse: `
 		{
-			"took": 11,
-			"timed_out": false,
-			"_shards": {
-				"total": 1,
-				"successful": 1,
-				"skipped": 0,
-				"failed": 0
-			},
-			"hits": {
-				"total": {
-					"value": 10000,
-					"relation": "gte"
-				},
-				"max_score": null,
-				"hits": []
-			},
 			"aggregations": {
 				"1": {
 					"doc_count_error_upper_bound": 0,
@@ -4755,11 +4740,10 @@ var AggregationTests2 = []AggregationTestCase{
 		},
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__1__parent_count",
-			  if("chess_goat" NOT IN tuple(Carlsen, Kasparov, Fis._er*), "chess_goat", NULL)
+			  if("chess_goat" NOT IN tuple('Carlsen', 'Kasparov', 'Fis._er*'), "chess_goat", NULL)
 			  AS "aggr__1__key_0", count(*) AS "aggr__1__count"
 			FROM __quesma_table_name
-			GROUP BY if("chess_goat" NOT IN tuple(Carlsen, Kasparov, Fis._er*), "chess_goat"
-			  , NULL) AS "aggr__1__key_0"
+			GROUP BY if("chess_goat" NOT IN tuple('Carlsen', 'Kasparov', 'Fis._er*'), "chess_goat", NULL) AS "aggr__1__key_0"
 			ORDER BY "aggr__1__count" DESC, "aggr__1__key_0" ASC
 			LIMIT 3`,
 	},
@@ -4779,24 +4763,9 @@ var AggregationTests2 = []AggregationTestCase{
 			"size": 0,
 			"track_total_hits": true
 		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
 		ExpectedResponse: `
 		{
-			"took": 11,
-			"timed_out": false,
-			"_shards": {
-				"total": 1,
-				"successful": 1,
-				"skipped": 0,
-				"failed": 0
-			},
-			"hits": {
-				"total": {
-					"value": 10000,
-					"relation": "gte"
-				},
-				"max_score": null,
-				"hits": []
-			},
 			"aggregations": {
 				"1": {
 					"doc_count_error_upper_bound": 0,
@@ -4847,24 +4816,9 @@ var AggregationTests2 = []AggregationTestCase{
 			"size": 0,
 			"track_total_hits": true
 		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
 		ExpectedResponse: `
 		{
-			"took": 11,
-			"timed_out": false,
-			"_shards": {
-				"total": 1,
-				"successful": 1,
-				"skipped": 0,
-				"failed": 0
-			},
-			"hits": {
-				"total": {
-					"value": 1000,
-					"relation": "eq"
-				},
-				"max_score": null,
-				"hits": []
-			},
 			"aggregations": {
 				"1": {
 					"doc_count_error_upper_bound": 0,
@@ -4915,24 +4869,9 @@ var AggregationTests2 = []AggregationTestCase{
 			"size": 0,
 			"track_total_hits": true
 		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
 		ExpectedResponse: `
 		{
-			"took": 11,
-			"timed_out": false,
-			"_shards": {
-				"total": 1,
-				"successful": 1,
-				"skipped": 0,
-				"failed": 0
-			},
-			"hits": {
-				"total": {
-					"value": 10000,
-					"relation": "gte"
-				},
-				"max_score": null,
-				"hits": []
-			},
 			"aggregations": {
 				"1": {
 					"doc_count_error_upper_bound": 0,
@@ -4966,5 +4905,337 @@ var AggregationTests2 = []AggregationTestCase{
 			GROUP BY if("chess_goat" LIKE 'K%', "chess_goat", NULL) AS "aggr__1__key_0"
 			ORDER BY "aggr__1__count" DESC, "aggr__1__key_0" ASC
 			LIMIT 2`,
+	},
+	{ // [74]
+		TestName: "complex terms with exclude: nested terms + 2 metrics",
+		QueryRequestJson: `
+		{
+			"aggs": {
+				"terms1": {
+					"aggs": {
+						"metric1": {
+							"avg": {
+								"field": "DistanceMiles"
+							}
+						},
+						"terms2": {
+							"aggs": {
+								"metric2": {
+									"sum": {
+										"field": "AvgTicketPrice"
+									}
+								}
+							},
+							"terms": {
+								"field": "DestCityName",
+								"size": 1
+							}
+						}
+					},
+					"terms": {
+						"exclude": [
+							"a",
+							"b"
+						],
+						"field": "Carrier",
+						"size": 2
+					}
+				}
+			},
+			"size": 0,
+			"track_total_hits": true
+		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
+		ExpectedResponse: `
+		{
+			"aggregations": {
+				"terms1": {
+					"buckets": [
+						{
+							"doc_count": 3323,
+							"key": "Logstash Airways",
+							"metric1": {
+								"value": 4451.946294580208
+							},
+							"terms2": {
+								"buckets": [
+									{
+										"doc_count": 173,
+										"key": "Zurich",
+										"metric2": {
+											"value": 102370.42402648926
+										}
+									}
+								],
+								"doc_count_error_upper_bound": 0,
+								"sum_other_doc_count": 3150
+							}
+						},
+						{
+							"doc_count": 3261,
+							"key": "JetBeats",
+							"metric1": {
+								"value": 4434.670874554115
+							},
+							"terms2": {
+								"buckets": [
+									{
+										"doc_count": 167,
+										"key": "Zurich",
+										"metric2": {
+											"value": 92215.76377868652
+										}
+									}
+								],
+								"doc_count_error_upper_bound": 0,
+								"sum_other_doc_count": 3094
+							}
+						}
+					],
+					"doc_count_error_upper_bound": 0,
+					"sum_other_doc_count": 6430
+				}
+			}
+		}`,
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "Logstash Airways"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3323)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4451.946294580208),
+				model.NewQueryResultCol("aggr__terms1__terms2__parent_count", int64(3323)),
+				model.NewQueryResultCol("aggr__terms1__terms2__key_0", "Zurich"),
+				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(173)),
+				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 102370.42402648926),
+			}},
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=1§
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "Logstash Airways"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3323)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4451.946294580208),
+				model.NewQueryResultCol("aggr__terms1__terms2__parent_count", int64(3323)),
+				model.NewQueryResultCol("aggr__terms1__terms2__key_0", "Wąchock"),
+				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(150)),
+				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", nil),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "JetBeats"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3261)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4434.670878262596),
+				model.NewQueryResultCol("aggr__terms1__terms2__parent_count", int64(3261)),
+				model.NewQueryResultCol("aggr__terms1__terms2__key_0", "Zurich"),
+				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(167)),
+				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 92215.763779),
+			}},
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=1
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "JetBeats"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3261)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4434.670878262596),
+				model.NewQueryResultCol("aggr__terms1__terms2__parent_count", int64(3261)),
+				model.NewQueryResultCol("aggr__terms1__terms2__key_0", "Wąchock"),
+				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(147)),
+				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 90242.31663285477),
+			}},
+			{Cols: []model.QueryResultCol{ // should be discarded by us because of size=2
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "Kibana Airlines"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3219)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4335.019248495363),
+				model.NewQueryResultCol("aggr__terms1__terms2__parent_count", int64(3219)),
+				model.NewQueryResultCol("aggr__terms1__terms2__key_0", "Zurich"),
+				model.NewQueryResultCol("aggr__terms1__terms2__count", int64(173)),
+				model.NewQueryResultCol("metric__terms1__terms2__metric2_col_0", 99314.3501429406),
+			}},
+		},
+		ExpectedPancakeSQL: `
+			SELECT "aggr__terms1__parent_count", "aggr__terms1__key_0",
+			  "aggr__terms1__count", "metric__terms1__metric1_col_0",
+			  "aggr__terms1__terms2__parent_count", "aggr__terms1__terms2__key_0",
+			  "aggr__terms1__terms2__count", "metric__terms1__terms2__metric2_col_0"
+			FROM (
+			  SELECT "aggr__terms1__parent_count", "aggr__terms1__key_0",
+				"aggr__terms1__count", "metric__terms1__metric1_col_0",
+				"aggr__terms1__terms2__parent_count", "aggr__terms1__terms2__key_0",
+				"aggr__terms1__terms2__count", "metric__terms1__terms2__metric2_col_0",
+				dense_rank() OVER (ORDER BY "aggr__terms1__count" DESC,
+				"aggr__terms1__key_0" ASC) AS "aggr__terms1__order_1_rank",
+				dense_rank() OVER (PARTITION BY "aggr__terms1__key_0" ORDER BY
+				"aggr__terms1__terms2__count" DESC, "aggr__terms1__terms2__key_0" ASC) AS
+				"aggr__terms1__terms2__order_1_rank"
+			  FROM (
+				SELECT sum(count(*)) OVER () AS "aggr__terms1__parent_count",
+				  if("Carrier" NOT IN tuple('a', 'b'), "Carrier", NULL) AS "aggr__terms1__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__terms1__key_0") AS
+				  "aggr__terms1__count",
+				  avgOrNullMerge(avgOrNullState("DistanceMiles")) OVER (PARTITION BY
+				  "aggr__terms1__key_0") AS "metric__terms1__metric1_col_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__terms1__key_0") AS
+				  "aggr__terms1__terms2__parent_count",
+				  "DestCityName" AS "aggr__terms1__terms2__key_0",
+				  count(*) AS "aggr__terms1__terms2__count",
+				  sumOrNull("AvgTicketPrice") AS "metric__terms1__terms2__metric2_col_0"
+				FROM __quesma_table_name
+				GROUP BY if("Carrier" NOT IN tuple('a', 'b'), "Carrier", NULL) AS
+				  "aggr__terms1__key_0", "DestCityName" AS "aggr__terms1__terms2__key_0"))
+			WHERE ("aggr__terms1__order_1_rank"<=3 AND "aggr__terms1__terms2__order_1_rank"
+			  <=2)
+			ORDER BY "aggr__terms1__order_1_rank" ASC,
+			  "aggr__terms1__terms2__order_1_rank" ASC`,
+	},
+	{ // [75]
+		TestName: "terms with exclude, but with branched off aggregation tree",
+		// One simple test, for more regex tests see util/regex unit tests
+		QueryRequestJson: `
+		{
+			"aggs": {
+				"terms1": {
+					"aggs": {
+						"metric1": {
+							"avg": {
+								"field": "DistanceMiles"
+							}
+						}
+					},
+					"terms": {
+						"exclude": [
+							"a",
+							"b"
+						],
+						"field": "Carrier",
+						"size": 1
+					}
+				},
+				"terms2": {
+					"aggs": {
+						"metric1": {
+							"avg": {
+								"field": "DistanceMiles"
+							}
+						}
+					},
+					"terms": {
+						"exclude": [
+							"Logstash Airways",
+							".*"
+						],
+						"field": "Carrier",
+						"size": 2
+					}
+				}
+			},
+			"size": 0,
+			"track_total_hits": true
+		}`,
+		// I omit "took", "timed_out", "_shards", and "hits" from the response for brevity (they can also be easily unit-tested)
+		ExpectedResponse: `
+		{
+			"_shards": {
+				"failed": 0,
+				"skipped": 0,
+				"successful": 1,
+				"total": 1
+			},
+			"aggregations": {
+				"terms1": {
+					"buckets": [
+						{
+							"doc_count": 3323,
+							"key": "Logstash Airways",
+							"metric1": {
+								"value": 4451.946294580208
+							}
+						}
+					],
+					"doc_count_error_upper_bound": 0,
+					"sum_other_doc_count": 9691
+				},
+				"terms2": {
+					"buckets": [
+						{
+							"doc_count": 3261,
+							"key": "JetBeats",
+							"metric1": {
+								"value": 4434.670874554115
+							}
+						},
+						{
+							"doc_count": 3219,
+							"key": "Kibana Airlines",
+							"metric1": {
+								"value": 4335.019245198367
+							}
+						}
+					],
+					"doc_count_error_upper_bound": 0,
+					"sum_other_doc_count": 6534
+				}
+			},
+			"hits": {
+				"hits": [],
+				"max_score": null,
+				"total": {
+					"relation": "eq",
+					"value": 13014
+				}
+			},
+			"timed_out": false,
+			"took": 18
+		}`,
+		ExpectedPancakeResults: []model.QueryResultRow{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "Logstash Airways"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(3323)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 4451.946294580208),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms1__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms1__key_0", "Discard"),
+				model.NewQueryResultCol("aggr__terms1__count", int64(5)),
+				model.NewQueryResultCol("metric__terms1__metric1_col_0", 6.20),
+			}},
+		},
+		ExpectedPancakeSQL: `
+			SELECT sum(count(*)) OVER () AS "aggr__terms1__parent_count",
+			  if("Carrier" NOT IN tuple('a', 'b'), "Carrier", NULL) AS "aggr__terms1__key_0"
+			  , count(*) AS "aggr__terms1__count",
+			  avgOrNull("DistanceMiles") AS "metric__terms1__metric1_col_0"
+			FROM __quesma_table_name
+			GROUP BY if("Carrier" NOT IN tuple('a', 'b'), "Carrier", NULL) AS
+			  "aggr__terms1__key_0"
+			ORDER BY "aggr__terms1__count" DESC, "aggr__terms1__key_0" ASC
+			LIMIT 2`,
+		ExpectedAdditionalPancakeResults: [][]model.QueryResultRow{{
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms2__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms2__key_0", "JetBeats"),
+				model.NewQueryResultCol("aggr__terms2__count", int64(3261)),
+				model.NewQueryResultCol("metric__terms2__metric1_col_0", 4434.670874554115),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms2__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms2__key_0", "Kibana Airlines"),
+				model.NewQueryResultCol("aggr__terms2__count", int64(3219)),
+				model.NewQueryResultCol("metric__terms2__metric1_col_0", 4335.019245198367),
+			}},
+			{Cols: []model.QueryResultCol{
+				model.NewQueryResultCol("aggr__terms2__parent_count", int64(13014)),
+				model.NewQueryResultCol("aggr__terms2__key_0", "Discard"),
+				model.NewQueryResultCol("aggr__terms2__count", int64(11)),
+				model.NewQueryResultCol("metric__terms2__metric1_col_0", 42),
+			}},
+		}},
+		ExpectedAdditionalPancakeSQLs: []string{`
+			SELECT sum(count(*)) OVER () AS "aggr__terms2__parent_count",
+			  if("Carrier" NOT IN tuple('Logstash Airways', '.*'), "Carrier", NULL) AS
+			  "aggr__terms2__key_0", count(*) AS "aggr__terms2__count",
+			  avgOrNull("DistanceMiles") AS "metric__terms2__metric1_col_0"
+			FROM __quesma_table_name
+			GROUP BY if("Carrier" NOT IN tuple('Logstash Airways', '.*'), "Carrier", NULL)
+			  AS "aggr__terms2__key_0"
+			ORDER BY "aggr__terms2__count" DESC, "aggr__terms2__key_0" ASC
+			LIMIT 3`},
 	},
 }

--- a/quesma/util/regex/regex.go
+++ b/quesma/util/regex/regex.go
@@ -18,7 +18,8 @@ func ToClickhouseExpr(pattern string) (clickhouseFuncName string, patternExpr mo
 		}
 		// .* allowed, but [any other char]* - not
 		for i, char := range pattern[1:] {
-			if char == '*' && pattern[i] != '.' {
+			prevChar := pattern[i]
+			if char == '*' && prevChar != '.' {
 				return false
 			}
 		}

--- a/quesma/util/regex/regex.go
+++ b/quesma/util/regex/regex.go
@@ -1,0 +1,39 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package regex
+
+import (
+	"quesma/model"
+	"strings"
+)
+
+// ToClickhouseExpr converts a regex pattern to a Clickhouse expression.
+// It's our old heuristic, maybe it'll need to be improved.
+func ToClickhouseExpr(pattern string) (clickhouseFuncName string, patternExpr model.Expr) {
+	// really simple == (out of all special characters, only . and .* may be present)
+	isPatternReallySimple := func(pattern string) bool {
+		// any special characters excluding . and * not allowed. Also (not the most important check) * can't be first character.
+		if strings.ContainsAny(pattern, `?+|{}[]()"\`) || (len(pattern) > 0 && pattern[0] == '*') {
+			return false
+		}
+		// .* allowed, but [any other char]* - not
+		for i, char := range pattern[1:] {
+			if char == '*' && pattern[i] != '.' {
+				return false
+			}
+		}
+		return true
+	}
+
+	var funcName string
+	if isPatternReallySimple(pattern) {
+		pattern = strings.ReplaceAll(pattern, "_", `\_`)
+		pattern = strings.ReplaceAll(pattern, ".*", "%")
+		pattern = strings.ReplaceAll(pattern, ".", "_")
+		funcName = "LIKE"
+	} else { // this Clickhouse function is much slower, so we use it only for complex regexps
+		funcName = "REGEXP"
+	}
+
+	return funcName, model.NewLiteral("'" + pattern + "'")
+}


### PR DESCRIPTION
https://github.com/QuesmaOrg/quesma/issues/1085

TODO (next PRs):
* `include` parameter can probably be quite easily handled the same way
* our regex translator is pretty basic, it requires tests + possibly a better implementation

Issue from the issue works fine now:
<img width="1420" alt="Screenshot 2024-12-27 at 01 30 32" src="https://github.com/user-attachments/assets/2b943135-7d10-4dd7-b418-600cd3a2632c" />
<img width="1416" alt="Screenshot 2024-12-27 at 01 32 17" src="https://github.com/user-attachments/assets/39b82688-1816-42b9-8823-77a93af6e108" />
