### PR TITLE
Quickfix: `bool` column with `terms` aggr

### DIFF
--- a/quesma/model/bucket_aggregations/terms.go
+++ b/quesma/model/bucket_aggregations/terms.go
@@ -37,16 +37,18 @@ func (query Terms) TranslateSqlResponseToJson(rows []model.QueryResultRow) model
 
 	var keyIsBool bool
 	for _, row := range rows {
+		key := query.key(row)
+		if key == nil {
+			continue
+		}
+
 		switch query.key(row).(type) {
 		case bool, *bool:
 			keyIsBool = true
-			break
-		case nil:
-			continue
 		default:
 			keyIsBool = false
-			break
 		}
+		break
 	}
 
 	var response []model.JsonMap

--- a/quesma/model/pipeline_aggregations/common.go
+++ b/quesma/model/pipeline_aggregations/common.go
@@ -43,11 +43,10 @@ func calculateResultWhenMissingCommonForDiffAggregations(ctx context.Context, pa
 		if row.LastColValue() != nil {
 			firstNonNilIndex = i + rowsWithNilValueCnt
 			break
-		} else {
-			resultRow := row.Copy()
-			resultRow.Cols[len(resultRow.Cols)-1].Value = nil
-			resultRows = append(resultRows, resultRow)
 		}
+		resultRow := row.Copy()
+		resultRow.Cols[len(resultRow.Cols)-1].Value = nil
+		resultRows = append(resultRows, resultRow)
 	}
 	if firstNonNilIndex == -1 {
 		return resultRows

--- a/quesma/model/pipeline_aggregations/max_bucket.go
+++ b/quesma/model/pipeline_aggregations/max_bucket.go
@@ -61,13 +61,7 @@ func (query MaxBucket) calculateSingleMaxBucket(parentRows []model.QueryResultRo
 	var resultValue any
 	var resultKeys []any
 
-	firstNonNilIndex := -1
-	for i, row := range parentRows {
-		if row.LastColValue() != nil {
-			firstNonNilIndex = i
-			break
-		}
-	}
+	firstNonNilIndex := model.FirstNonNilIndex(parentRows)
 	if firstNonNilIndex == -1 {
 		resultRow := parentRows[0].Copy()
 		resultRow.Cols[len(resultRow.Cols)-1].Value = model.JsonMap{

--- a/quesma/model/pipeline_aggregations/sum_bucket.go
+++ b/quesma/model/pipeline_aggregations/sum_bucket.go
@@ -60,13 +60,7 @@ func (query SumBucket) CalculateResultWhenMissing(parentRows []model.QueryResult
 func (query SumBucket) calculateSingleSumBucket(parentRows []model.QueryResultRow) model.QueryResultRow {
 	var resultValue any
 
-	firstNonNilIndex := -1
-	for i, row := range parentRows {
-		if row.LastColValue() != nil {
-			firstNonNilIndex = i
-			break
-		}
-	}
+	firstNonNilIndex := model.FirstNonNilIndex(parentRows)
 	if firstNonNilIndex == -1 {
 		resultRow := parentRows[0].Copy()
 		resultRow.Cols[len(resultRow.Cols)-1].Value = model.JsonMap{

--- a/quesma/model/query_result.go
+++ b/quesma/model/query_result.go
@@ -111,3 +111,12 @@ func (r *QueryResultRow) Copy() QueryResultRow {
 func (r *QueryResultRow) LastColValue() any {
 	return r.Cols[len(r.Cols)-1].Value
 }
+
+func FirstNonNilIndex(rows []QueryResultRow) int {
+	for i, row := range rows {
+		if row.LastColValue() != nil {
+			return i
+		}
+	}
+	return -1
+}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,10 +52,6 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
-			if i != 104 {
-				//t.Skip()
-			}
-
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/queryparser/pancake_sql_query_generation_test.go
+++ b/quesma/queryparser/pancake_sql_query_generation_test.go
@@ -52,6 +52,10 @@ func TestPancakeQueryGeneration(t *testing.T) {
 				t.Skip("Fix filters")
 			}
 
+			if i != 104 {
+				//t.Skip()
+			}
+
 			if test.TestName == "Line, Y-axis: Min, Buckets: Date Range, X-Axis: Terms, Split Chart: Date Histogram(file:kibana-visualize/agg_req,nr:9)" {
 				t.Skip("Date range is broken, fix in progress (PR #971)")
 			}

--- a/quesma/testdata/aggregation_requests_2.go
+++ b/quesma/testdata/aggregation_requests_2.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+var randomTrueVariableUsedBelow = true
+
 // Goland lags a lot when you edit aggregation_requests.go file, so let's add new tests to this one.
 
 var AggregationTests2 = []AggregationTestCase{
@@ -5340,7 +5342,7 @@ var AggregationTests2 = []AggregationTestCase{
 			}},
 			{Cols: []model.QueryResultCol{
 				model.NewQueryResultCol("aggr__terms__parent_count", int64(50000)),
-				model.NewQueryResultCol("aggr__terms__key_0", &someTrue),
+				model.NewQueryResultCol("aggr__terms__key_0", &randomTrueVariableUsedBelow), // used here
 				model.NewQueryResultCol("aggr__terms__count", int64(2)),
 			}},
 		},

--- a/quesma/testdata/kibana-visualize/aggregation_requests.go
+++ b/quesma/testdata/kibana-visualize/aggregation_requests.go
@@ -960,7 +960,8 @@ var AggregationTests = []testdata.AggregationTestCase{
 										"95.0": 15480.335426897316
 									}
 								},
-								"key": false,
+								"key": 0,
+								"key_as_string": "false",
 								"doc_count": 2974
 							},
 							{
@@ -991,7 +992,8 @@ var AggregationTests = []testdata.AggregationTestCase{
 										"95.0": 14463.254101562497
 									}
 								},
-								"key": true,
+								"key": 1,
+								"key_as_string": "true",
 								"doc_count": 419
 							}
 						]

--- a/quesma/testdata/opensearch-visualize/pipeline_aggregation_requests.go
+++ b/quesma/testdata/opensearch-visualize/pipeline_aggregation_requests.go
@@ -988,7 +988,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 							"key": 1714871400000,
 							"key_as_string": "2024-05-05T01:10:00.000"
 						},
-{
+						{
 							"1": {
 								"value": 0.0
 							},
@@ -999,7 +999,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 							"key": 1714872000000,
 							"key_as_string": "2024-05-05T01:20:00.000"
 						},
-{
+						{
 							"1": {
 								"value": 0.0
 							},
@@ -1010,7 +1010,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 							"key": 1714872600000,
 							"key_as_string": "2024-05-05T01:30:00.000"
 						},
-{
+						{
 							"1": {
 								"value": 0.0
 							},
@@ -1021,7 +1021,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 							"key": 1714873200000,
 							"key_as_string": "2024-05-05T01:40:00.000"
 						},
-{
+						{
 							"1": {
 								"value": 0.0
 							},
@@ -1032,7 +1032,7 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 							"key": 1714873800000,
 							"key_as_string": "2024-05-05T01:50:00.000"
 						},
-{
+						{
 							"1": {
 								"value": 0.0
 							},
@@ -3345,11 +3345,13 @@ var PipelineAggregationTests = []testdata.AggregationTestCase{
 					"buckets": [
 						{
 							"doc_count": 260,
-							"key": true
+							"key": 1,
+							"key_as_string": "true"
 						},
 						{
 							"doc_count": 1923,
-							"key": false
+							"key": 0,
+							"key_as_string": "false"
 						}
 					],
 					"doc_count_error_upper_bound": 0,

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -737,6 +737,19 @@ func ExtractNumeric64(value any) float64 {
 	return asFloat64
 }
 
+// ExtractBool returns:
+// * (value as bool, nil), if value is either bool or *bool
+// * (false, err), otherwise
+func ExtractBool(value any) (bool, error) {
+	switch valueTyped := value.(type) {
+	case bool:
+		return valueTyped, nil
+	case *bool:
+		return *valueTyped, nil
+	}
+	return false, fmt.Errorf("ExtractBool, value of incorrect type. Expected (*)bool, received: %v; type: %T", value, value)
+}
+
 type sqlMockMismatchSql struct {
 	expected string
 	actual   string

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -737,17 +737,18 @@ func ExtractNumeric64(value any) float64 {
 	return asFloat64
 }
 
-// ExtractBool returns:
-// * (value as bool, nil), if value is either bool or *bool
-// * (false, err), otherwise
-func ExtractBool(value any) (bool, error) {
-	switch valueTyped := value.(type) {
-	case bool:
-		return valueTyped, nil
-	case *bool:
-		return *valueTyped, nil
+func BoolToInt(b bool) int {
+	if b {
+		return 1
 	}
-	return false, fmt.Errorf("ExtractBool, value of incorrect type. Expected (*)bool, received: %v; type: %T", value, value)
+	return 0
+}
+
+func BoolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 type sqlMockMismatchSql struct {


### PR DESCRIPTION
Response for a `bool` bucket needs to be slightly different.

Before:
<img width="1728" alt="Screenshot 2024-12-28 at 15 42 21" src="https://github.com/user-attachments/assets/adf4c2e9-067e-4964-87fb-e2ccaead19b9" />
After:
<img width="1728" alt="Screenshot 2024-12-28 at 15 17 41" src="https://github.com/user-attachments/assets/3713f95e-53b2-46a6-a383-d1fd665ce02e" />
