### PR TITLE
Async Insert Optimizer

### DIFF
--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -761,7 +761,7 @@ func (ip *IngestProcessor) applyAsyncInsertOptimizer(tableName string, clickhous
 	var asyncInsertProps map[string]string
 
 	if optimizer, ok := ip.cfg.DefaultIngestOptimizers[asyncInsertOptimizerName]; ok {
-		if optimizer.Disabled == false {
+		if !optimizer.Disabled {
 			enableAsyncInsert = true
 			asyncInsertProps = optimizer.Properties
 		}

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -769,11 +769,9 @@ func (ip *IngestProcessor) applyAsyncInsertOptimizer(tableName string, clickhous
 
 	idxCfg, ok := ip.cfg.IndexConfig[tableName]
 	if ok {
-		if properties, disabled := idxCfg.GetOptimizerConfiguration(asyncInsertOptimizerName); !disabled {
-			enableAsyncInsert = true
-			asyncInsertProps = properties
-		} else {
-			enableAsyncInsert = false
+		if optimizer, ok := idxCfg.Optimizers[asyncInsertOptimizerName]; ok {
+			enableAsyncInsert = !optimizer.Disabled
+			asyncInsertProps = optimizer.Properties
 		}
 	}
 

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -754,6 +754,46 @@ func (lm *IngestProcessor) ProcessInsertQuery(ctx context.Context, tableName str
 	return nil
 }
 
+func (ip *IngestProcessor) applyAsyncInsertOptimizer(tableName string, clickhouseSettings clickhouse.Settings) clickhouse.Settings {
+
+	const asyncInsertOptimizerName = "async_insert"
+	enableAsyncInsert := false
+	var asyncInsertProps map[string]string
+
+	if optimizer, ok := ip.cfg.DefaultIngestOptimizers[asyncInsertOptimizerName]; ok {
+		if optimizer.Disabled == false {
+			enableAsyncInsert = true
+			asyncInsertProps = optimizer.Properties
+		}
+	}
+
+	idxCfg, ok := ip.cfg.IndexConfig[tableName]
+	if ok {
+		if properties, disabled := idxCfg.GetOptimizerConfiguration(asyncInsertOptimizerName); !disabled {
+			enableAsyncInsert = true
+			asyncInsertProps = properties
+		} else {
+			enableAsyncInsert = false
+		}
+	}
+
+	if enableAsyncInsert {
+		clickhouseSettings["async_insert"] = 1
+
+		// some sane defaults
+		clickhouseSettings["wait_for_async_insert"] = 1
+		clickhouseSettings["async_insert_busy_timeout_ms"] = 1000
+		clickhouseSettings["async_insert_max_data_size"] = 1000000
+		clickhouseSettings["async_insert_max_query_number"] = 10000
+
+		for k, v := range asyncInsertProps {
+			clickhouseSettings[k] = v
+		}
+	}
+
+	return clickhouseSettings
+}
+
 func (ip *IngestProcessor) processInsertQueryInternal(ctx context.Context, tableName string,
 	jsonData []types.JSON, transformer jsonprocessor.IngestTransformer,
 	tableFormatter TableColumNameFormatter, isVirtualTable bool) error {
@@ -776,10 +816,14 @@ func (ip *IngestProcessor) processInsertQueryInternal(ctx context.Context, table
 		return nil
 	}
 
-	// We expect to have date format set to `best_effort`
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+	clickhouseSettings := clickhouse.Settings{
 		"date_time_input_format": "best_effort",
-	}))
+	}
+
+	clickhouseSettings = ip.applyAsyncInsertOptimizer(tableName, clickhouseSettings)
+
+	// We expect to have date format set to `best_effort`
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouseSettings))
 
 	return ip.executeStatements(ctx, statements)
 }

--- a/quesma/ingest/processor2.go
+++ b/quesma/ingest/processor2.go
@@ -483,6 +483,44 @@ func (lm *IngestProcessor2) ProcessInsertQuery(ctx context.Context, tableName st
 	return nil
 }
 
