### PR TITLE
More router_v2 portability (terms_enum + minor additions)

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"quesma/end_user_errors"
 	"quesma/logger"
+	"quesma/model"
 	"quesma/persistence"
 	"quesma/quesma/config"
 	"quesma/quesma/recovery"
@@ -69,6 +70,8 @@ type (
 
 type LogManagerIFace interface {
 	ResolveIndexPattern(ctx context.Context, schema schema.Registry, pattern string) (results []string, err error)
+	FindTable(tableName string) (result *Table)
+	ProcessQuery(ctx context.Context, table *Table, query *model.Query) (rows []model.QueryResultRow, performanceResult PerformanceResult, err error)
 }
 
 func NewTableMap() *TableMap {

--- a/quesma/quesma/functionality/terms_enum/terms_enum.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-func HandleTermsEnum(ctx context.Context, index string, body types.JSON, lm *clickhouse.LogManager,
+func HandleTermsEnum(ctx context.Context, index string, body types.JSON, lm clickhouse.LogManagerIFace,
 	schemaRegistry schema.Registry, qmc diag.DebugInfoCollector) ([]byte, error) {
 	if indices, err := lm.ResolveIndexPattern(ctx, schemaRegistry, index); err != nil || len(indices) != 1 { // multi index terms enum is not yet supported
 		errorMsg := fmt.Sprintf("terms enum failed - could not resolve table name for index: %s", index)
@@ -37,7 +37,7 @@ func HandleTermsEnum(ctx context.Context, index string, body types.JSON, lm *cli
 	}
 }
 
-func handleTermsEnumRequest(ctx context.Context, body types.JSON, lm *clickhouse.LogManager, qt *queryparser.ClickhouseQueryTranslator,
+func handleTermsEnumRequest(ctx context.Context, body types.JSON, lm clickhouse.LogManagerIFace, qt *queryparser.ClickhouseQueryTranslator,
 	qmc diag.DebugInfoCollector) (result []byte, err error) {
 	startTime := time.Now()
 

--- a/quesma/quesma/route_handlers.go
+++ b/quesma/quesma/route_handlers.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 	"quesma/clickhouse"
 	"quesma/elasticsearch"
+	"quesma/logger"
 	"quesma/queryparser"
 	"quesma/quesma/config"
 	quesma_errors "quesma/quesma/errors"
 	"quesma/quesma/functionality/field_capabilities"
 	"quesma/quesma/functionality/resolve"
+	"quesma/quesma/functionality/terms_enum"
 	"quesma/quesma/types"
 	"quesma/schema"
 	quesma_api "quesma_v2/core"
@@ -120,4 +122,62 @@ func HandleFieldCaps(ctx context.Context, indexPattern string, allowNoIndices, i
 		}
 	}
 	return elasticsearchQueryResult(string(responseBody), http.StatusOK), nil
+}
+
+func HandlePutIndex(index string, reqBody types.JSON, sr schema.Registry) (*quesma_api.Result, error) {
+	if len(reqBody) == 0 {
+		logger.Warn().Msgf("empty body in PUT /%s request, Quesma is not doing anything", index)
+		return putIndexResult(index)
+	}
+
+	mappings, ok := reqBody["mappings"]
+	if !ok {
+		logger.Warn().Msgf("no mappings found in PUT /%s request, ignoring that request. Full content: %s", index, reqBody)
+		return putIndexResult(index)
+	}
+	columns := elasticsearch.ParseMappings("", mappings.(map[string]interface{}))
+
+	sr.UpdateDynamicConfiguration(schema.IndexName(index), schema.Table{Columns: columns})
+
+	return putIndexResult(index)
+}
+
+func HandleGetIndex(sr schema.Registry, index string) (*quesma_api.Result, error) {
+	foundSchema, found := sr.FindSchema(schema.IndexName(index))
+	if !found {
+		return &quesma_api.Result{StatusCode: http.StatusNotFound, GenericResult: make([]byte, 0)}, nil
+	}
+
+	hierarchicalSchema := schema.SchemaToHierarchicalSchema(&foundSchema)
+	mappings := elasticsearch.GenerateMappings(hierarchicalSchema)
+
+	return getIndexResult(index, mappings)
+}
+
+func HandleTermsEnum(ctx context.Context, indexPattern string, body types.JSON, lm clickhouse.LogManagerIFace, sr schema.Registry, dependencies quesma_api.Dependencies) (*quesma_api.Result, error) {
+	if responseBody, err := terms_enum.HandleTermsEnum(ctx, indexPattern, body, lm, sr, dependencies.DebugInfoCollector()); err != nil {
+		return nil, err
+	} else {
+		return elasticsearchQueryResult(string(responseBody), http.StatusOK), nil
+	}
+}
+
+func HandleClusterHealth() (*quesma_api.Result, error) {
+	return ElasticsearchQueryResult(`{"cluster_name": "quesma"}`, http.StatusOK), nil
+}
+
+func HandleIndexRefresh() (*quesma_api.Result, error) {
+	return ElasticsearchInsertResult(`{"_shards":{"total":1,"successful":1,"failed":0}}`, http.StatusOK), nil
+}
+
+func HandleGetIndexMapping(sr schema.Registry, index string) (*quesma_api.Result, error) {
+	foundSchema, found := sr.FindSchema(schema.IndexName(index))
+	if !found {
+		return &quesma_api.Result{StatusCode: http.StatusNotFound, GenericResult: make([]byte, 0)}, nil
+	}
+
+	hierarchicalSchema := schema.SchemaToHierarchicalSchema(&foundSchema)
+	mappings := elasticsearch.GenerateMappings(hierarchicalSchema)
+
+	return getIndexMappingResult(index, mappings)
 }

--- a/quesma/quesma/router.go
+++ b/quesma/quesma/router.go
@@ -505,6 +505,11 @@ type countResult struct {
 	Count int64 `json:"count"`
 }
 
+// ElasticsearchQueryResult is a low-effort way to export widely used func without too much refactoring
+func ElasticsearchQueryResult(body string, statusCode int) *quesma_api.Result {
+	return elasticsearchQueryResult(body, statusCode)
+}
+
 func elasticsearchQueryResult(body string, statusCode int) *quesma_api.Result {
 	return &quesma_api.Result{Body: body, Meta: map[string]any{
 		// TODO copy paste from the original request
@@ -576,6 +581,11 @@ func bulkInsertResult(ctx context.Context, ops []bulk.BulkItem, err error) (*que
 	}
 
 	return elasticsearchInsertResult(string(body), http.StatusOK), nil
+}
+
+// ElasticsearchInsertResult is a low-effort way to export widely used func without too much refactoring
+func ElasticsearchInsertResult(body string, statusCode int) *quesma_api.Result {
+	return elasticsearchInsertResult(body, statusCode)
 }
 
 func elasticsearchInsertResult(body string, statusCode int) *quesma_api.Result {


### PR DESCRIPTION
Mainly that's just adding 2 more methods to `LogManagerIFace` so that `terms_enum` request can be handled using `v2` api as well.
Another round of "general changes" helpful for https://github.com/QuesmaOrg/quesma/pull/1119