### PR TITLE
Add placeholder for release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
             ```
             
             **Release Notes:**
-            - This is a bugix release.
+            - This is a minor bugfix release.
 
             All tags URL: https://hub.docker.com/r/quesma/quesma/tags
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,9 @@ jobs:
             ```bash
             docker pull quesma/quesma:${{ github.event.inputs.VERSION }}
             ```
+            
+            **Release Notes:**
+            - This is a bugix release.
 
             All tags URL: https://hub.docker.com/r/quesma/quesma/tags
           draft: true


### PR DESCRIPTION
By the time we figure that out programmatically, let's just add a placeholder to remind about adding at least one sentence about what is changing.