+func (ip *IngestProcessor2) applyAsyncInsertOptimizer(tableName string, clickhouseSettings clickhouse.Settings) clickhouse.Settings {
+
+	const asyncInsertOptimizerName = "async_insert"
+	enableAsyncInsert := false
+	var asyncInsertProps map[string]string
+
+	if optimizer, ok := ip.cfg.DefaultIngestOptimizers[asyncInsertOptimizerName]; ok {
+		if !optimizer.Disabled {
+			enableAsyncInsert = true
+			asyncInsertProps = optimizer.Properties
+		}
+	}
+
+	idxCfg, ok := ip.cfg.IndexConfig[tableName]
+	if ok {
+		if optimizer, ok := idxCfg.Optimizers[asyncInsertOptimizerName]; ok {
+			enableAsyncInsert = !optimizer.Disabled
+			asyncInsertProps = optimizer.Properties
+		}
+	}
+
+	if enableAsyncInsert {
+		clickhouseSettings["async_insert"] = 1
+
+		// some sane defaults
+		clickhouseSettings["wait_for_async_insert"] = 1
+		clickhouseSettings["async_insert_busy_timeout_ms"] = 1000
+		clickhouseSettings["async_insert_max_data_size"] = 1000000
+		clickhouseSettings["async_insert_max_query_number"] = 10000
+
+		for k, v := range asyncInsertProps {
+			clickhouseSettings[k] = v
+		}
+	}
+
+	return clickhouseSettings
+}
+
 func (ip *IngestProcessor2) processInsertQueryInternal(ctx context.Context, tableName string,
 	jsonData []types.JSON, transformer jsonprocessor.IngestTransformer,
 	tableFormatter TableColumNameFormatter, isVirtualTable bool) error {
@@ -505,10 +543,14 @@ func (ip *IngestProcessor2) processInsertQueryInternal(ctx context.Context, tabl
 		return nil
 	}
 
-	// We expect to have date format set to `best_effort`
-	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+	clickhouseSettings := clickhouse.Settings{
 		"date_time_input_format": "best_effort",
-	}))
+	}
+
+	clickhouseSettings = ip.applyAsyncInsertOptimizer(tableName, clickhouseSettings)
+
+	// We expect to have date format set to `best_effort`
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouseSettings))
 
 	return ip.executeStatements(ctx, statements)
 }

--- a/quesma/quesma/config/config.go
+++ b/quesma/quesma/config/config.go
@@ -48,6 +48,7 @@ type QuesmaConfiguration struct {
 	UseCommonTableForWildcard bool //the meaning of this is to use a common table for wildcard (default) indexes
 	DefaultIngestTarget       []string
 	DefaultQueryTarget        []string
+	DefaultIngestOptimizers   map[string]OptimizerConfiguration
 }
 
 func (c *QuesmaConfiguration) AliasFields(indexName string) map[string]string {

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -776,6 +776,14 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		conf.EnableIngest = true
 		conf.IngestStatistics = c.IngestStatistics
 
+		if defaultIngestConfig, ok := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]; ok {
+			conf.DefaultIngestOptimizers = defaultIngestConfig.Optimizers
+		} else {
+			conf.DefaultIngestOptimizers = nil
+		}
+
+		delete(ingestProcessor.Config.IndexConfig, DefaultWildcardIndexName)
+
 		for indexName, indexConfig := range ingestProcessor.Config.IndexConfig {
 			processedConfig, found := conf.IndexConfig[indexName]
 			if !found {
@@ -820,13 +828,6 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 			conf.IndexConfig[indexName] = processedConfig
 		}
 
-		if defaultIngestConfig, ok := ingestProcessor.Config.IndexConfig[DefaultWildcardIndexName]; ok {
-			conf.DefaultIngestOptimizers = defaultIngestConfig.Optimizers
-		} else {
-			conf.DefaultIngestOptimizers = nil
-		}
-
-		delete(ingestProcessor.Config.IndexConfig, DefaultWildcardIndexName)
 	}
 
 END:

--- a/quesma/quesma/config/config_v2.go
+++ b/quesma/quesma/config/config_v2.go
@@ -779,7 +779,7 @@ func (c *QuesmaNewConfiguration) TranslateToLegacyConfig() QuesmaConfiguration {
 		}
 
 		conf.EnableIngest = true
