### PR TITLE
Improve `_msearch` handling

### DIFF
--- a/quesma/quesma/router_v2.go
+++ b/quesma/quesma/router_v2.go
@@ -190,7 +190,7 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, dependencies quesm
 		return HandleIndexAsyncSearch(ctx, req.Params["index"], query, waitForResultsMs, keepOnCompletion, queryRunner)
 	})
 
-	router.Register(routes.IndexMsearchPath, and(method("GET", "POST"), quesma_api.Always()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+	router.Register(routes.IndexMsearchPath, and(method("GET", "POST"), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
 		return HandleMultiSearch(ctx, req, req.Params["index"], queryRunner)
 	})
 

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -453,9 +453,10 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 		}
 	}
 
-	// it's impossible here to don't have a clickhouse decision TODO: it's possible in `_msearch` case
 	if clickhouseConnector == nil {
-		return nil, fmt.Errorf("no clickhouse connector")
+		// TODO: at this moment it's possible to land in this situation if `_msearch` payload contains Elasticsearch-targetted query
+		logger.Warn().Msgf("multi-search payload contains Elasticsearch-targetted query")
+		return nil, fmt.Errorf("quesma-processed _msearch payload contains Elasticsearch-targetted query")
 	}
 
 	var responseBody []byte


### PR DESCRIPTION
This PR puts a tiny improvement over multi-search handling: 

❗ `:index/_msearch` calls targeted to Elasticsearch will be routed directly to Elasticsearch instead of failing later on with enigmatic `no clickhouse connector` error.

Implementing a high-road fix in the current architecture requires adding a somehow 'dirty' dependency (QueryRunner will have to call Elasticsearch directly). Overall we can do it and sanitize `handleSearchCommon` a little too, but together with @pdelewski we decided to postpone this for now. 