### PR TITLE
Improve validation of Array types

### DIFF
--- a/quesma/ingest/ingest_validator_test.go
+++ b/quesma/ingest/ingest_validator_test.go
@@ -46,14 +46,14 @@ func TestValidateIngest(t *testing.T) {
 		GoType: clickhouse.NewBaseType("float64").GoType,
 	}}
 
-	invalidJson := validateValueAgainstType("float", 1, floatCol)
+	invalidJson := validateValueAgainstType("float", 1, floatCol.Type)
 	assert.Equal(t, 0, len(invalidJson))
 	StringCol := &clickhouse.Column{Name: "float_field", Type: clickhouse.BaseType{
 		Name:   "String",
 		GoType: clickhouse.NewBaseType("string").GoType,
 	}}
 
-	invalidJson = validateValueAgainstType("string", 1, StringCol)
+	invalidJson = validateValueAgainstType("string", 1, StringCol.Type)
 	assert.Equal(t, 1, len(invalidJson))
 
 }
@@ -97,6 +97,9 @@ func TestIngestValidation(t *testing.T) {
 		`{"uint8_field":-1}`,
 		`{"uint8_field":255}`,
 		`{"uint8_field":1000}`,
+
+		`{"float_array_field":[3.14, 6.28, 0.99]}`,
+		`{"float_array_field":[1, 2, 3]}`,
 	}
 	expectedInsertJsons := []string{
 		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"attributes_values":{"string_field":"10"},"attributes_metadata":{"string_field":"v1;Int64"}}`, tableName),
@@ -124,6 +127,9 @@ func TestIngestValidation(t *testing.T) {
 		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"attributes_values":{"uint8_field":"-1"},"attributes_metadata":{"uint8_field":"v1;Int64"}}`, tableName),
 		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"uint8_field":255}`, tableName),
 		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"attributes_values":{"uint8_field":"1000"},"attributes_metadata":{"uint8_field":"v1;Int64"}}`, tableName),
+
+		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"float_array_field":[3.14,6.28,0.99]}`, tableName),
+		fmt.Sprintf(`INSERT INTO "%s" FORMAT JSONEachRow {"float_array_field":[1,2,3]}`, tableName),
 	}
 	tableMap := util.NewSyncMapWith(tableName, &clickhouse.Table{
 		Name:   tableName,
@@ -161,6 +167,13 @@ func TestIngestValidation(t *testing.T) {
 				BaseType: clickhouse.BaseType{
 					Name:   "Int64",
 					GoType: clickhouse.NewBaseType("Int64").GoType,
+				},
+			}},
+			"float_array_field": {Name: "float_array_field", Type: clickhouse.CompoundType{
+				Name: "Array",
+				BaseType: clickhouse.BaseType{
+					Name:   "Float64",
+					GoType: clickhouse.NewBaseType("Float64").GoType,
 				},
 			}},
 		},


### PR DESCRIPTION
Before this change, `validateValueAgainstType` would just compare the type name string in case of arrays. This could cause problems in case of arrays of numbers, for example if the user had an `Array(Float64)` ClickHouse column, but tried to insert an array of ints (e.g. `[3, 5, 7]`).

After this fix, the `validateValueAgainstType` logic now works recursively, validating the element type of `Array` (e.g. `Float64` of `Array(Float64)`) and comparing that with an element of incoming array from Elastic API.