### PR TITLE
Turing-3 `buckets: null` in aggregation response

### DIFF
--- a/quesma/model/bucket_aggregations/date_histogram.go
+++ b/quesma/model/bucket_aggregations/date_histogram.go
@@ -73,7 +73,7 @@ func (query *DateHistogram) AggregationType() model.AggregationType {
 }
 
 func (query *DateHistogram) TranslateSqlResponseToJson(rows []model.QueryResultRow) model.JsonMap {
-
+	fmt.Println("rows", len(rows))
 	if len(rows) > 0 && len(rows[0].Cols) < 2 {
 		logger.ErrorWithCtx(query.ctx).Msgf(
 			"unexpected number of columns in date_histogram aggregation response, len(rows[0].Cols): %d",
@@ -110,6 +110,7 @@ func (query *DateHistogram) TranslateSqlResponseToJson(rows []model.QueryResultR
 		})
 	}
 
+	fmt.Println("KK buckets:", response)
 	return model.JsonMap{
 		"buckets": response,
 	}

--- a/quesma/queryparser/aggregation_parser_test.go
+++ b/quesma/queryparser/aggregation_parser_test.go
@@ -667,6 +667,7 @@ func allAggregationTests() []testdata.AggregationTestCase {
 	add(clients.KunkkaTests, "clients/kunkka")
 	add(clients.OpheliaTests, "clients/ophelia")
 	add(clients.CloverTests, "clients/clover")
+	add(clients.TuringTests, "clients/turing")
 
 	return allTests
 }

--- a/quesma/testdata/clients/turing.go
+++ b/quesma/testdata/clients/turing.go
@@ -1,0 +1,74 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+package clients
+
+import (
+	"github.com/QuesmaOrg/quesma/quesma/model"
+	"github.com/QuesmaOrg/quesma/quesma/testdata"
+)
+
+var TuringTests = []testdata.AggregationTestCase{
+	{ // [0]
+		TestName: "empty results",
+		QueryRequestJson: `
+		{
+			"aggs": {
+				"2": {
+					"aggs": {
+						"3": {
+							"terms": {
+								"field": "score",
+								"order": {
+									"_count": "desc"
+								},
+								"shard_size": 25,
+								"size": 5
+							}
+						}
+					},
+					"date_histogram": {
+						"field": "@timestamp",
+						"fixed_interval": "12h",
+						"min_doc_count": 1,
+						"time_zone": "Europe/Warsaw"
+					}
+				}
+			},
+			"size": 0
+		}`,
+		ExpectedResponse: `
+		{
+			"aggregations": {
+				"2": {
+					"buckets": null
+				}
+			}
+		}`,
+		ExpectedPancakeResults: []model.QueryResultRow{},
+		ExpectedPancakeSQL: `
+			SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__parent_count",
+			  "aggr__2__3__key_0", "aggr__2__3__count"
+			FROM (
+			  SELECT "aggr__2__key_0", "aggr__2__count", "aggr__2__3__parent_count",
+				"aggr__2__3__key_0", "aggr__2__3__count",
+				dense_rank() OVER (ORDER BY "aggr__2__key_0" ASC) AS "aggr__2__order_1_rank"
+				,
+				dense_rank() OVER (PARTITION BY "aggr__2__key_0" ORDER BY
+				"aggr__2__3__count" DESC, "aggr__2__3__key_0" ASC) AS
+				"aggr__2__3__order_1_rank"
+			  FROM (
+				SELECT toInt64((toUnixTimestamp64Milli("@timestamp")+timeZoneOffset(
+				  toTimezone("@timestamp", 'Europe/Warsaw'))*1000) / 43200000) AS
+				  "aggr__2__key_0",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS "aggr__2__count",
+				  sum(count(*)) OVER (PARTITION BY "aggr__2__key_0") AS
+				  "aggr__2__3__parent_count", "score" AS "aggr__2__3__key_0",
+				  count(*) AS "aggr__2__3__count"
+				FROM __quesma_table_name
+				GROUP BY toInt64((toUnixTimestamp64Milli("@timestamp")+timeZoneOffset(
+				  toTimezone("@timestamp", 'Europe/Warsaw'))*1000) / 43200000) AS
+				  "aggr__2__key_0", "level" AS "aggr__2__3__key_0"))
+			WHERE "aggr__2__3__order_1_rank"<=6
+			ORDER BY "aggr__2__order_1_rank" ASC, "aggr__2__3__order_1_rank" ASC`,
+	},
+}


### PR DESCRIPTION
For such a simple aggregation: 
```
"aggs": {
        "2": {
            "aggs": {
                "3": {
                    "terms": {
                        "field": "field",
                        "order": {
                            "_count": "desc"
                        },
                        "shard_size": 25,
                        "size": 5
                    }
                }
            },
            "date_histogram": {
                "field": "@timestamp",
                "fixed_interval": "12h",
                "min_doc_count": 1,
                "time_zone": "Europe/Warsaw"
            }
        }
    },
```
we return
```
"aggregations": {
            "2": {
                "buckets": null
            }
        },
```
which is weird, as in the test that I added we return `buckets: []` (which is probably what we want).

Result in Elastic:
<img width="542" alt="Screenshot 2025-01-26 at 18 32 22" src="https://github.com/user-attachments/assets/58f632e3-3cb2-497b-9441-c7bc4d9c81b9" />
