### PR TITLE
Multiple schema resolve - speed up 

### DIFF
--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -49,7 +49,9 @@ func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegist
 			continue
 		}
 
-		if schemaDefinition, found := schemaRegistry.FindSchema(schema.IndexName(resolvedIndex)); found {
+		schemas := schemaRegistry.AllSchemas()
+
+		if schemaDefinition, found := schemas[schema.IndexName(resolvedIndex)]; found {
 			indexConfig, configured := cfg[resolvedIndex]
 			if configured && !indexConfig.IsClickhouseQueryEnabled() {
 				continue

--- a/quesma/quesma/functionality/field_capabilities/field_caps.go
+++ b/quesma/quesma/functionality/field_capabilities/field_caps.go
@@ -44,12 +44,13 @@ func addFieldCapabilityFromSchemaRegistry(fields map[string]map[string]model.Fie
 
 func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegistry schema.Registry, indexes []string) ([]byte, error) {
 	fields := make(map[string]map[string]model.FieldCapability)
+
+	schemas := schemaRegistry.AllSchemas()
+
 	for _, resolvedIndex := range indexes {
 		if len(resolvedIndex) == 0 {
 			continue
 		}
-
-		schemas := schemaRegistry.AllSchemas()
 
 		if schemaDefinition, found := schemas[schema.IndexName(resolvedIndex)]; found {
 			indexConfig, configured := cfg[resolvedIndex]

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -534,8 +534,10 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			DatabaseName:       "", // it doesn't matter here, common table will be used
 		}
 
+		schemas := q.schemaRegistry.AllSchemas()
+
 		for _, idx := range resolvedIndexes {
-			scm, ok := q.schemaRegistry.FindSchema(schema.IndexName(idx))
+			scm, ok := schemas[schema.IndexName(idx)]
 			if !ok {
 				return []byte{}, end_user_errors.ErrNoSuchTable.New(fmt.Errorf("can't load %s schema", idx)).Details("Table: %s", idx)
 			}


### PR DESCRIPTION
We can speed up the process of resolving multiple schemas more simply.  No cache is required now. 

