### PR TITLE
Add Unlicence to allowed license list for go-licence-detector

### DIFF
--- a/.github/go-licence-detector/rules.json
+++ b/.github/go-licence-detector/rules.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "This is the stock rules.json file (https://github.com/elastic/go-licence-detector/blob/master/assets/rules.json) but with added Unlicense",
+  "allowlist": [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Public Domain",
+    "CC0-1.0",
+    
+    "Unlicense"
+  ]
+}

--- a/.github/workflows/generate-notice.yml
+++ b/.github/workflows/generate-notice.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           go mod tidy
           go mod download all
-          go list -m -json all | jq 'select(.Path != "quesma_v2")' | go-licence-detector -includeIndirect -noticeTemplate=../.github/go-licence-detector/templates/NOTICE.MD.tmpl -noticeOut=../NOTICE.MD -depsTemplate=../.github/go-licence-detector/templates/dependencies.asciidoc.tmpl -depsOut=dependencies.asciidoc -overrides=../.github/go-licence-detector/overrides.ndjson
+          go list -m -json all | jq 'select(.Path != "quesma_v2")' | go-licence-detector -includeIndirect -noticeTemplate=../.github/go-licence-detector/templates/NOTICE.MD.tmpl -noticeOut=../NOTICE.MD -depsTemplate=../.github/go-licence-detector/templates/dependencies.asciidoc.tmpl -depsOut=dependencies.asciidoc -overrides=../.github/go-licence-detector/overrides.ndjson -rules=../.github/go-licence-detector/rules.json
           rm dependencies.asciidoc
 
       - name: Print NOTICE.MD


### PR DESCRIPTION
After #1212, go-licence-detector GitHub Actions job started failing. One of the added dependencies uses [Unlicense](https://en.wikipedia.org/wiki/Unlicense) license, which is not on the allowlist of the default go-licence-detector rules list.

Unlicense is a public-domain-equivalent license. The default rules list already allowed similar licenses, such as "CC0-1.0" and "Public Domain", so it should be OK for us to add Unlicense to the allowed list.

The added rules.json is a default rules file with only Unlicense added.

This fixes the NOTICE.MD generation with go-licence-detector.