### PR TITLE
Clear `CLIENT_SSL` in MySQL `Handshake` packet

### DIFF
--- a/quesma/processors/tcp_passthrough_mysql_processor.go
+++ b/quesma/processors/tcp_passthrough_mysql_processor.go
@@ -5,10 +5,12 @@
 package processors
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/frontend_connectors"
+	"github.com/QuesmaOrg/quesma/quesma/logger"
 	quesma_api "github.com/QuesmaOrg/quesma/quesma/v2/core"
 	"net"
 )
@@ -75,10 +77,87 @@ func (t *TcpPassthroughMysqlProcessor) Handle(metadata map[string]interface{}, m
 			break
 		}
 
+		if metadata["handshake_processed"] == nil {
+			metadata["handshake_processed"] = true
+			fullPacketBytes = maybeProcessHandshake(fullPacketBytes)
+		}
+
 		response = append(response, fullPacketBytes...)
 	}
 
 	return metadata, response, nil
+}
+
+func maybeProcessHandshake(msg []byte) []byte {
+	// This function processes the initial handshake packet sent by the MySQL server.
+	// https://dev.mysql.com/doc/dev/mysql-server/8.4.3/page_protocol_connection_phase_packets_protocol_handshake_v10.html
+
+	// It rewrites capability_flags field, disabling SSL flag (CLIENT_SSL).
+	reader := bytes.NewReader(msg)
+
+	// Skip packet length and packet number
+	packetLenNoData := make([]byte, 3+1)
+	if n, err := reader.Read(packetLenNoData); err != nil || n != 3+1 {
+		logger.Warn().Msg("While parsing handshake packet, error reading packet length and packet number")
+		return msg
+	}
+
+	// Protocol version (1 byte)
+	const PROTOCOL_VERSION = 10
+	if b, err := reader.ReadByte(); err != nil || b != PROTOCOL_VERSION {
+		logger.Warn().Msgf("While parsing handshake packet, unexpected protocol version: %d", b)
+		return msg
+	}
+
+	// Server version (null-terminated string)
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			logger.Warn().Msg("While parsing handshake packet, error reading server version")
+			return msg
+		}
+		if b == 0 {
+			break
+		}
+	}
+
+	// Thread id (4 bytes)
+	threadIdBytes := make([]byte, 4)
+	if n, err := reader.Read(threadIdBytes); err != nil || n != 4 {
+		logger.Warn().Msg("While parsing handshake packet, error reading thread id")
+		return msg
+	}
+
+	// auth-plugin-data-part-1 (8 bytes)
+	authData := make([]byte, 8)
+	if n, err := reader.Read(authData); err != nil || n != 8 {
+		logger.Warn().Msg("While parsing handshake packet, error reading auth-plugin-data-part-1")
+		return msg
+	}
+
+	// filler (1 byte)
+	if _, err := reader.ReadByte(); err != nil {
+		logger.Warn().Msg("While parsing handshake packet, error reading filler")
+		return msg
+	}
+
+	// capability_flags_1 (2 bytes)
+	capabilityFlagsBytes := make([]byte, 2)
+	if n, err := reader.Read(capabilityFlagsBytes); err != nil || n != 2 {
+		logger.Warn().Msg("While parsing handshake packet, error reading capability_flags_1")
+		return msg
+	}
+
+	// Clear CLIENT_SSL
+	const CLIENT_SSL = 2048
+	capabilityFlags := binary.LittleEndian.Uint16(capabilityFlagsBytes)
+	capabilityFlags &^= CLIENT_SSL
+	pos := len(msg) - reader.Len() - 2
+	binary.LittleEndian.PutUint16(msg[pos:pos+2], capabilityFlags)
+
+	// Don't bother parsing the rest of the packet
+
+	return msg
 }
 
 func maybeProcessComQuery(msg []byte) []byte {


### PR DESCRIPTION
The `TcpPassthroughMysqlProcessor` does not yet support SSL, so when using a MySQL client you had to explicitly disable SSL on the client side or disable it on the MySQL server.

This change rewrites the initial `Handshake` packet sent by the MySQL server to inform the client that the server doesn't support SSL. After this change you can connect to MySQL via Quesma without having to manually disable SSL on the client side:

```
mysql -h localhost -P 13306 -u root -p
```

instead of

```
mysql --skip-ssl -h localhost -P 13306 -u root -p
```