### PR TITLE
Improve logging of NewType

### DIFF
--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -156,7 +156,7 @@ func BuildAttrsMap(m SchemaMap, config *ChTableConfig) (map[string][]interface{}
 			if a.Type.CanConvert(value) {
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
-				result[a.TypesArrayName] = append(result[a.TypesArrayName], NewType(value).String())
+				result[a.TypesArrayName] = append(result[a.TypesArrayName], NewType(value, name).String())
 
 				matched = true
 				break

--- a/quesma/ingest/parser.go
+++ b/quesma/ingest/parser.go
@@ -94,7 +94,7 @@ func JsonToColumns(m SchemaMap, chConfig *clickhouse.ChTableConfig) []CreateTabl
 		if value == nil { // HACK ALERT -> We're treating null values as strings for now, so that we don't completely discard documents with empty values
 			fTypeString = "Nullable(String)"
 		} else {
-			fType := clickhouse.NewType(value)
+			fType := clickhouse.NewType(value, name)
 
 			// handle "field":{} case (Elastic Agent sends such JSON fields) by ignoring them
 			if multiValueType, ok := fType.(clickhouse.MultiValueType); ok && len(multiValueType.Cols) == 0 {
@@ -315,7 +315,7 @@ func BuildAttrsMap(m SchemaMap, config *clickhouse.ChTableConfig) (map[string][]
 			if a.Type.CanConvert(value) {
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
-				result[a.TypesArrayName] = append(result[a.TypesArrayName], clickhouse.NewType(value).String())
+				result[a.TypesArrayName] = append(result[a.TypesArrayName], clickhouse.NewType(value, name).String())
 
 				matched = true
 				break

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -258,7 +258,7 @@ func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalid
 	for k, v := range invalidJson {
 		newAttrsMap[chLib.DeprecatedAttributesKeyColumn] = append(newAttrsMap[chLib.DeprecatedAttributesKeyColumn], k)
 		newAttrsMap[chLib.DeprecatedAttributesValueColumn] = append(newAttrsMap[chLib.DeprecatedAttributesValueColumn], v)
-		newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], chLib.NewType(v).String())
+		newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], chLib.NewType(v, k).String())
 	}
 	return newAttrsMap
 }


### PR DESCRIPTION
Before this change, `NewType(nil)` would return a unhelpful error message:

```
Unsupported type '<nil>' of value: <nil> in /quesma/clickhouse/schema.go:273
```

Improve the log by providing the "origin" of the `nil` value (in most cases the column name with that `nil` value).