### PR TITLE
Generalize `TableResolver` and `LogManager` implementation

### DIFF
--- a/quesma/backend_connectors/clickhouse_backend_connector.go
+++ b/quesma/backend_connectors/clickhouse_backend_connector.go
@@ -19,6 +19,16 @@ type ClickHouseBackendConnector struct {
 type ClickHouseRows struct {
 	rows *sql.Rows
 }
+type ClickHouseRow struct {
+	row *sql.Row
+}
+
+func (p *ClickHouseRow) Scan(dest ...interface{}) error {
+	if p.row == nil {
+		return sql.ErrNoRows
+	}
+	return p.row.Scan(dest...)
+}
 
 func (p *ClickHouseRows) Next() bool {
 	return p.rows.Next()
@@ -66,6 +76,10 @@ func (p *ClickHouseBackendConnector) Query(ctx context.Context, query string, ar
 		return nil, err
 	}
 	return &ClickHouseRows{rows: rows}, nil
+}
+
+func (p *ClickHouseBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
+	return p.connection.QueryRowContext(ctx, query, args...)
 }
 
 func (p *ClickHouseBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {

--- a/quesma/backend_connectors/clickhouse_backend_connector.go
+++ b/quesma/backend_connectors/clickhouse_backend_connector.go
@@ -28,11 +28,8 @@ func (p *ClickHouseRows) Scan(dest ...interface{}) error {
 	return p.rows.Scan(dest...)
 }
 
-func (p *ClickHouseRows) Close() {
-	err := p.rows.Close()
-	if err != nil {
-		panic(err)
-	}
+func (p *ClickHouseRows) Close() error {
+	return p.rows.Close()
 }
 
 func (p *ClickHouseRows) Err() error {
@@ -57,6 +54,10 @@ func (p *ClickHouseBackendConnector) Close() error {
 		return nil
 	}
 	return p.connection.Close()
+}
+
+func (p *ClickHouseBackendConnector) Ping() error {
+	return p.connection.Ping()
 }
 
 func (p *ClickHouseBackendConnector) Query(ctx context.Context, query string, args ...interface{}) (quesma_api.Rows, error) {
@@ -94,6 +95,15 @@ func initDBConnection() (*sql.DB, error) {
 func NewClickHouseBackendConnector(endpoint string) *ClickHouseBackendConnector {
 	return &ClickHouseBackendConnector{
 		Endpoint: endpoint,
+	}
+}
+
+// NewClickHouseBackendConnectorWithConnection bridges the gap between the ClickHouseBackendConnector and the sql.DB
+// so that it is can be used in pre-v2 code. Should be removed when moving forwards.
+func NewClickHouseBackendConnectorWithConnection(endpoint string, conn *sql.DB) *ClickHouseBackendConnector {
+	return &ClickHouseBackendConnector{
+		Endpoint:   endpoint,
+		connection: conn,
 	}
 }
 

--- a/quesma/backend_connectors/clickhouse_backend_connector.go
+++ b/quesma/backend_connectors/clickhouse_backend_connector.go
@@ -91,6 +91,14 @@ func (p *ClickHouseBackendConnector) Exec(ctx context.Context, query string, arg
 	return err
 }
 
+func (p *ClickHouseBackendConnector) Stats() quesma_api.DBStats {
+	stats := p.connection.Stats()
+	return quesma_api.DBStats{
+		MaxOpenConnections: stats.MaxOpenConnections,
+		OpenConnections:    stats.OpenConnections,
+	}
+}
+
 // func initDBConnection(c *config.QuesmaConfiguration, tlsConfig *tls.Config) *sql.DB {
 func initDBConnection() (*sql.DB, error) {
 	options := clickhouse.Options{Addr: []string{"localhost:9000"}}

--- a/quesma/backend_connectors/elasticsearch_backend_connector.go
+++ b/quesma/backend_connectors/elasticsearch_backend_connector.go
@@ -108,3 +108,7 @@ func (e *ElasticsearchBackendConnector) Exec(ctx context.Context, query string, 
 func (e *ElasticsearchBackendConnector) Close() error {
 	return nil
 }
+
+func (e *ElasticsearchBackendConnector) Ping() error {
+	return nil
+}

--- a/quesma/backend_connectors/elasticsearch_backend_connector.go
+++ b/quesma/backend_connectors/elasticsearch_backend_connector.go
@@ -101,6 +101,14 @@ func (e *ElasticsearchBackendConnector) Query(ctx context.Context, query string,
 	panic("not implemented")
 }
 
+func (e *ElasticsearchBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
+	panic("not implemented")
+}
+
+func (e *ElasticsearchBackendConnector) Stats() quesma_api.DBStats {
+	return quesma_api.DBStats{}
+}
+
 func (e *ElasticsearchBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	panic("not implemented")
 }

--- a/quesma/backend_connectors/mysql_backend_connector.go
+++ b/quesma/backend_connectors/mysql_backend_connector.go
@@ -84,6 +84,14 @@ func (p *MySqlBackendConnector) Exec(ctx context.Context, query string, args ...
 	return err
 }
 
+func (p *MySqlBackendConnector) Stats() quesma_api.DBStats {
+	stats := p.connection.Stats()
+	return quesma_api.DBStats{
+		MaxOpenConnections: stats.MaxOpenConnections,
+		OpenConnections:    stats.OpenConnections,
+	}
+}
+
 func (p *MySqlBackendConnector) Ping() error {
 	return nil
 }

--- a/quesma/backend_connectors/mysql_backend_connector.go
+++ b/quesma/backend_connectors/mysql_backend_connector.go
@@ -71,6 +71,10 @@ func (p *MySqlBackendConnector) Query(ctx context.Context, query string, args ..
 	return &MySqlRows{rows: rows}, nil
 }
 
+func (p *MySqlBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
+	return p.connection.QueryRowContext(ctx, query, args...)
+}
+
 func (p *MySqlBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	if len(args) == 0 {
 		_, err := p.connection.ExecContext(context.Background(), query)

--- a/quesma/backend_connectors/mysql_backend_connector.go
+++ b/quesma/backend_connectors/mysql_backend_connector.go
@@ -22,11 +22,8 @@ func (p *MySqlRows) Scan(dest ...interface{}) error {
 	return p.rows.Scan(dest...)
 }
 
-func (p *MySqlRows) Close() {
-	err := p.rows.Close()
-	if err != nil {
-		panic(err)
-	}
+func (p *MySqlRows) Close() error {
+	return p.rows.Close()
 }
 
 func (p *MySqlRows) Err() error {
@@ -81,4 +78,8 @@ func (p *MySqlBackendConnector) Exec(ctx context.Context, query string, args ...
 	}
 	_, err := p.connection.ExecContext(context.Background(), query, args...)
 	return err
+}
+
+func (p *MySqlBackendConnector) Ping() error {
+	return nil
 }

--- a/quesma/backend_connectors/postgres_backend_connector.go
+++ b/quesma/backend_connectors/postgres_backend_connector.go
@@ -42,6 +42,10 @@ func (p *PostgresBackendConnector) Query(ctx context.Context, query string, args
 	return &PgRows{rows: pgRows}, nil
 }
 
+func (p *PostgresBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
+	return p.connection.QueryRow(ctx, query, args...)
+}
+
 func (p *PostgresBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	if len(args) == 0 {
 		_, err := p.connection.Exec(ctx, query)

--- a/quesma/backend_connectors/postgres_backend_connector.go
+++ b/quesma/backend_connectors/postgres_backend_connector.go
@@ -55,6 +55,10 @@ func (p *PostgresBackendConnector) Exec(ctx context.Context, query string, args 
 	return err
 }
 
+func (p *PostgresBackendConnector) Stats() quesma_api.DBStats {
+	return quesma_api.DBStats{}
+}
+
 type PgRows struct {
 	rows pgx.Rows
 }

--- a/quesma/backend_connectors/postgres_backend_connector.go
+++ b/quesma/backend_connectors/postgres_backend_connector.go
@@ -35,14 +35,39 @@ func (p *PostgresBackendConnector) Close() error {
 }
 
 func (p *PostgresBackendConnector) Query(ctx context.Context, query string, args ...interface{}) (quesma_api.Rows, error) {
-	return p.connection.Query(context.Background(), query, args...)
+	pgRows, err := p.connection.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &PgRows{rows: pgRows}, nil
 }
 
 func (p *PostgresBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	if len(args) == 0 {
-		_, err := p.connection.Exec(context.Background(), query)
+		_, err := p.connection.Exec(ctx, query)
 		return err
 	}
-	_, err := p.connection.Exec(context.Background(), query, args...)
+	_, err := p.connection.Exec(ctx, query, args...)
 	return err
+}
+
+type PgRows struct {
+	rows pgx.Rows
+}
+
+func (p *PgRows) Next() bool {
+	return p.rows.Next()
+}
+
+func (p *PgRows) Scan(dest ...interface{}) error {
+	return p.rows.Scan(dest...)
+}
+
+func (p *PgRows) Close() error {
+	p.rows.Close()
+	return nil
+}
+
+func (p *PgRows) Err() error {
+	return p.rows.Err()
 }

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -205,7 +205,7 @@ func (lm *LogManager) CountMultiple(ctx context.Context, tables ...string) (int6
 	for _, t := range tables {
 		anyTables = append(anyTables, t)
 	}
-	rows, err := lm.chDb.Query(ctx, fmt.Sprintf("SELECT sum(count) as count FROM (%s)", strings.Join(subCountStatements, " UNION ALL ")), anyTables...)
+	rows, err := lm.chDb.Query(ctx, fmt.Sprintf("SELECT sum(*) as count FROM (%s)", strings.Join(subCountStatements, " UNION ALL ")), anyTables...)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
 	}
@@ -220,8 +220,7 @@ func (lm *LogManager) CountMultiple(ctx context.Context, tables ...string) (int6
 
 func (lm *LogManager) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	query := fmt.Sprintf("SELECT count(*) FROM %s", table)
-	rows, err := lm.chDb.Query(ctx, query)
+	rows, err := lm.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
 	}

--- a/quesma/clickhouse/clickhouse.go
+++ b/quesma/clickhouse/clickhouse.go
@@ -4,7 +4,6 @@ package clickhouse
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"quesma/end_user_errors"
 	"quesma/logger"
@@ -14,6 +13,7 @@ import (
 	"quesma/quesma/recovery"
 	"quesma/schema"
 	"quesma/util"
+	quesma_api "quesma_v2/core"
 	"quesma_v2/core/diag"
 	"slices"
 	"strings"
@@ -30,7 +30,7 @@ type (
 	LogManager struct {
 		ctx            context.Context
 		cancel         context.CancelFunc
-		chDb           *sql.DB
+		chDb           quesma_api.BackendConnector
 		tableDiscovery TableDiscovery
 		cfg            *config.QuesmaConfiguration
 		phoneHomeAgent diag.PhoneHomeClient
@@ -205,31 +205,37 @@ func (lm *LogManager) CountMultiple(ctx context.Context, tables ...string) (int6
 	for _, t := range tables {
 		anyTables = append(anyTables, t)
 	}
-	err := lm.chDb.QueryRowContext(ctx, fmt.Sprintf("SELECT sum(*) as count FROM (%s)", strings.Join(subCountStatements, " UNION ALL ")), anyTables...).Scan(&count)
+	rows, err := lm.chDb.Query(ctx, fmt.Sprintf("SELECT sum(*) as count FROM (%s)", strings.Join(subCountStatements, " UNION ALL ")), anyTables...)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
+	}
+	if errScan := rows.Scan(&count); errScan != nil {
+		return 0, fmt.Errorf("clickhouse: scan failed: %v", errScan)
 	}
 	return count, nil
 }
 
 func (lm *LogManager) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	err := lm.chDb.QueryRowContext(ctx, "SELECT count(*) FROM ?", table).Scan(&count)
+	rows, err := lm.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
+	}
+	if errScan := rows.Scan(&count); errScan != nil {
+		return 0, fmt.Errorf("clickhouse: scan failed: %v", errScan)
 	}
 	return count, nil
 }
 
-func (lm *LogManager) executeRawQuery(query string) (*sql.Rows, error) {
-	if res, err := lm.chDb.Query(query); err != nil {
+func (lm *LogManager) executeRawQuery(query string) (quesma_api.Rows, error) {
+	if res, err := lm.chDb.Query(context.Background(), query); err != nil {
 		return nil, fmt.Errorf("error in executeRawQuery: query: %s\nerr:%v", query, err)
 	} else {
 		return res, nil
 	}
 }
 
-func (lm *LogManager) GetDB() *sql.DB {
+func (lm *LogManager) GetDB() quesma_api.BackendConnector {
 	return lm.chDb
 }
 
@@ -327,7 +333,7 @@ func (lm *LogManager) Ping() error {
 	return lm.chDb.Ping()
 }
 
-func NewEmptyLogManager(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent diag.PhoneHomeClient, loader TableDiscovery) *LogManager {
+func NewEmptyLogManager(cfg *config.QuesmaConfiguration, chDb quesma_api.BackendConnector, phoneHomeAgent diag.PhoneHomeClient, loader TableDiscovery) *LogManager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &LogManager{ctx: ctx, cancel: cancel, chDb: chDb, tableDiscovery: loader, cfg: cfg, phoneHomeAgent: phoneHomeAgent}
 }
@@ -341,7 +347,7 @@ func NewLogManager(tables *TableMap, cfg *config.QuesmaConfiguration) *LogManage
 }
 
 // right now only for tests purposes
-func NewLogManagerWithConnection(db *sql.DB, tables *TableMap) *LogManager {
+func NewLogManagerWithConnection(db quesma_api.BackendConnector, tables *TableMap) *LogManager {
 	return &LogManager{chDb: db, tableDiscovery: NewTableDiscoveryWith(&config.QuesmaConfiguration{}, db, *tables),
 		phoneHomeAgent: diag.NewPhoneHomeEmptyAgent()}
 }

--- a/quesma/clickhouse/connection.go
+++ b/quesma/clickhouse/connection.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"net"
+	"quesma/backend_connectors"
 	"quesma/buildinfo"
 	"quesma/logger"
 	"quesma/quesma/config"
+	quesma_api "quesma_v2/core"
 	"strings"
 	"time"
 )
@@ -51,7 +53,7 @@ func initDBConnection(c *config.QuesmaConfiguration, tlsConfig *tls.Config) *sql
 
 }
 
-func InitDBConnectionPool(c *config.QuesmaConfiguration) *sql.DB {
+func InitDBConnectionPool(c *config.QuesmaConfiguration) quesma_api.BackendConnector {
 	if c.ClickHouse.Url == nil {
 		return nil
 	}
@@ -94,7 +96,7 @@ func InitDBConnectionPool(c *config.QuesmaConfiguration) *sql.DB {
 	// clean up connections after 5 minutes, before that they may be killed by the firewall
 	db.SetConnMaxLifetime(time.Duration(5) * time.Minute) // default is 1h
 
-	return db
+	return backend_connectors.NewClickHouseBackendConnectorWithConnection(c.ClickHouse.Url.String(), db)
 }
 
 // RunClickHouseConnectionDoctor is very blunt and verbose function which aims to print some helpful information

--- a/quesma/clickhouse/quesma_communicator.go
+++ b/quesma/clickhouse/quesma_communicator.go
@@ -4,7 +4,6 @@ package clickhouse
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"math/rand"
@@ -12,6 +11,7 @@ import (
 	"quesma/logger"
 	"quesma/model"
 	"quesma/quesma/recovery"
+	quesma_api "quesma_v2/core"
 	tracing "quesma_v2/core/tracing"
 	"strconv"
 	"strings"
@@ -109,7 +109,7 @@ func (lm *LogManager) explainQuery(ctx context.Context, query string, elapsed ti
 
 	explainQuery := "EXPLAIN json=1, indexes=1 " + query
 
-	rows, err := lm.chDb.QueryContext(ctx, explainQuery)
+	rows, err := lm.chDb.Query(ctx, explainQuery)
 	if err != nil {
 		logger.ErrorWithCtx(ctx).Msgf("failed to explain slow query: %v", err)
 	}
@@ -182,7 +182,7 @@ func executeQuery(ctx context.Context, lm *LogManager, query *model.Query, field
 
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings), clickhouse.WithQueryID(queryID))
 
-	rows, err := lm.chDb.QueryContext(ctx, queryAsString)
+	rows, err := lm.chDb.Query(ctx, queryAsString)
 	if err != nil {
 		elapsed := span.End(err)
 		performanceResult.Duration = elapsed
@@ -205,7 +205,7 @@ func executeQuery(ctx context.Context, lm *LogManager, query *model.Query, field
 
 // 'selectFields' are all values that we return from the query, both columns and non-schema fields,
 // like e.g. count(), or toInt8(boolField)
-func read(ctx context.Context, rows *sql.Rows, selectFields []string, rowToScan []interface{}, limit int) ([]model.QueryResultRow, error) {
+func read(ctx context.Context, rows quesma_api.Rows, selectFields []string, rowToScan []interface{}, limit int) ([]model.QueryResultRow, error) {
 
 	// read selected fields from the metadata
 

--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -4,7 +4,6 @@ package clickhouse
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"github.com/goccy/go-json"
@@ -15,6 +14,7 @@ import (
 	"quesma/quesma/config"
 	"quesma/schema"
 	"quesma/util"
+	quesma_api "quesma_v2/core"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -44,7 +44,7 @@ type TableDiscovery interface {
 
 type tableDiscovery struct {
 	cfg                               *config.QuesmaConfiguration
-	dbConnPool                        *sql.DB
+	dbConnPool                        quesma_api.BackendConnector
 	tableDefinitions                  *atomic.Pointer[TableMap]
 	tableDefinitionsAccessUnixSec     atomic.Int64
 	tableDefinitionsLastReloadUnixSec atomic.Int64
@@ -61,7 +61,7 @@ type columnMetadata struct {
 	comment string
 }
 
-func NewTableDiscovery(cfg *config.QuesmaConfiguration, dbConnPool *sql.DB, virtualTablesDB persistence.JSONDatabase) TableDiscovery {
+func NewTableDiscovery(cfg *config.QuesmaConfiguration, dbConnPool quesma_api.BackendConnector, virtualTablesDB persistence.JSONDatabase) TableDiscovery {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(NewTableMap())
 	result := &tableDiscovery{
@@ -112,7 +112,7 @@ func (t TableDiscoveryTableProviderAdapter) TableDefinitions() map[string]schema
 	return tables
 }
 
-func NewTableDiscoveryWith(cfg *config.QuesmaConfiguration, dbConnPool *sql.DB, tables TableMap) TableDiscovery {
+func NewTableDiscoveryWith(cfg *config.QuesmaConfiguration, dbConnPool quesma_api.BackendConnector, tables TableMap) TableDiscovery {
 	var tableDefinitions = atomic.Pointer[TableMap]{}
 	tableDefinitions.Store(&tables)
 	result := &tableDiscovery{
@@ -542,7 +542,7 @@ func (td *tableDiscovery) readTables(database string) (map[string]map[string]col
 	if td.dbConnPool == nil {
 		return map[string]map[string]columnMetadata{}, fmt.Errorf("database connection pool is nil, cannot describe tables")
 	}
-	rows, err := td.dbConnPool.Query("SELECT table, name, type, comment FROM system.columns WHERE database = ?", database)
+	rows, err := td.dbConnPool.Query(context.Background(), "SELECT table, name, type, comment FROM system.columns WHERE database = ?", database)
 	if err != nil {
 		err = end_user_errors.GuessClickhouseErrorType(err).InternalDetails("reading list of columns from system.columns")
 		return map[string]map[string]columnMetadata{}, err
@@ -576,8 +576,12 @@ func (td *tableDiscovery) tableTimestampField(database, table string, dbKind DbK
 func (td *tableDiscovery) getTimestampFieldForHydrolix(database, table string) (timestampField string) {
 	// In Hydrolix, there's always only one column in a table set as a primary timestamp
 	// Ref: https://docs.hydrolix.io/docs/transforms-and-write-schema#primary-timestamp
-	if err := td.dbConnPool.QueryRow("SELECT primary_key FROM system.tables WHERE database = ? and table = ?", database, table).Scan(&timestampField); err != nil {
+	rows, err := td.dbConnPool.Query(context.Background(), "SELECT primary_key FROM system.tables WHERE database = ? and table = ?", database, table)
+	if err != nil {
 		logger.Debug().Msgf("failed fetching primary key for table %s: %v", table, err)
+	}
+	if scanErr := rows.Scan(&timestampField); scanErr != nil {
+		logger.Debug().Msgf("failed scanning primary key for table %s: %v", table, scanErr)
 	}
 	return timestampField
 }
@@ -585,8 +589,13 @@ func (td *tableDiscovery) getTimestampFieldForHydrolix(database, table string) (
 func (td *tableDiscovery) getTimestampFieldForClickHouse(database, table string) (timestampField string) {
 	// In ClickHouse, there's no concept of a primary timestamp field, primary keys are often composite,
 	// hence we have to use following heuristic to determine the timestamp field (also just picking the first column if there are multiple)
-	if err := td.dbConnPool.QueryRow("SELECT name FROM system.columns WHERE database = ? AND table = ? AND is_in_primary_key = 1 AND type iLIKE 'DateTime%'", database, table).Scan(&timestampField); err != nil {
+	rows, err := td.dbConnPool.Query(context.Background(), "SELECT name FROM system.columns WHERE database = ? AND table = ? AND is_in_primary_key = 1 AND type iLIKE 'DateTime%'", database, table)
+	if err != nil {
 		logger.Debug().Msgf("failed fetching primary key for table %s: %v", table, err)
+		return
+	}
+	if scanErr := rows.Scan(&timestampField); scanErr != nil {
+		logger.Debug().Msgf("failed scanning primary key for table %s: %v", table, scanErr)
 		return
 	}
 	return timestampField
@@ -594,19 +603,24 @@ func (td *tableDiscovery) getTimestampFieldForClickHouse(database, table string)
 
 func (td *tableDiscovery) tableComment(database, table string) (comment string) {
 
-	err := td.dbConnPool.QueryRow("SELECT comment FROM system.tables WHERE database = ? and table = ?", database, table).Scan(&comment)
+	rows, err := td.dbConnPool.Query(context.Background(), "SELECT comment FROM system.tables WHERE database = ? and table = ?", database, table)
 
 	if err != nil {
 		logger.Error().Msgf("could not get table comment: %v", err)
+	}
+	if scanErr := rows.Scan(&comment); scanErr != nil {
+		logger.Debug().Msgf("failed scanning primary key for table %s: %v", table, scanErr)
 	}
 	return comment
 }
 
 func (td *tableDiscovery) createTableQuery(database, table string) (ddl string) {
-	err := td.dbConnPool.QueryRow("SELECT create_table_query FROM system.tables WHERE database = ? and table = ? ", database, table).Scan(&ddl)
-
+	rows, err := td.dbConnPool.Query(context.Background(), "SELECT create_table_query FROM system.tables WHERE database = ? and table = ? ", database, table)
 	if err != nil {
 		logger.Error().Msgf("could not get table comment: %v", err)
+	}
+	if scanErr := rows.Scan(&ddl); scanErr != nil {
+		logger.Debug().Msgf("failed scanning primary key for table %s: %v", table, scanErr)
 	}
 	return ddl
 }

--- a/quesma/common_table/const.go
+++ b/quesma/common_table/const.go
@@ -3,8 +3,9 @@
 package common_table
 
 import (
-	"database/sql"
+	"context"
 	"quesma/logger"
+	quesma_api "quesma_v2/core"
 )
 
 const TableName = "quesma_common_table"
@@ -25,10 +26,10 @@ CREATE TABLE IF NOT EXISTS "quesma_common_table"
 
 `
 
-func EnsureCommonTableExists(db *sql.DB) {
+func EnsureCommonTableExists(db quesma_api.BackendConnector) {
 
 	logger.Info().Msgf("Ensuring common table '%v' exists", TableName)
-	_, err := db.Exec(singleTableDDL)
+	err := db.Exec(context.Background(), singleTableDDL)
 	if err != nil {
 		// TODO check if we've got RO access to the database
 		logger.Warn().Msgf("Failed to create common table '%v': %v", TableName, err)

--- a/quesma/connectors/connector.go
+++ b/quesma/connectors/connector.go
@@ -3,13 +3,13 @@
 package connectors
 
 import (
-	"database/sql"
 	"fmt"
 	"quesma/clickhouse"
 	"quesma/licensing"
 	"quesma/logger"
 	"quesma/quesma/config"
 	"quesma/telemetry"
+	quesma_api "quesma_v2/core"
 )
 
 type Connector interface {
@@ -38,13 +38,13 @@ func (c *ConnectorManager) GetConnector() *clickhouse.LogManager {
 	return c.connectors[0].GetConnector()
 }
 
-func NewConnectorManager(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery) *ConnectorManager {
+func NewConnectorManager(cfg *config.QuesmaConfiguration, chDb quesma_api.BackendConnector, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery) *ConnectorManager {
 	return &ConnectorManager{
 		connectors: registerConnectors(cfg, chDb, phoneHomeAgent, loader),
 	}
 }
 
-func registerConnectors(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery) (conns []Connector) {
+func registerConnectors(cfg *config.QuesmaConfiguration, chDb quesma_api.BackendConnector, phoneHomeAgent telemetry.PhoneHomeAgent, loader clickhouse.TableDiscovery) (conns []Connector) {
 	for connName, conn := range cfg.Connectors {
 		logger.Info().Msgf("Registering connector named [%s] of type [%s]", connName, conn.ConnectorType)
 		switch conn.ConnectorType {

--- a/quesma/ingest/common_table_test.go
+++ b/quesma/ingest/common_table_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/jsonprocessor"
@@ -180,7 +181,8 @@ func TestIngestToCommonTable(t *testing.T) {
 
 			tables.Store(common_table.TableName, quesmaCommonTable)
 
-			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			conn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			if err != nil {
 				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 			}

--- a/quesma/ingest/ingest_validator_test.go
+++ b/quesma/ingest/ingest_validator_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/quesma/config"
 	"quesma/quesma/types"
@@ -166,7 +167,8 @@ func TestIngestValidation(t *testing.T) {
 		Created: true,
 	})
 	for i := range inputJson {
-		db, mock := util.InitSqlMockWithPrettyPrint(t, true)
+		conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+		db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 		ip := newIngestProcessorEmpty()
 		ip.chDb = db
 		ip.tableDiscovery = clickhouse.NewTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tableMap)

--- a/quesma/ingest/insert_test.go
+++ b/quesma/ingest/insert_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/jsonprocessor"
 	"quesma/persistence"
@@ -237,7 +238,8 @@ func TestProcessInsertQuery(t *testing.T) {
 		for index2, config := range configs {
 			for index3, ip := range ingestProcessors(config) {
 				t.Run("case insertTest["+strconv.Itoa(index1)+"], config["+strconv.Itoa(index2)+"], ingestProcessor["+strconv.Itoa(index3)+"]", func(t *testing.T) {
-					db, mock := util.InitSqlMockWithPrettyPrint(t, true)
+					conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+					db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 					ip.ip.chDb = db
 					resolver := table_resolver.NewEmptyTableResolver()
 					decision := &mux.Decision{
@@ -291,7 +293,8 @@ func TestInsertVeryBigIntegers(t *testing.T) {
 	// big integer as a schema field
 	for i, bigInt := range bigInts {
 		t.Run("big integer schema field: "+bigInt, func(t *testing.T) {
-			db, mock := util.InitSqlMockWithPrettyPrint(t, true)
+			conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			lm := newIngestProcessorEmpty()
 			lm.chDb = db
 			defer db.Close()
@@ -317,7 +320,8 @@ func TestInsertVeryBigIntegers(t *testing.T) {
 
 	for i, bigInt := range bigInts {
 		t.Run("big integer attribute field: "+bigInt, func(t *testing.T) {
-			db, mock := util.InitSqlMockWithPrettyPrint(t, true)
+			conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			lm := newIngestProcessorEmpty()
 			lm.chDb = db
 			lm.tableDiscovery = clickhouse.NewTableDiscoveryWith(&config.QuesmaConfiguration{}, nil, *tableMapNoSchemaFields)
@@ -413,7 +417,8 @@ func TestCreateTableIfSomeFieldsExistsInSchemaAlready(t *testing.T) {
 
 			tables := NewTableMap()
 
-			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			conn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			if err != nil {
 				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 			}

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -172,12 +172,15 @@ func addOurFieldsToCreateTableQuery(q string, config *chLib.ChTableConfig, table
 
 func (ip *IngestProcessor) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	rows, err := ip.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
+	rows, err := ip.chDb.Query(ctx, fmt.Sprintf("SELECT count(*) FROM %s", table))
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
 	}
-	if errScan := rows.Scan(&count); errScan != nil {
-		return 0, fmt.Errorf("clickhouse: scan row failed: %v", errScan)
+	defer rows.Close()
+	if rows.Next() {
+		if errScan := rows.Scan(&count); errScan != nil {
+			return 0, fmt.Errorf("clickhouse: scan row failed: %v", errScan)
+		}
 	}
 	return count, nil
 }

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -4,7 +4,6 @@ package ingest
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/goccy/go-json"
@@ -60,7 +59,7 @@ type (
 	IngestProcessor struct {
 		ctx                       context.Context
 		cancel                    context.CancelFunc
-		chDb                      *sql.DB
+		chDb                      quesma_api.BackendConnector
 		tableDiscovery            chLib.TableDiscovery
 		cfg                       *config.QuesmaConfiguration
 		phoneHomeAgent            diag.PhoneHomeClient
@@ -173,9 +172,12 @@ func addOurFieldsToCreateTableQuery(q string, config *chLib.ChTableConfig, table
 
 func (ip *IngestProcessor) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	err := ip.chDb.QueryRowContext(ctx, "SELECT count(*) FROM ?", table).Scan(&count)
+	rows, err := ip.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
+	}
+	if errScan := rows.Scan(&count); errScan != nil {
+		return 0, fmt.Errorf("clickhouse: scan row failed: %v", errScan)
 	}
 	return count, nil
 }
@@ -851,7 +853,7 @@ func (ip *IngestProcessor) execute(ctx context.Context, query string) error {
 		}
 	}
 
-	_, err := ip.chDb.ExecContext(ctx, query)
+	err := ip.chDb.Exec(ctx, query)
 	span.End(err)
 	return err
 }
@@ -974,7 +976,7 @@ func (ip *IngestProcessor) Ping() error {
 	return ip.chDb.Ping()
 }
 
-func NewIngestProcessor(cfg *config.QuesmaConfiguration, chDb *sql.DB, phoneHomeAgent telemetry.PhoneHomeAgent, loader chLib.TableDiscovery, schemaRegistry schema.Registry, virtualTableStorage persistence.JSONDatabase, tableResolver table_resolver.TableResolver) *IngestProcessor {
+func NewIngestProcessor(cfg *config.QuesmaConfiguration, chDb quesma_api.BackendConnector, phoneHomeAgent telemetry.PhoneHomeAgent, loader chLib.TableDiscovery, schemaRegistry schema.Registry, virtualTableStorage persistence.JSONDatabase, tableResolver table_resolver.TableResolver) *IngestProcessor {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &IngestProcessor{ctx: ctx, cancel: cancel, chDb: chDb, tableDiscovery: loader, cfg: cfg, phoneHomeAgent: phoneHomeAgent, schemaRegistry: schemaRegistry, virtualTableStorage: virtualTableStorage, tableResolver: tableResolver}
 }

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -172,15 +172,9 @@ func addOurFieldsToCreateTableQuery(q string, config *chLib.ChTableConfig, table
 
 func (ip *IngestProcessor) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	rows, err := ip.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
+	err := ip.chDb.QueryRow(ctx, "SELECT count(*) FROM ?", table).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
-	}
-	defer rows.Close()
-	if rows.Next() {
-		if errScan := rows.Scan(&count); errScan != nil {
-			return 0, fmt.Errorf("clickhouse: scan row failed: %v", errScan)
-		}
 	}
 	return count, nil
 }

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -172,7 +172,7 @@ func addOurFieldsToCreateTableQuery(q string, config *chLib.ChTableConfig, table
 
 func (ip *IngestProcessor) Count(ctx context.Context, table string) (int64, error) {
 	var count int64
-	rows, err := ip.chDb.Query(ctx, fmt.Sprintf("SELECT count(*) FROM %s", table))
+	rows, err := ip.chDb.Query(ctx, "SELECT count(*) FROM ?", table)
 	if err != nil {
 		return 0, fmt.Errorf("clickhouse: query row failed: %v", err)
 	}

--- a/quesma/quesma/functionality/terms_enum/terms_enum_test.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/logger"
 	"quesma/model"
@@ -95,7 +96,8 @@ func testHandleTermsEnumRequest(t *testing.T, requestBody []byte) {
 	}
 	tableResolver := table_resolver.NewEmptyTableResolver()
 	managementConsole := ui.NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, nil, make(<-chan logger.LogWithLevel, 50000), diag.EmptyPhoneHomeRecentStatsProvider(), nil, tableResolver)
-	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
+	conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+	db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 	defer db.Close()
 	lm := clickhouse.NewLogManagerWithConnection(db, util.NewSyncMapWith(testTableName, table))
 	s := schema.StaticRegistry{

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -4,7 +4,6 @@ package quesma
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"quesma/ab_testing"
@@ -117,7 +116,7 @@ func (q *QueryRunner) GetLogManager() clickhouse.LogManagerIFace {
 	return q.logManager
 }
 
-func NewQueryRunnerDefaultForTests(db *sql.DB, cfg *config.QuesmaConfiguration,
+func NewQueryRunnerDefaultForTests(db quesma_api.BackendConnector, cfg *config.QuesmaConfiguration,
 	tableName string, tables *clickhouse.TableMap, staticRegistry *schema.StaticRegistry) *QueryRunner {
 
 	lm := clickhouse.NewLogManagerWithConnection(db, tables)

--- a/quesma/quesma/search_common_table_test.go
+++ b/quesma/quesma/search_common_table_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/DATA-DOG/go-sqlmock"
 	"quesma/ab_testing"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/common_table"
 	"quesma/elasticsearch"
@@ -304,7 +305,8 @@ func TestSearchCommonTable(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%s(%d)", tt.Name, i), func(t *testing.T) {
 
-			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			conn, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			if err != nil {
 				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
 			}

--- a/quesma/quesma/search_norace_test.go
+++ b/quesma/quesma/search_norace_test.go
@@ -11,6 +11,7 @@ package quesma
 import (
 	"context"
 	"math/rand"
+	"quesma/backend_connectors"
 	"quesma/logger"
 	"quesma/quesma/types"
 	"quesma/schema"
@@ -29,7 +30,8 @@ func TestAllUnsupportedQueryTypesAreProperlyRecorded(t *testing.T) {
 			if tt.QueryType == "script" {
 				t.Skip("Only 1 test. We can't deal with scripts inside queries yet. It fails very early, during JSON unmarshalling, so we can't even know the type of aggregation.")
 			}
-			db, _ := util.InitSqlMockWithPrettyPrint(t, false)
+			conn, _ := util.InitSqlMockWithPrettyPrint(t, false)
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 			defer db.Close()
 
 			s := &schema.StaticRegistry{
@@ -100,7 +102,8 @@ func TestDifferentUnsupportedQueries(t *testing.T) {
 		testCounts[randInt]++
 	}
 
-	db, _ := util.InitSqlMockWithPrettyPrint(t, false)
+	conn, _ := util.InitSqlMockWithPrettyPrint(t, false)
+	db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 	defer db.Close()
 
 	s := &schema.StaticRegistry{

--- a/quesma/quesma/search_opensearch_test.go
+++ b/quesma/quesma/search_opensearch_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"quesma/backend_connectors"
 	"quesma/clickhouse"
 	"quesma/model"
 	"quesma/queryparser"
@@ -42,8 +43,9 @@ func TestSearchOpensearch(t *testing.T) {
 
 	for i, tt := range testdata.OpensearchSearchTests {
 		t.Run(strconv.Itoa(i)+tt.Name, func(t *testing.T) {
-			db, mock := util.InitSqlMockWithPrettySqlAndPrint(t, false)
-			defer db.Close()
+			conn, mock := util.InitSqlMockWithPrettySqlAndPrint(t, false)
+			defer conn.Close()
+			db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 
 			queryRunner := NewQueryRunnerDefaultForTests(db, &DefaultConfig, tableName, util.NewSyncMapWith(tableName, &table), s)
 			cw := queryparser.ClickhouseQueryTranslator{Table: &table, Ctx: context.Background(), Schema: s.Tables[tableName], Config: &DefaultConfig}
@@ -185,8 +187,9 @@ func TestHighlighter(t *testing.T) {
 			tableName: schema.NewSchemaWithAliases(fields, map[schema.FieldName]schema.FieldName{}, true, ""),
 		},
 	}
-	db, mock := util.InitSqlMockWithPrettyPrint(t, true)
-	defer db.Close()
+	conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
+	defer conn.Close()
+	db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 
 	// careful, it's not always in this order, order is nondeterministic
 	mock.ExpectQuery("").WillReturnRows(sqlmock.NewRows([]string{"message$*%:;", "host.name", "@timestamp"}).

--- a/quesma/quesma/ui/ab_testing.go
+++ b/quesma/quesma/ui/ab_testing.go
@@ -24,11 +24,14 @@ func (qmc *QuesmaManagementConsole) hasABTestingTable() bool {
 
 	sql := `SELECT count(*) FROM ab_testing_logs`
 
-	row := db.QueryRow(sql)
+	row, err := db.Query(context.Background(), sql)
 	var count int
-	err := row.Scan(&count)
 	if err != nil {
 		logger.Error().Err(err).Msg("Error checking for ab_testing_logs table")
+		return false
+	}
+	if errScan := row.Scan(&count); errScan != nil {
+		logger.Error().Err(errScan).Msg("Error scanning for ab_testing_logs table")
 		return false
 	}
 
@@ -327,7 +330,7 @@ GROUP BY
 	var result []abTestingReportRow
 
 	db := qmc.logManager.GetDB()
-	rows, err := db.Query(sql, orderBySQL)
+	rows, err := db.Query(context.Background(), sql, orderBySQL)
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +504,7 @@ func (qmc *QuesmaManagementConsole) abTestingReadPanelDetails(dashboardId, panel
 `
 	db := qmc.logManager.GetDB()
 
-	rows, err := db.Query(sql, dashboardId, panelId)
+	rows, err := db.Query(context.Background(), sql, dashboardId, panelId)
 	if err != nil {
 		return nil, err
 	}
@@ -684,7 +687,7 @@ func (qmc *QuesmaManagementConsole) abTestingReadMismatchDetails(dashboardId, pa
 
 	db := qmc.logManager.GetDB()
 
-	rows, err := db.Query(sql, dashboardId, panelId, mismatchHash)
+	rows, err := db.Query(context.Background(), sql, dashboardId, panelId, mismatchHash)
 	if err != nil {
 		return nil, err
 	}
@@ -820,10 +823,12 @@ func (qmc *QuesmaManagementConsole) abTestingReadRow(requestId string) (abTestin
 
 	db := qmc.logManager.GetDB()
 
-	row := db.QueryRow(sql, requestId)
-
+	row, err := db.Query(context.Background(), sql, requestId)
 	rec := abTestingTableRow{}
-	err := row.Scan(
+	if err != nil {
+		return rec, err
+	}
+	errScan := row.Scan(
 		&rec.requestID, &rec.requestPath, &rec.requestIndexName,
 		&rec.requestBody, &rec.responseBTime, &rec.responseBError, &rec.responseBName, &rec.responseBBody,
 		&rec.quesmaHash, &rec.kibanaDashboardID, &rec.opaqueID, &rec.responseABody, &rec.responseATime,
@@ -832,8 +837,8 @@ func (qmc *QuesmaManagementConsole) abTestingReadRow(requestId string) (abTestin
 		&rec.responseMismatchMismatches, &rec.responseMismatchMessage, &rec.quesmaVersion,
 		&rec.kibanaDashboardPanelID)
 
-	if err != nil {
-		return rec, err
+	if errScan != nil {
+		return rec, errScan
 	}
 
 	if row.Err() != nil {

--- a/quesma/telemetry/phone_home.go
+++ b/quesma/telemetry/phone_home.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
-	"database/sql"
 	"fmt"
 	"github.com/goccy/go-json"
 	"github.com/google/uuid"
@@ -20,6 +19,7 @@ import (
 	"quesma/elasticsearch"
 	"quesma/health"
 	telemetry_headers "quesma/telemetry/headers"
+	quesma_api "quesma_v2/core"
 	"quesma_v2/core/diag"
 	"sort"
 
@@ -64,7 +64,7 @@ type agent struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	clickHouseDb *sql.DB
+	clickHouseDb quesma_api.BackendConnector
 	config       *config.QuesmaConfiguration
 	clientId     string
 
@@ -110,7 +110,7 @@ func hostname() string {
 	return name
 }
 
-func NewPhoneHomeAgent(configuration *config.QuesmaConfiguration, clickHouseDb *sql.DB, clientId string) PhoneHomeAgent {
+func NewPhoneHomeAgent(configuration *config.QuesmaConfiguration, clickHouseDb quesma_api.BackendConnector, clientId string) PhoneHomeAgent {
 
 	// TODO
 	// this is a question, maybe we should inherit context from the caller
@@ -198,7 +198,7 @@ where active
 	ctx, cancel := context.WithTimeout(ctx, clickhouseTimeout)
 	defer cancel()
 
-	rows, err := a.clickHouseDb.QueryContext(ctx, totalSummaryQuery)
+	rows, err := a.clickHouseDb.Query(ctx, totalSummaryQuery)
 
 	if err != nil {
 
@@ -267,7 +267,7 @@ WHERE active = 1 AND database = ?
 GROUP BY table
 ORDER BY total_size DESC;`
 
-	rows, err := a.clickHouseDb.QueryContext(ctx, query, dbName)
+	rows, err := a.clickHouseDb.Query(ctx, query, dbName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to execute query: %w", err)
 	}
@@ -319,7 +319,7 @@ func (a *agent) collectClickHouseVersion(ctx context.Context, stats *diag.ClickH
 	ctx, cancel := context.WithTimeout(ctx, clickhouseTimeout)
 	defer cancel()
 
-	rows, err := a.clickHouseDb.QueryContext(ctx, totalSummaryQuery)
+	rows, err := a.clickHouseDb.Query(ctx, totalSummaryQuery)
 
 	if err != nil {
 		logger.Error().Err(err).Msg("Error getting version from clickhouse.")
@@ -348,10 +348,10 @@ func (a *agent) CollectClickHouse(ctx context.Context) (stats diag.ClickHouseSta
 	// https://gist.github.com/sanchezzzhak/511fd140e8809857f8f1d84ddb937015
 	stats.Status = statusNotOk
 
-	dbStats := a.clickHouseDb.Stats()
+	//dbStats := a.clickHouseDb.Stats(). TODO: after moving to generic impl (quesma_api.BackendConnector) we lost this driver-specific call
 
-	stats.MaxOpenConnection = dbStats.MaxOpenConnections
-	stats.OpenConnection = dbStats.OpenConnections
+	//stats.MaxOpenConnection = dbStats.MaxOpenConnections
+	//stats.OpenConnection = dbStats.OpenConnections
 
 	if err := a.collectClickHouseUsage(ctx, &stats); err != nil {
 		return stats

--- a/quesma/telemetry/phone_home.go
+++ b/quesma/telemetry/phone_home.go
@@ -348,10 +348,10 @@ func (a *agent) CollectClickHouse(ctx context.Context) (stats diag.ClickHouseSta
 	// https://gist.github.com/sanchezzzhak/511fd140e8809857f8f1d84ddb937015
 	stats.Status = statusNotOk
 
-	//dbStats := a.clickHouseDb.Stats(). TODO: after moving to generic impl (quesma_api.BackendConnector) we lost this driver-specific call
+	dbStats := a.clickHouseDb.Stats()
 
-	//stats.MaxOpenConnection = dbStats.MaxOpenConnections
-	//stats.OpenConnection = dbStats.OpenConnections
+	stats.MaxOpenConnection = dbStats.MaxOpenConnections
+	stats.OpenConnection = dbStats.OpenConnections
 
 	if err := a.collectClickHouseUsage(ctx, &stats); err != nil {
 		return stats

--- a/quesma/v2/core/backend_connectors.go
+++ b/quesma/v2/core/backend_connectors.go
@@ -56,6 +56,10 @@ func (p *NoopBackendConnector) QueryRow(ctx context.Context, query string, args 
 	return nil
 }
 
+func (p *NoopBackendConnector) Stats() DBStats {
+	return DBStats{}
+}
+
 func (p *NoopBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	return nil
 }

--- a/quesma/v2/core/backend_connectors.go
+++ b/quesma/v2/core/backend_connectors.go
@@ -55,3 +55,7 @@ func (p *NoopBackendConnector) Query(ctx context.Context, query string, args ...
 func (p *NoopBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	return nil
 }
+
+func (p *NoopBackendConnector) Ping() error {
+	return nil
+}

--- a/quesma/v2/core/backend_connectors.go
+++ b/quesma/v2/core/backend_connectors.go
@@ -52,6 +52,10 @@ func (p *NoopBackendConnector) Query(ctx context.Context, query string, args ...
 	return nil, nil
 }
 
+func (p *NoopBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) Row {
+	return nil
+}
+
 func (p *NoopBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
 	return nil
 }

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -106,6 +106,14 @@ type BackendConnector interface {
 	QueryRow(ctx context.Context, query string, args ...interface{}) Row
 	// Exec executes a command that doesn't return rows, typically an INSERT, UPDATE, or DELETE.
 	Exec(ctx context.Context, query string, args ...interface{}) error
+	Stats() DBStats // smaller version of sql.DBStats
 	Close() error
 	Ping() error
+}
+
+// DBStats is a smaller version of sql.DBStats,
+// used (at least for now) to provide backwards compat with `sql.DB` interface primarily used in Quesma v1
+type DBStats struct {
+	MaxOpenConnections int
+	OpenConnections    int
 }

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -89,7 +89,7 @@ type Processor interface {
 type Rows interface {
 	Next() bool
 	Scan(dest ...interface{}) error
-	Close()
+	Close() error
 	Err() error
 }
 
@@ -102,5 +102,6 @@ type BackendConnector interface {
 
 	// Exec executes a command that doesn't return rows, typically an INSERT, UPDATE, or DELETE.
 	Exec(ctx context.Context, query string, args ...interface{}) error
-	Close() error // TODO we should revisit returning error here
+	Close() error
+	Ping() error
 }

--- a/quesma/v2/core/quesma_apis.go
+++ b/quesma/v2/core/quesma_apis.go
@@ -93,13 +93,17 @@ type Rows interface {
 	Err() error
 }
 
+type Row interface {
+	Scan(dest ...interface{}) error
+}
+
 type BackendConnector interface {
 	InstanceNamer
 	GetId() BackendConnectorType
 	Open() error
 	// Query executes a query that returns rows, typically a SELECT.
 	Query(ctx context.Context, query string, args ...interface{}) (Rows, error)
-
+	QueryRow(ctx context.Context, query string, args ...interface{}) Row
 	// Exec executes a command that doesn't return rows, typically an INSERT, UPDATE, or DELETE.
 	Exec(ctx context.Context, query string, args ...interface{}) error
 	Close() error


### PR DESCRIPTION
... so that it relies on `quesma_api.BackendConnector` instead of `*sql.DB`.

This may look like it's complicating the current codebase, but effectively makes both of these structures reusable in the v2 API.

Ref: https://github.com/QuesmaOrg/quesma/pull/1119