-		conf.IngestStatistics = true
+		conf.IngestStatistics = c.IngestStatistics
 
 		for indexName, indexConfig := range ingestProcessor.Config.IndexConfig {
 			processedConfig, found := conf.IndexConfig[indexName]

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -4,7 +4,6 @@ package config
 
 import (
 	"fmt"
-	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
@@ -332,17 +331,11 @@ func TestIngestOptimizers(t *testing.T) {
 	logs1, ok := legacyConf.IndexConfig["logs-1"]
 
 	assert.True(t, ok)
-
 	assert.Equal(t, 2, len(logs1.Optimizers))
-
 	assert.NotNil(t, legacyConf.DefaultIngestOptimizers)
 	assert.Equal(t, 1, len(legacyConf.DefaultIngestOptimizers))
-
-	pp.Print(legacyConf.DefaultIngestOptimizers)
-
 	assert.NotNil(t, legacyConf.DefaultIngestOptimizers["ingest_only"])
 
 	_, ok = legacyConf.DefaultIngestOptimizers["query_only"]
 	assert.False(t, ok)
-
 }

--- a/quesma/quesma/config/config_v2_test.go
+++ b/quesma/quesma/config/config_v2_test.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/k0kubun/pp"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
@@ -317,4 +318,31 @@ func TestUseCommonTableGlobalProperty(t *testing.T) {
 
 	assert.Equal(t, true, flights.UseCommonTable)
 	assert.Equal(t, false, ecommerce.UseCommonTable)
+}
+
+func TestIngestOptimizers(t *testing.T) {
+	os.Setenv(configFileLocationEnvVar, "./test_configs/ingest_only_optimizers.yaml")
+	cfg := LoadV2Config()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("error validating config: %v", err)
+	}
+	legacyConf := cfg.TranslateToLegacyConfig()
+	assert.False(t, legacyConf.TransparentProxy)
+	assert.Equal(t, 1, len(legacyConf.IndexConfig))
+	logs1, ok := legacyConf.IndexConfig["logs-1"]
+
+	assert.True(t, ok)
+
+	assert.Equal(t, 2, len(logs1.Optimizers))
+
+	assert.NotNil(t, legacyConf.DefaultIngestOptimizers)
+	assert.Equal(t, 1, len(legacyConf.DefaultIngestOptimizers))
+
+	pp.Print(legacyConf.DefaultIngestOptimizers)
+
+	assert.NotNil(t, legacyConf.DefaultIngestOptimizers["ingest_only"])
+
+	_, ok = legacyConf.DefaultIngestOptimizers["query_only"]
+	assert.False(t, ok)
+
 }

--- a/quesma/quesma/config/test_configs/ingest_only_optimizers.yaml
+++ b/quesma/quesma/config/test_configs/ingest_only_optimizers.yaml
@@ -1,0 +1,66 @@
+installationId: #HYDROLIX_REQUIRES_THIS
+frontendConnectors:
+  - name: elastic-ingest
+    type: elasticsearch-fe-ingest
+    config:
+      listenPort: 8080
+  - name: elastic-query
+    type: elasticsearch-fe-query
+    config:
+      listenPort: 8080
+backendConnectors:
+  - name: E
+    type: elasticsearch
+    config:
+      url: "http://elasticsearch:9200"
+  - name: C
+    type: clickhouse-os
+    config:
+      url: "clickhouse://clickhouse:9000"
+ingestStatistics: true
+processors:
+  - name: QP
+    type: quesma-v1-processor-query
+    config:
+      indexes:
+
+        logs-1:
+          optimizers:
+              - query_only:
+                  disabled: false
+          target:
+            - C
+
+        "*":
+          optimizers:
+            - query_only:
+                disabled: false
+          target:
+            - C
+
+  - name: IP
+    type: quesma-v1-processor-ingest
+    config:
+      indexes:
+        logs-1:
+          optimizers:
+            - ingest_only:
+               disabled: false
+          target:
+            - C
+        "*":
+          optimizers:
+            - ingest_only:
+                disabled: false
+          target:
+            - C
+
+pipelines:
+  - name: my-elasticsearch-proxy-read
+    frontendConnectors: [ elastic-query ]
+    processors: [ QP ]
+    backendConnectors: [ E, C ]
+  - name: my-elasticsearch-proxy-write
+    frontendConnectors: [ elastic-ingest ]
+    processors: [ IP ]
+    backendConnectors: [ E, C ]


### PR DESCRIPTION
This PR adds the ability to buffer inserts. If the optimizer is enabled, we add an "async insert"[1] setting to every `INSERT` query. 

Motivation: clickhouse doesn't handle multiple inserts per second well.  We need to compensate for this.


The optimizer can be enabled for all indexes 
```
...
# ingest pipeline config 

...
        '*':
          optimizers:
            - async_insert:
                disabled: false
                properties:
                  wait_for_async_insert: 0 
                  async_insert_busy_timeout_ms: 10000
          target: [ my-clickhouse-data-source ]
...
```
Or can be added to a single index.
```
...
        device_logs:
          target: [ my-clickhouse-data-source ]
          optimizers:
            - async_insert:
                disabled: true

        other:
          target: [ my-clickhouse-data-source ]
          optimizers:
            - async_insert:
                disabled: false
...
```




[1] https://clickhouse.com/blog/asynchronous-data-inserts-in-clickhouse
