### PR TITLE
Get rid of l4_proxy package

### DIFF
--- a/quesma/quesma/l4_proxy.go
+++ b/quesma/quesma/l4_proxy.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package proxy
+package quesma
 
 import (
 	"context"

--- a/quesma/quesma/l4_proxy_test.go
+++ b/quesma/quesma/l4_proxy_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package proxy
+package quesma
 
 import (
 	"bytes"

--- a/quesma/quesma/quesma.go
+++ b/quesma/quesma/quesma.go
@@ -9,7 +9,6 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/ingest"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
-	"github.com/QuesmaOrg/quesma/quesma/proxy"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/recovery"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/ui"
@@ -48,7 +47,7 @@ func (q *Quesma) Start() {
 
 func NewQuesmaTcpProxy(config *config.QuesmaConfiguration, quesmaManagementConsole *ui.QuesmaManagementConsole, logChan <-chan logger.LogWithLevel, inspect bool) *Quesma {
 	return &Quesma{
-		processor:               proxy.NewTcpProxy(config.PublicTcpPort, config.Elasticsearch.Url.Host, inspect),
+		processor:               NewTcpProxy(config.PublicTcpPort, config.Elasticsearch.Url.Host, inspect),
 		publicTcpPort:           config.PublicTcpPort,
 		quesmaManagementConsole: quesmaManagementConsole,
 		config:                  config,


### PR DESCRIPTION
Moving `l4_proxy` package (two files) to quesma