### PR TITLE
Relaxing explicit index definition override requirement

### DIFF
--- a/quesma/clickhouse/table_discovery.go
+++ b/quesma/clickhouse/table_discovery.go
@@ -289,6 +289,9 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]columnMet
 	var explicitlyDisabledTables, notConfiguredTables []string
 	overrideToOriginal := make(map[string]string)
 
+	// populate map of override to original table names
+	// this will be further used to take specific index config
+	// from the original table
 	for indexName, indexConfig := range td.cfg.IndexConfig {
 		if len(indexConfig.Override) > 0 {
 			overrideToOriginal[indexConfig.Override] = indexName
@@ -309,6 +312,7 @@ func (td *tableDiscovery) configureTables(tables map[string]map[string]columnMet
 			if isCommonTable {
 				indexConfig = config.IndexConfiguration{}
 			}
+			// if table is overridden, we take the index config from the original index
 			if override {
 				indexConfig = td.cfg.IndexConfig[overrideToOriginal[table]]
 			}

--- a/quesma/frontend_connectors/dispatcher.go
+++ b/quesma/frontend_connectors/dispatcher.go
@@ -273,7 +273,9 @@ func (r *Dispatcher) Reroute(ctx context.Context, w http.ResponseWriter, req *ht
 		quesmaResponse, err := recordRequestToClickhouse(req.URL.Path, r.debugInfoCollector, func() (*quesma_api.Result, error) {
 			var result *quesma_api.Result
 			result, err = handlersPipe.Handler(ctx, quesmaRequest, w)
-
+			if err != nil {
+				logger.ErrorWithCtx(ctx).Msgf("Error processing request: %v", err)
+			}
 			if result == nil {
 				return result, err
 			}


### PR DESCRIPTION
Before this change such configuration:
```
        kibana_sample_data_flights:
          target: [ my-clickhouse-data-source ]
          tableName: "kibana_sample_data_flights_ext"
```
required also explicit override index definition:
```
        kibana_sample_data_flights_ext:
          target: [ my-clickhouse-data-source ]
```
otherwise kibana_sample_data_flights_ext was treaded as non-configured.