### PR TITLE
Introduce `basic_sql_backend_connector` for `sql.DB` connectors

### DIFF
--- a/quesma/backend_connectors/basic_sql_backend_connector.go
+++ b/quesma/backend_connectors/basic_sql_backend_connector.go
@@ -1,0 +1,83 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package backend_connectors
+
+import (
+	"context"
+	"database/sql"
+	quesma_api "github.com/QuesmaOrg/quesma/quesma/v2/core"
+)
+
+type BasicSqlBackendConnector struct {
+	connection *sql.DB
+}
+
+type SqlRows struct {
+	rows *sql.Rows
+}
+
+func (p *SqlRows) Next() bool {
+	return p.rows.Next()
+}
+
+func (p *SqlRows) Scan(dest ...interface{}) error {
+	return p.rows.Scan(dest...)
+}
+
+func (p *SqlRows) Close() error {
+	return p.rows.Close()
+}
+
+func (p *SqlRows) Err() error {
+	return p.rows.Err()
+}
+
+func (p *BasicSqlBackendConnector) Open() error {
+	conn, err := initDBConnection()
+	if err != nil {
+		return err
+	}
+	p.connection = conn
+	return nil
+}
+
+func (p *BasicSqlBackendConnector) Close() error {
+	if p.connection == nil {
+		return nil
+	}
+	return p.connection.Close()
+}
+
+func (p *BasicSqlBackendConnector) Ping() error {
+	return p.connection.Ping()
+}
+
+func (p *BasicSqlBackendConnector) Query(ctx context.Context, query string, args ...interface{}) (quesma_api.Rows, error) {
+	rows, err := p.connection.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &SqlRows{rows: rows}, nil
+}
+
+func (p *BasicSqlBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
+	return p.connection.QueryRowContext(ctx, query, args...)
+}
+
+func (p *BasicSqlBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
+	if len(args) == 0 {
+		_, err := p.connection.ExecContext(ctx, query)
+		return err
+	}
+	_, err := p.connection.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (p *BasicSqlBackendConnector) Stats() quesma_api.DBStats {
+	stats := p.connection.Stats()
+	return quesma_api.DBStats{
+		MaxOpenConnections: stats.MaxOpenConnections,
+		OpenConnections:    stats.OpenConnections,
+	}
+}

--- a/quesma/backend_connectors/mysql_backend_connector.go
+++ b/quesma/backend_connectors/mysql_backend_connector.go
@@ -4,35 +4,14 @@
 package backend_connectors
 
 import (
-	"context"
 	"database/sql"
 	quesma_api "github.com/QuesmaOrg/quesma/quesma/v2/core"
 	_ "github.com/go-sql-driver/mysql"
 )
 
-type MySqlRows struct {
-	rows *sql.Rows
-}
-
-func (p *MySqlRows) Next() bool {
-	return p.rows.Next()
-}
-
-func (p *MySqlRows) Scan(dest ...interface{}) error {
-	return p.rows.Scan(dest...)
-}
-
-func (p *MySqlRows) Close() error {
-	return p.rows.Close()
-}
-
-func (p *MySqlRows) Err() error {
-	return p.rows.Err()
-}
-
 type MySqlBackendConnector struct {
-	Endpoint   string
-	connection *sql.DB
+	BasicSqlBackendConnector
+	Endpoint string
 }
 
 func (p *MySqlBackendConnector) InstanceName() string {
@@ -53,45 +32,5 @@ func (p *MySqlBackendConnector) Open() error {
 		return err
 	}
 	p.connection = conn
-	return nil
-}
-
-func (p *MySqlBackendConnector) Close() error {
-	if p.connection == nil {
-		return nil
-	}
-	return p.connection.Close()
-}
-
-func (p *MySqlBackendConnector) Query(ctx context.Context, query string, args ...interface{}) (quesma_api.Rows, error) {
-	rows, err := p.connection.QueryContext(context.Background(), query, args...)
-	if err != nil {
-		return nil, err
-	}
-	return &MySqlRows{rows: rows}, nil
-}
-
-func (p *MySqlBackendConnector) QueryRow(ctx context.Context, query string, args ...interface{}) quesma_api.Row {
-	return p.connection.QueryRowContext(ctx, query, args...)
-}
-
-func (p *MySqlBackendConnector) Exec(ctx context.Context, query string, args ...interface{}) error {
-	if len(args) == 0 {
-		_, err := p.connection.ExecContext(context.Background(), query)
-		return err
-	}
-	_, err := p.connection.ExecContext(context.Background(), query, args...)
-	return err
-}
-
-func (p *MySqlBackendConnector) Stats() quesma_api.DBStats {
-	stats := p.connection.Stats()
-	return quesma_api.DBStats{
-		MaxOpenConnections: stats.MaxOpenConnections,
-		OpenConnections:    stats.OpenConnections,
-	}
-}
-
-func (p *MySqlBackendConnector) Ping() error {
 	return nil
 }

--- a/quesma/go.mod
+++ b/quesma/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.4 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -57,6 +58,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 )
 

--- a/quesma/go.sum
+++ b/quesma/go.sum
@@ -140,7 +140,10 @@ github.com/jackc/pgx/v5 v5.7.2/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsb
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
@@ -365,6 +368,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
A lot of golang drivers for different SQL libraries expose a standard `sql.DB` interface. Our backend connector code for ClickHouse, Postgres, MySQL can be unified around this interface.

This reduces the code duplication by moving the common code to a new `basic_sql_backend_connector` struct.