### PR TITLE
Bring back ingest ab result to CH

### DIFF
--- a/ci/it/testcases/test_ab.go
+++ b/ci/it/testcases/test_ab.go
@@ -41,7 +41,7 @@ func (a *ABTestcase) SetupContainers(ctx context.Context) error {
 func (a *ABTestcase) RunTests(ctx context.Context, t *testing.T) error {
 	t.Run("test basic request", func(t *testing.T) { a.testBasicRequest(ctx, t) })
 	t.Run("test ingest to both connectors", func(t *testing.T) { a.testIngest(ctx, t) })
-	t.Run("test A/B queries", func(t *testing.T) { a.testQueries(ctx, t) })
+	t.Run("test A/B queries with ClickHouse result store", func(t *testing.T) { a.testQueries(ctx, t) })
 	return nil
 }
 

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-const abTestingLogsIndex = "ab_testing_logs"
+//const abTestingLogsIndex = "ab_testing_logs"
 
 type ResponseMismatch struct {
 	IsOK bool `json:"is_ok"` // true if responses are the same
@@ -93,7 +93,7 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 			//	esConn:    esConn,
 			//	indexName: abTestingLogsIndex,
 			//},
-			&internalIngestFanout{ // due to migration to V2 architecture, ClickHouse ingest is disabled
+			&internalIngestFanout{
 				indexName:       ab_testing.ABTestingTableName,
 				ingestProcessor: ingester,
 			},

--- a/quesma/ab_testing/collector/collector.go
+++ b/quesma/ab_testing/collector/collector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/ab_testing"
 	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/buildinfo"
+	"github.com/QuesmaOrg/quesma/quesma/ingest"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/recovery"
 	"time"
@@ -70,7 +71,7 @@ func (r *InMemoryCollector) String() string {
 	return "InMemoryCollector(sends data to Quesma)"
 }
 
-func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessage, esConn *backend_connectors.ElasticsearchBackendConnector) *InMemoryCollector {
+func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessage, _ *backend_connectors.ElasticsearchBackendConnector, ingester ingest.Ingester) *InMemoryCollector {
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -88,14 +89,14 @@ func NewCollector(ctx context.Context, healthQueue chan<- ab_testing.HealthMessa
 			//&ppPrintFanout{},
 			//&mismatchedOnlyFilter{},
 			&redactOkResults{},
-			&elasticSearchFanout{
-				esConn:    esConn,
-				indexName: abTestingLogsIndex,
-			},
-			//&internalIngestFanout{ // due to migration to V2 architecture, ClickHouse ingest is disabled
-			//	indexName:       ab_testing.ABTestingTableName,
-			//	ingestProcessor: ingester,
+			//&elasticSearchFanout{
+			//	esConn:    esConn,
+			//	indexName: abTestingLogsIndex,
 			//},
+			&internalIngestFanout{ // due to migration to V2 architecture, ClickHouse ingest is disabled
+				indexName:       ab_testing.ABTestingTableName,
+				ingestProcessor: ingester,
+			},
 		},
 		healthQueue:         healthQueue,
 		processorErrorQueue: make(chan processorErrorMessage, 100),

--- a/quesma/main.go
+++ b/quesma/main.go
@@ -126,7 +126,7 @@ func main() {
 
 	quesmaManagementConsole := ui.NewQuesmaManagementConsole(&cfg, lm, qmcLogChannel, phoneHomeAgent, schemaRegistry, tableResolver)
 
-	abTestingController := sender.NewSenderCoordinator(&cfg)
+	abTestingController := sender.NewSenderCoordinator(&cfg, ingestProcessor)
 	abTestingController.Start()
 
 	instance := constructQuesma(&cfg, tableDisco, lm, ingestProcessor, schemaRegistry, phoneHomeAgent, quesmaManagementConsole, qmcLogChannel, abTestingController.GetSender(), tableResolver)

--- a/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
+++ b/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
@@ -44,9 +44,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) InstanceName() string {
 }
 
 func (p *ElasticsearchToClickHouseIngestProcessor) Init() error {
-	// TODO so we initialize the connection pool in `prepareTemporaryIngestProcessor`, maybe we should do it here?
-	p.legacyIngestProcessor = p.prepareTemporaryIngestProcessor()
-
+	p.legacyIngestProcessor = p.legacyDependencies.IngestProcessor
 	return nil
 }
 
@@ -68,24 +66,6 @@ func (p *ElasticsearchToClickHouseIngestProcessor) GetId() string {
 
 func (p *ElasticsearchToClickHouseIngestProcessor) GetSchemaRegistry() schema.Registry {
 	return p.legacyIngestProcessor.GetSchemaRegistry()
-}
-
-// prepareTemporaryIngestProcessor creates a temporary ingest processor which is a new version of the ingest processor,
-// which uses `quesma_api.BackendConnector` instead of `*sql.DB` for the database connection.
-func (p *ElasticsearchToClickHouseIngestProcessor) prepareTemporaryIngestProcessor() *ingest.IngestProcessor {
-
-	ip := ingest.NewIngestProcessor(
-		p.legacyDependencies.OldQuesmaConfig,
-		p.legacyDependencies.ConnectionPool,
-		p.legacyDependencies.PhoneHomeAgent(),
-		p.legacyDependencies.TableDiscovery,
-		p.legacyDependencies.SchemaRegistry,
-		&p.legacyDependencies.VirtualTableStorage,
-		p.legacyDependencies.TableResolver,
-	)
-
-	ip.Start()
-	return ip
 }
 
 func (p *ElasticsearchToClickHouseIngestProcessor) Handle(metadata map[string]interface{}, message ...any) (map[string]interface{}, any, error) {


### PR DESCRIPTION
I decided to revert this change and make it work in V2 architecture. 

Little nonsense in the dependencies, but at the cost of 100% feature parity 🙃 