### PR TITLE
Respect `ingestStatistics` config parameter

### DIFF
--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -779,7 +779,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		}
 
 		conf.EnableIngest = true
-		conf.IngestStatistics = true
+		conf.IngestStatistics = c.IngestStatistics
 
 		for indexName, indexConfig := range ingestProcessor.Config.IndexConfig {
 			processedConfig, found := conf.IndexConfig[indexName]


### PR DESCRIPTION
Ingest statistics were enabled by default. If we have a lot of indexes, these stats can lead to OOM. This PR fixes configuration parsing. Ingest statistics are disabled by default now. 

<img width="2106" alt="Screenshot 2024-12-30 at 13 14 20" src="https://github.com/user-attachments/assets/a45f1a2a-f570-444c-b9ca-0f41d3dcb989" />
<img width="705" alt="Screenshot 2024-12-30 at 13 33 15" src="https://github.com/user-attachments/assets/5fdde056-8de6-4dec-a86d-2fe11a0cbf28" />
