### PR TITLE
Get rid of additional QueryRunner

### DIFF
--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -72,6 +72,9 @@ type LogManagerIFace interface {
 	ResolveIndexPattern(ctx context.Context, schema schema.Registry, pattern string) (results []string, err error)
 	FindTable(tableName string) (result *Table)
 	ProcessQuery(ctx context.Context, table *Table, query *model.Query) (rows []model.QueryResultRow, performanceResult PerformanceResult, err error)
+	CountMultiple(ctx context.Context, tables ...string) (int64, error)
+	Count(ctx context.Context, table string) (int64, error)
+	GetTableDefinitions() (TableMap, error)
 }
 
 func NewTableMap() *TableMap {

--- a/quesma/eql/query_translator.go
+++ b/quesma/eql/query_translator.go
@@ -21,7 +21,7 @@ import (
 // It implements quesma.IQueryTranslator for EQL queries.
 
 type ClickhouseEQLQueryTranslator struct {
-	ClickhouseLM *clickhouse.LogManager
+	ClickhouseLM clickhouse.LogManagerIFace
 	Table        *clickhouse.Table
 	Ctx          context.Context
 }

--- a/quesma/quesma/query_translator.go
+++ b/quesma/quesma/query_translator.go
@@ -33,7 +33,7 @@ const (
 	QueryLanguageEQL     = "eql"
 )
 
-func NewQueryTranslator(ctx context.Context, language QueryLanguage, schema schema.Schema, table *clickhouse.Table, logManager *clickhouse.LogManager, dateMathRenderer string, indexes []string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
+func NewQueryTranslator(ctx context.Context, language QueryLanguage, schema schema.Schema, table *clickhouse.Table, logManager clickhouse.LogManagerIFace, dateMathRenderer string, indexes []string, configuration *config.QuesmaConfiguration) (queryTranslator IQueryTranslator) {
 	switch language {
 	case QueryLanguageEQL:
 		return &eql.ClickhouseEQLQueryTranslator{ClickhouseLM: logManager, Table: table, Ctx: ctx}

--- a/quesma/table_resolver/table_resolver_dummy.go
+++ b/quesma/table_resolver/table_resolver_dummy.go
@@ -1,0 +1,39 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package table_resolver
+
+import (
+	mux "quesma_v2/core"
+)
+
+// DummyTableResolver is a dummy implementation of TableResolver to satisfy the QueryRunner and make it be compatible with the v2 api
+// thanks to this we can reuse the existing QueryRunner implementation without any changes.
+type DummyTableResolver struct{}
+
+func NewDummyTableResolver() *DummyTableResolver {
+	return &DummyTableResolver{}
+}
+
+func (t DummyTableResolver) Start() {}
+
+func (t DummyTableResolver) Stop() {}
+
+func (t DummyTableResolver) Resolve(_ string, indexPattern string) *mux.Decision {
+	return &mux.Decision{
+		UseConnectors: []mux.ConnectorDecision{
+			&mux.ConnectorDecisionClickhouse{
+				ClickhouseTableName: indexPattern,
+				ClickhouseIndexes:   []string{indexPattern}, // TODO this won't work for 'common table' feature
+				//IsCommonTable: false,
+			},
+		},
+	}
+
+}
+
+func (t DummyTableResolver) Pipelines() []string { return []string{} }
+
+func (t DummyTableResolver) RecentDecisions() []mux.PatternDecisions {
+	return []mux.PatternDecisions{}
+}


### PR DESCRIPTION
Changing the QueryRunner so that it relies on `clickhouse.LogManagerIFace` instead of `*clickhouse.LogManager`.

Having that, we won't need a duplicate of `QueryRunner` in https://github.com/QuesmaOrg/quesma/pull/1119. 

Caveat: we're adding a that dumb dummy table resolver, but that's way simpler than having a copy of QueryRunner. 

Lots of LoCs to save here 😉  