### PR TITLE
Re-adding features to V2 architecture

### DIFF
--- a/quesma/ab_testing/collector/fanout.go
+++ b/quesma/ab_testing/collector/fanout.go
@@ -3,9 +3,9 @@
 package collector
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/ingest"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
@@ -14,9 +14,9 @@ import (
 )
 
 type elasticSearchFanout struct {
-	url        string
 	indexName  string
 	errorCount int
+	esConn     *backend_connectors.ElasticsearchBackendConnector
 }
 
 func (t *elasticSearchFanout) name() string {
@@ -43,7 +43,7 @@ func (t *elasticSearchFanout) process(in EnrichedResults) (out EnrichedResults, 
 	logBytes = append(logBytes, logLine...)
 	logBytes = append(logBytes, []byte("\n")...)
 
-	if resp, err := http.Post(t.url+"/_bulk", "application/json", bytes.NewBuffer(logBytes)); err != nil {
+	if resp, err := t.esConn.Request(context.Background(), http.MethodPost, "/_bulk", logBytes); err != nil {
 		t.errorCount += +1
 		return in, false, fmt.Errorf("failed to send A/B results: %v", err)
 	} else {

--- a/quesma/elasticsearch/index_resolver.go
+++ b/quesma/elasticsearch/index_resolver.go
@@ -53,7 +53,7 @@ func NormalizePattern(p string) string {
 }
 
 func (im *indexResolver) Resolve(indexPattern string) (Sources, bool, error) {
-	response, err := im.httpClient.Request(context.Background(), "GET", "_resolve/index/"+indexPattern+"?expand_wildcards=open", []byte{})
+	response, err := im.httpClient.Request(context.Background(), "GET", ResolveIndexPattenPath(indexPattern), []byte{})
 	if err != nil {
 		return Sources{}, false, err
 	}
@@ -91,4 +91,8 @@ func NewEmptyIndexResolver() *EmptyIndexResolver {
 func (r *EmptyIndexResolver) Resolve(indexPattern string) (Sources, bool, error) {
 	res, ok := r.Indexes[indexPattern]
 	return res, ok, nil
+}
+
+func ResolveIndexPattenPath(indexPattern string) string {
+	return "_resolve/index/" + indexPattern + "?expand_wildcards=open"
 }

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -134,7 +134,7 @@ func main() {
 
 	logger.Info().Msgf("loaded config: %s", cfg.String())
 
-	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, im, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver)
+	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver)
 
 	abTestingController := sender.NewSenderCoordinator(&cfg, ingestProcessor)
 	abTestingController.Start()

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver)
 
-	abTestingController := sender.NewSenderCoordinator(&cfg, ingestProcessor)
+	abTestingController := sender.NewSenderCoordinator(&cfg)
 	abTestingController.Start()
 
 	instance := constructQuesma(&cfg, tableDisco, lm, ingestProcessor, schemaRegistry, phoneHomeAgent, quesmaManagementConsole, qmcLogChannel, abTestingController.GetSender(), tableResolver)

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -134,7 +134,7 @@ func main() {
 
 	logger.Info().Msgf("loaded config: %s", cfg.String())
 
-	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, im, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver) //FIXME no ingest processor here just for now
+	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, im, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver)
 
 	abTestingController := sender.NewSenderCoordinator(&cfg, ingestProcessor)
 	abTestingController.Start()

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -110,6 +110,7 @@ func main() {
 	schemaRegistry.Start()
 
 	im := elasticsearch.NewIndexManagement(cfg.Elasticsearch)
+	im.Start()
 
 	connManager := connectors.NewConnectorManager(&cfg, connectionPool, phoneHomeAgent, tableDisco)
 	lm := connManager.GetConnector()
@@ -138,7 +139,7 @@ func main() {
 	abTestingController := sender.NewSenderCoordinator(&cfg, ingestProcessor)
 	abTestingController.Start()
 
-	instance := constructQuesma(&cfg, tableDisco, lm, ingestProcessor, im, schemaRegistry, phoneHomeAgent, quesmaManagementConsole, qmcLogChannel, abTestingController.GetSender(), tableResolver)
+	instance := constructQuesma(&cfg, tableDisco, lm, ingestProcessor, schemaRegistry, phoneHomeAgent, quesmaManagementConsole, qmcLogChannel, abTestingController.GetSender(), tableResolver)
 	instance.Start()
 
 	<-doneCh
@@ -157,10 +158,10 @@ func main() {
 
 }
 
-func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscovery, lm *clickhouse.LogManager, ip *ingest.IngestProcessor, im elasticsearch.IndexManagement, schemaRegistry schema.Registry, phoneHomeAgent telemetry.PhoneHomeAgent, quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, abResultsrepository ab_testing.Sender, indexRegistry table_resolver.TableResolver) *quesma.Quesma {
+func constructQuesma(cfg *config.QuesmaConfiguration, sl clickhouse.TableDiscovery, lm *clickhouse.LogManager, ip *ingest.IngestProcessor, schemaRegistry schema.Registry, phoneHomeAgent telemetry.PhoneHomeAgent, quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, abResultsrepository ab_testing.Sender, indexRegistry table_resolver.TableResolver) *quesma.Quesma {
 	if cfg.TransparentProxy {
 		return quesma.NewQuesmaTcpProxy(cfg, quesmaManagementConsole, logChan, false)
 	} else {
-		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, im, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry)
+		return quesma.NewHttpProxy(phoneHomeAgent, lm, ip, sl, schemaRegistry, cfg, quesmaManagementConsole, abResultsrepository, indexRegistry)
 	}
 }

--- a/quesma/processors/es_to_ch_common/common.go
+++ b/quesma/processors/es_to_ch_common/common.go
@@ -123,7 +123,7 @@ func InitializeLegacyQuesmaDependencies(baseDeps *quesma_api.DependenciesImpl, o
 	tableDisco := clickhouse.NewTableDiscovery(oldQuesmaConfig, connectionPool, virtualTableStorage)
 	schemaRegistry := schema.NewSchemaRegistry(clickhouse.TableDiscoveryTableProviderAdapter{TableDiscovery: tableDisco}, oldQuesmaConfig, clickhouse.SchemaTypeAdapter{})
 	schemaRegistry.Start()
-	dummyTableResolver := table_resolver.NewDummyTableResolver(oldQuesmaConfig.IndexConfig)
+	dummyTableResolver := table_resolver.NewDummyTableResolver(oldQuesmaConfig.IndexConfig, oldQuesmaConfig.UseCommonTableForWildcard)
 	legacyDependencies := NewLegacyQuesmaDependencies(*baseDeps, oldQuesmaConfig, connectionPool, *virtualTableStorage, tableDisco, schemaRegistry, dummyTableResolver)
 	return legacyDependencies
 }

--- a/quesma/processors/es_to_ch_common/common.go
+++ b/quesma/processors/es_to_ch_common/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/common_table"
 	"github.com/QuesmaOrg/quesma/quesma/persistence"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
+	"github.com/QuesmaOrg/quesma/quesma/quesma/ui"
 	"github.com/QuesmaOrg/quesma/quesma/schema"
 	"github.com/QuesmaOrg/quesma/quesma/table_resolver"
 	quesma_api "github.com/QuesmaOrg/quesma/quesma/v2/core"
@@ -95,6 +96,7 @@ type LegacyQuesmaDependencies struct {
 	TableDiscovery      clickhouse.TableDiscovery
 	SchemaRegistry      schema.Registry
 	TableResolver       table_resolver.TableResolver
+	Adminconsole        *ui.QuesmaManagementConsole
 }
 
 func NewLegacyQuesmaDependencies(

--- a/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
+++ b/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
@@ -200,7 +200,10 @@ func (p *ElasticsearchToClickHouseIngestProcessor) routeToElasticsearch(metadata
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch Elasticsearch backend connector")
 	}
-	resp := esConn.Send(req)
+	resp, err := esConn.Send(req)
+	if err != nil {
+		return metadata, nil, err
+	}
 	respBody, err := ReadResponseBody(resp)
 	if err != nil {
 		return metadata, nil, fmt.Errorf("failed to read response body from Elastic")

--- a/quesma/processors/es_to_ch_query/elasticsearch_to_clickhouse_query_processor.go
+++ b/quesma/processors/es_to_ch_query/elasticsearch_to_clickhouse_query_processor.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/QuesmaOrg/quesma/quesma/ab_testing/sender"
 	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
 	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
@@ -74,14 +73,11 @@ func (p *ElasticsearchToClickHouseQueryProcessor) prepareTemporaryQueryProcessor
 	logManager := clickhouse.NewEmptyLogManager(p.legacyDependencies.OldQuesmaConfig, p.legacyDependencies.ConnectionPool, p.legacyDependencies.PhoneHomeAgent(), p.legacyDependencies.TableDiscovery)
 	logManager.Start()
 
-	abTestingController := sender.NewSenderCoordinator(p.legacyDependencies.OldQuesmaConfig)
-	abTestingController.Start()
-
 	queryRunner := quesm.NewQueryRunner(logManager,
 		p.legacyDependencies.OldQuesmaConfig,
 		nil,
 		p.legacyDependencies.SchemaRegistry,
-		abTestingController.GetSender(),
+		p.legacyDependencies.AbTestingController.GetSender(),
 		p.legacyDependencies.TableResolver,
 		p.legacyDependencies.TableDiscovery,
 	)

--- a/quesma/processors/es_to_ch_query/elasticsearch_to_clickhouse_query_processor.go
+++ b/quesma/processors/es_to_ch_query/elasticsearch_to_clickhouse_query_processor.go
@@ -76,7 +76,6 @@ func (p *ElasticsearchToClickHouseQueryProcessor) prepareTemporaryQueryProcessor
 	queryRunner := quesm.NewQueryRunner(logManager,
 		p.legacyDependencies.OldQuesmaConfig,
 		nil,
-		nil,
 		p.legacyDependencies.SchemaRegistry,
 		nil,
 		p.legacyDependencies.TableResolver,

--- a/quesma/quesma/functionality/bulk/bulk_test.go
+++ b/quesma/quesma/functionality/bulk/bulk_test.go
@@ -116,7 +116,7 @@ func Test_BulkForEachDeleteOnly(t *testing.T) {
 // This table resolver will only route `kibana_sample_data_ecommerce` to ClickHouse, rest will go to Elasticsearch
 var testTableResolver = table_resolver.NewDummyTableResolver(config.IndicesConfigs{
 	"kibana_sample_data_ecommerce": config.IndexConfiguration{},
-})
+}, false)
 
 func TestSplitBulkSampleData(t *testing.T) {
 	ctx := context.Background()

--- a/quesma/quesma/functionality/terms_enum/terms_enum_test.go
+++ b/quesma/quesma/functionality/terms_enum/terms_enum_test.go
@@ -95,7 +95,7 @@ func testHandleTermsEnumRequest(t *testing.T, requestBody []byte) {
 		Created: true,
 	}
 	tableResolver := table_resolver.NewEmptyTableResolver()
-	managementConsole := ui.NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, nil, make(<-chan logger.LogWithLevel, 50000), diag.EmptyPhoneHomeRecentStatsProvider(), nil, tableResolver)
+	managementConsole := ui.NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, make(<-chan logger.LogWithLevel, 50000), diag.EmptyPhoneHomeRecentStatsProvider(), nil, tableResolver)
 	conn, mock := util.InitSqlMockWithPrettyPrint(t, true)
 	db := backend_connectors.NewClickHouseBackendConnectorWithConnection("", conn)
 	defer db.Close()

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"github.com/QuesmaOrg/quesma/quesma/ab_testing"
 	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
-	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/ingest"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/proxy"
@@ -58,7 +57,6 @@ func NewQuesmaTcpProxy(config *config.QuesmaConfiguration, quesmaManagementConso
 func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent,
 	logManager *clickhouse.LogManager, ingestProcessor *ingest.IngestProcessor,
 	schemaLoader clickhouse.TableDiscovery,
-	indexManager elasticsearch.IndexManagement,
 	schemaRegistry schema.Registry, config *config.QuesmaConfiguration,
 	quesmaManagementConsole *ui.QuesmaManagementConsole,
 	abResultsRepository ab_testing.Sender, resolver table_resolver.TableResolver) *Quesma {
@@ -70,7 +68,7 @@ func NewHttpProxy(phoneHomeAgent telemetry.PhoneHomeAgent,
 
 	return &Quesma{
 		telemetryAgent: phoneHomeAgent,
-		processor: newDualWriteProxyV2(dependencies, schemaLoader, logManager, indexManager,
+		processor: newDualWriteProxyV2(dependencies, schemaLoader, logManager,
 			schemaRegistry, config,
 			ingestProcessor, resolver, abResultsRepository),
 		publicTcpPort:           config.PublicTcpPort,

--- a/quesma/quesma/router_test.go
+++ b/quesma/quesma/router_test.go
@@ -158,7 +158,8 @@ func configureRouter(cfg *config.QuesmaConfiguration, sr schema.Registry, lm *cl
 	})
 
 	router.Register(routes.ResolveIndexPath, method("GET"), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
-		sources, err := resolve.HandleResolve(req.Params["index"], sr, queryRunner.im)
+		ir := elasticsearch.NewIndexResolver(cfg.Elasticsearch)
+		sources, err := resolve.HandleResolve(req.Params["index"], sr, ir)
 		if err != nil {
 			return nil, err
 		}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -49,7 +49,6 @@ type QueryRunner struct {
 	AsyncQueriesContexts async_search_storage.AsyncQueryContextStorage
 	logManager           clickhouse.LogManagerIFace
 	cfg                  *config.QuesmaConfiguration
-	im                   elasticsearch.IndexManagement
 	debugInfoCollector   diag.DebugInfoCollector
 
 	tableDiscovery clickhouse.TableDiscovery
@@ -86,7 +85,6 @@ func (q *QueryRunner) EnableQueryOptimization(cfg *config.QuesmaConfiguration) {
 
 func NewQueryRunner(lm clickhouse.LogManagerIFace,
 	cfg *config.QuesmaConfiguration,
-	im elasticsearch.IndexManagement,
 	qmc diag.DebugInfoCollector,
 	schemaRegistry schema.Registry,
 	abResultsRepository ab_testing.Sender,
@@ -95,7 +93,7 @@ func NewQueryRunner(lm clickhouse.LogManagerIFace,
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &QueryRunner{logManager: lm, cfg: cfg, im: im, debugInfoCollector: qmc,
+	return &QueryRunner{logManager: lm, cfg: cfg, debugInfoCollector: qmc,
 		executionCtx: ctx, cancel: cancel,
 		AsyncRequestStorage:  async_search_storage.NewAsyncSearchStorageInMemory(),
 		AsyncQueriesContexts: async_search_storage.NewAsyncQueryContextStorageInMemory(),
@@ -141,7 +139,7 @@ func NewQueryRunnerDefaultForTests(db quesma_api.BackendConnector, cfg *config.Q
 
 	go managementConsole.RunOnlyChannelProcessor()
 
-	return NewQueryRunner(lm, cfg, nil, managementConsole, staticRegistry, ab_testing.NewEmptySender(), resolver, tableDiscovery)
+	return NewQueryRunner(lm, cfg, managementConsole, staticRegistry, ab_testing.NewEmptySender(), resolver, tableDiscovery)
 }
 
 // HandleCount returns -1 when table name could not be resolved

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -481,7 +481,10 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 	var currentSchema schema.Schema
 	resolvedIndexes := clickhouseConnector.ClickhouseIndexes
 
-	if len(resolvedIndexes) == 1 {
+	if !clickhouseConnector.IsCommonTable {
+		if len(resolvedIndexes) < 1 {
+			return []byte{}, end_user_errors.ErrNoSuchTable.New(fmt.Errorf("can't load [%s] schema", resolvedIndexes)).Details("Table: [%v]", resolvedIndexes)
+		}
 		indexName := resolvedIndexes[0] // we got exactly one table here because of the check above
 		resolvedTableName := q.cfg.IndexConfig[indexName].TableName(indexName)
 

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -135,7 +135,7 @@ func NewQueryRunnerDefaultForTests(db quesma_api.BackendConnector, cfg *config.Q
 	tableDiscovery := clickhouse.NewEmptyTableDiscovery()
 	tableDiscovery.TableMap = tables
 
-	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, nil, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
+	managementConsole := ui.NewQuesmaManagementConsole(cfg, nil, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
 
 	go managementConsole.RunOnlyChannelProcessor()
 

--- a/quesma/quesma/search_common_table_test.go
+++ b/quesma/quesma/search_common_table_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
 	"github.com/QuesmaOrg/quesma/quesma/common_table"
-	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
@@ -313,10 +312,9 @@ func TestSearchCommonTable(t *testing.T) {
 
 			defer db.Close()
 
-			indexManagement := elasticsearch.NewFixedIndexManagement()
 			lm := clickhouse.NewLogManagerWithConnection(db, tableMap)
 
-			managementConsole := ui.NewQuesmaManagementConsole(quesmaConfig, nil, indexManagement, make(<-chan logger.LogWithLevel, 50000), diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
+			managementConsole := ui.NewQuesmaManagementConsole(quesmaConfig, nil, make(<-chan logger.LogWithLevel, 50000), diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
 
 			for i, query := range tt.WantedSql {
 

--- a/quesma/quesma/search_common_table_test.go
+++ b/quesma/quesma/search_common_table_test.go
@@ -328,7 +328,7 @@ func TestSearchCommonTable(t *testing.T) {
 				mock.ExpectQuery(query).WillReturnRows(rows)
 			}
 
-			queryRunner := NewQueryRunner(lm, quesmaConfig, indexManagement, managementConsole, &schemaRegistry, ab_testing.NewEmptySender(), resolver, tableDiscovery)
+			queryRunner := NewQueryRunner(lm, quesmaConfig, managementConsole, &schemaRegistry, ab_testing.NewEmptySender(), resolver, tableDiscovery)
 			queryRunner.maxParallelQueries = 0
 
 			_, err = queryRunner.HandleSearch(ctx, tt.IndexPattern, types.MustJSON(tt.QueryJson))

--- a/quesma/quesma/ui/data_sources.go
+++ b/quesma/quesma/ui/data_sources.go
@@ -3,9 +3,10 @@
 package ui
 
 import (
+	"context"
+	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/ui/internal/builder"
 	"slices"
-	"strings"
 )
 
 func (qmc *QuesmaManagementConsole) generateDatasourcesPage() []byte {
@@ -69,11 +70,11 @@ func (qmc *QuesmaManagementConsole) generateDatasources() []byte {
 
 	buffer.Html(`<ul>`)
 
-	qmc.indexManagement.Start()
-	indexNames := []string{}
-	internalIndexNames := []string{}
-	for indexName := range qmc.indexManagement.GetSourceNames() {
-		if strings.HasPrefix(indexName, ".") {
+	var indexNames []string
+	var internalIndexNames []string
+
+	for _, indexName := range qmc.GetElasticSearchIndices(context.Background()) {
+		if elasticsearch.IsInternalIndex(indexName) {
 			internalIndexNames = append(internalIndexNames, indexName)
 		} else {
 			indexNames = append(indexNames, indexName)

--- a/quesma/quesma/ui/html_pages_test.go
+++ b/quesma/quesma/ui/html_pages_test.go
@@ -23,7 +23,7 @@ func TestHtmlPages(t *testing.T) {
 	id := "b1c4a89e-4905-5e3c-b57f-dc92627d011e"
 	logChan := make(chan logger.LogWithLevel, 5)
 	resolver := table_resolver.NewEmptyTableResolver()
-	qmc := NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, nil, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
+	qmc := NewQuesmaManagementConsole(&config.QuesmaConfiguration{}, nil, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
 	qmc.PushPrimaryInfo(&diag.QueryDebugPrimarySource{Id: id, QueryResp: xssBytes})
 	qmc.PushSecondaryInfo(&diag.QueryDebugSecondarySource{Id: id,
 		Path:                   xss,
@@ -104,7 +104,7 @@ func TestHtmlSchemaPage(t *testing.T) {
 	logManager := clickhouse.NewLogManager(tables, &cfg)
 
 	resolver := table_resolver.NewEmptyTableResolver()
-	qmc := NewQuesmaManagementConsole(&cfg, logManager, nil, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
+	qmc := NewQuesmaManagementConsole(&cfg, logManager, logChan, diag.EmptyPhoneHomeRecentStatsProvider(), nil, resolver)
 
 	t.Run("schema got no XSS and no panic", func(t *testing.T) {
 		response := string(qmc.generateTables())

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -273,7 +273,7 @@ func (qmc *QuesmaManagementConsole) GetElasticSearchIndices(ctx context.Context)
 }
 
 func (qmc *QuesmaManagementConsole) elasticsearchResolveIndexPattern(ctx context.Context, indexPattern string) (sources elasticsearch.Sources) {
-	resp, err := qmc.elasticsearch.RequestWithHeaders(ctx, "GET", "_resolve/index/"+indexPattern+"?expand_wildcards=open", nil, nil)
+	resp, err := qmc.elasticsearch.RequestWithHeaders(ctx, "GET", elasticsearch.ResolveIndexPattenPath(indexPattern), nil, nil)
 	if err != nil {
 		logger.InfoWithCtx(ctx).Msgf("Failed call Elasticsearch: %v", err)
 		return

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -4,17 +4,20 @@ package ui
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
+	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
 	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
+	"github.com/QuesmaOrg/quesma/quesma/logger"
+	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
 	"github.com/QuesmaOrg/quesma/quesma/schema"
+	"github.com/QuesmaOrg/quesma/quesma/stats"
 	"github.com/QuesmaOrg/quesma/quesma/table_resolver"
 	"github.com/QuesmaOrg/quesma/quesma/util"
 	"github.com/QuesmaOrg/quesma/quesma/v2/core/diag"
 	"github.com/rs/zerolog"
-
-	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
-	"github.com/QuesmaOrg/quesma/quesma/logger"
-	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
-	"github.com/QuesmaOrg/quesma/quesma/stats"
+	"io"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -75,10 +78,10 @@ type (
 		clickhouseStatusCache     healthCheckStatusCache
 		elasticStatusCache        healthCheckStatusCache
 		logManager                *clickhouse.LogManager
-		indexManagement           elasticsearch.IndexManagement
 		phoneHomeAgent            diag.PhoneHomeRecentStatsProvider
 		schemasProvider           SchemasProvider
 		totalUnsupportedQueries   int
+		elasticsearch             *backend_connectors.ElasticsearchBackendConnector
 		tableResolver             table_resolver.TableResolver
 
 		isAuthEnabled bool
@@ -88,7 +91,7 @@ type (
 	}
 )
 
-func NewQuesmaManagementConsole(cfg *config.QuesmaConfiguration, logManager *clickhouse.LogManager, indexManager elasticsearch.IndexManagement, logChan <-chan logger.LogWithLevel, phoneHomeAgent diag.PhoneHomeRecentStatsProvider, schemasProvider SchemasProvider, indexRegistry table_resolver.TableResolver) *QuesmaManagementConsole {
+func NewQuesmaManagementConsole(cfg *config.QuesmaConfiguration, logManager *clickhouse.LogManager, logChan <-chan logger.LogWithLevel, phoneHomeAgent diag.PhoneHomeRecentStatsProvider, schemasProvider SchemasProvider, indexRegistry table_resolver.TableResolver) *QuesmaManagementConsole {
 	return &QuesmaManagementConsole{
 		queryDebugPrimarySource:   make(chan *diag.QueryDebugPrimarySource, 10),
 		queryDebugSecondarySource: make(chan *diag.QueryDebugSecondarySource, 10),
@@ -103,7 +106,7 @@ func NewQuesmaManagementConsole(cfg *config.QuesmaConfiguration, logManager *cli
 		clickhouseStatusCache:     newHealthCheckStatusCache(),
 		elasticStatusCache:        newHealthCheckStatusCache(),
 		logManager:                logManager,
-		indexManagement:           indexManager,
+		elasticsearch:             backend_connectors.NewElasticsearchBackendConnector(cfg.Elasticsearch),
 		phoneHomeAgent:            phoneHomeAgent,
 		schemasProvider:           schemasProvider,
 		tableResolver:             indexRegistry,
@@ -259,6 +262,33 @@ func (qmc *QuesmaManagementConsole) processChannelMessage() {
 
 func isComplete(value queryDebugInfo) bool {
 	return !reflect.DeepEqual(value.QueryDebugPrimarySource, diag.QueryDebugPrimarySource{}) && !reflect.DeepEqual(value.QueryDebugSecondarySource, diag.QueryDebugSecondarySource{})
+}
+
+func (qmc *QuesmaManagementConsole) GetElasticSearchIndices(ctx context.Context) (indices []string) {
+	sources := qmc.elasticsearchResolveIndexPattern(ctx, "*")
+	for _, index := range sources.Indices {
+		indices = append(indices, index.Name)
+	}
+	return
+}
+
+func (qmc *QuesmaManagementConsole) elasticsearchResolveIndexPattern(ctx context.Context, indexPattern string) (sources elasticsearch.Sources) {
+	resp, err := qmc.elasticsearch.RequestWithHeaders(ctx, "GET", "_resolve/index/"+indexPattern+"?expand_wildcards=open", nil, nil)
+	if err != nil {
+		logger.InfoWithCtx(ctx).Msgf("Failed call Elasticsearch: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return
+	}
+	body, err := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &sources)
+	if err != nil {
+		logger.InfoWithCtx(ctx).Msgf("Failed to parse response from Elasticsearch: %v", err)
+		return
+	}
+	return
 }
 
 func (qmc *QuesmaManagementConsole) Run() {

--- a/quesma/quesma/ui/management_console.go
+++ b/quesma/quesma/ui/management_console.go
@@ -283,6 +283,10 @@ func (qmc *QuesmaManagementConsole) elasticsearchResolveIndexPattern(ctx context
 		return
 	}
 	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		logger.InfoWithCtx(ctx).Msgf("Failed to read response from Elasticsearch: %v", err)
+		return
+	}
 	err = json.Unmarshal(body, &sources)
 	if err != nil {
 		logger.InfoWithCtx(ctx).Msgf("Failed to parse response from Elasticsearch: %v", err)

--- a/quesma/table_resolver/table_resolver_dummy.go
+++ b/quesma/table_resolver/table_resolver_dummy.go
@@ -50,18 +50,6 @@ func (t DummyTableResolver) RecentDecisions() []mux.PatternDecisions {
 	return []mux.PatternDecisions{}
 }
 
-//func (t DummyTableResolver) resolveWildcardCommonTable(indexPattern string) *mux.Decision {
-//	return &mux.Decision{
-//		UseConnectors: []mux.ConnectorDecision{
-//			&mux.ConnectorDecisionClickhouse{
-//				ClickhouseTableName: common_table.TableName,
-//				ClickhouseIndexes:   []string{indexPattern},
-//				IsCommonTable:       true,
-//			},
-//		},
-//	}
-//}
-
 func (t DummyTableResolver) resolveElastic() *mux.Decision {
 	return &mux.Decision{
 		UseConnectors: []mux.ConnectorDecision{

--- a/quesma/table_resolver/table_resolver_dummy.go
+++ b/quesma/table_resolver/table_resolver_dummy.go
@@ -4,6 +4,8 @@
 package table_resolver
 
 import (
+	"github.com/QuesmaOrg/quesma/quesma/common_table"
+	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
 	mux "github.com/QuesmaOrg/quesma/quesma/v2/core"
 )
@@ -11,11 +13,12 @@ import (
 // DummyTableResolver is a dummy implementation of TableResolver to satisfy the QueryRunner and make it be compatible with the v2 api
 // thanks to this we can reuse the existing QueryRunner implementation without any changes.
 type DummyTableResolver struct {
-	cfg config.IndicesConfigs
+	cfg                 config.IndicesConfigs
+	wildcardCommonTable bool
 }
 
-func NewDummyTableResolver(cfg config.IndicesConfigs) *DummyTableResolver {
-	return &DummyTableResolver{cfg: cfg}
+func NewDummyTableResolver(cfg config.IndicesConfigs, wildcardCommonTable bool) *DummyTableResolver {
+	return &DummyTableResolver{cfg: cfg, wildcardCommonTable: wildcardCommonTable}
 }
 
 func (t DummyTableResolver) Start() {}
@@ -23,22 +26,20 @@ func (t DummyTableResolver) Start() {}
 func (t DummyTableResolver) Stop() {}
 
 func (t DummyTableResolver) Resolve(_ string, indexPattern string) *mux.Decision {
-	_, ok := t.cfg[indexPattern] // TODO: if index doens't exist in config - route to Elasticsearch (just for now)
-	if !ok {
-		return &mux.Decision{
-			UseConnectors: []mux.ConnectorDecision{
-				&mux.ConnectorDecisionElastic{},
-			},
-		}
+	if elasticsearch.IsInternalIndex(indexPattern) { // e.g. `.kibana_analytics_8.11.1`
+		return t.resolveElastic()
+	}
+	if t.wildcardCommonTable {
+		return t.resolveCommonTable(indexPattern)
+	}
+
+	if indexCfg, ok := t.cfg[indexPattern]; !ok {
+		return t.resolveElastic()
 	} else {
-		return &mux.Decision{
-			UseConnectors: []mux.ConnectorDecision{
-				&mux.ConnectorDecisionClickhouse{
-					ClickhouseTableName: indexPattern,
-					ClickhouseIndexes:   []string{indexPattern}, // TODO this won't work for 'common table' feature
-					//IsCommonTable: false,
-				},
-			},
+		if indexCfg.UseCommonTable {
+			return t.resolveCommonTable(indexPattern)
+		} else {
+			return t.resolveClickhouse(indexPattern)
 		}
 	}
 }
@@ -47,4 +48,47 @@ func (t DummyTableResolver) Pipelines() []string { return []string{} }
 
 func (t DummyTableResolver) RecentDecisions() []mux.PatternDecisions {
 	return []mux.PatternDecisions{}
+}
+
+//func (t DummyTableResolver) resolveWildcardCommonTable(indexPattern string) *mux.Decision {
+//	return &mux.Decision{
+//		UseConnectors: []mux.ConnectorDecision{
+//			&mux.ConnectorDecisionClickhouse{
+//				ClickhouseTableName: common_table.TableName,
+//				ClickhouseIndexes:   []string{indexPattern},
+//				IsCommonTable:       true,
+//			},
+//		},
+//	}
+//}
+
+func (t DummyTableResolver) resolveElastic() *mux.Decision {
+	return &mux.Decision{
+		UseConnectors: []mux.ConnectorDecision{
+			&mux.ConnectorDecisionElastic{},
+		},
+	}
+}
+
+func (t DummyTableResolver) resolveCommonTable(indexPattern string) *mux.Decision {
+	return &mux.Decision{
+		UseConnectors: []mux.ConnectorDecision{
+			&mux.ConnectorDecisionClickhouse{
+				ClickhouseTableName: common_table.TableName,
+				ClickhouseIndexes:   []string{indexPattern},
+				IsCommonTable:       true,
+			},
+		},
+	}
+}
+
+func (t DummyTableResolver) resolveClickhouse(indexPattern string) *mux.Decision {
+	return &mux.Decision{
+		UseConnectors: []mux.ConnectorDecision{
+			&mux.ConnectorDecisionClickhouse{
+				ClickhouseTableName: indexPattern,
+				ClickhouseIndexes:   []string{indexPattern},
+			},
+		},
+	}
 }

--- a/quesma/v2_quesma_builder.go
+++ b/quesma/v2_quesma_builder.go
@@ -32,7 +32,7 @@ func BuildNewQuesma() quesma_api.QuesmaBuilder {
 	}
 
 	processorConfig := config.QuesmaProcessorConfig{
-		UseCommonTable: false,
+		UseCommonTable: true,
 		IndexConfig: map[string]config.IndexConfiguration{
 			"test_index":   {},
 			"test_index_2": {},
@@ -55,7 +55,8 @@ func BuildNewQuesma() quesma_api.QuesmaBuilder {
 		IndexConfig: processorConfig.IndexConfig,
 		ClickHouse:  config.RelationalDbConfiguration{Url: (*config.Url)(&url.URL{Scheme: "clickhouse", Host: "localhost:9000"})},
 		// Elasticsearch section is here only for the phone home agent not to blow up
-		Elasticsearch: config.ElasticsearchConfiguration{Url: (*config.Url)(&url.URL{Scheme: "http", Host: "localhost:9200"})},
+		Elasticsearch:             config.ElasticsearchConfiguration{Url: (*config.Url)(&url.URL{Scheme: "http", Host: "localhost:9200"})},
+		UseCommonTableForWildcard: processorConfig.UseCommonTable,
 	}
 
 	legacyDependencies := es_to_ch_common.InitializeLegacyQuesmaDependencies(deps, oldQuesmaConfig)


### PR DESCRIPTION
I've made some (a lot of) shortcuts to merge v2 architecture processors. Now it's time to take the high road.

Changes:
* added common table support for query/ingest
* Removed dependency on `IndexManagement` (the only component which depends on it is `TableResolver`
* Switching AB testing logs collector to Elasticsearch to remove dependency on `ClickHouse Ingester` interface @nablaone 