### PR TITLE
Skip invalid/incomplete types in CREATE TABLE

### DIFF
--- a/ci/it/configs/quesma-ingest.yml.template
+++ b/ci/it/configs/quesma-ingest.yml.template
@@ -99,6 +99,9 @@ processors:
         encodings_test:
           target:
             - my-clickhouse-instance
+        incomplete_types_test:
+          target:
+            - my-clickhouse-instance
         "*":
           target:
             - my-clickhouse-instance
@@ -175,6 +178,9 @@ processors:
           target:
             - my-clickhouse-instance
         encodings_test:
+          target:
+            - my-clickhouse-instance
+        incomplete_types_test:
           target:
             - my-clickhouse-instance
         "*":

--- a/ci/it/testcases/test_ingest.go
+++ b/ci/it/testcases/test_ingest.go
@@ -41,6 +41,7 @@ func (a *IngestTestcase) RunTests(ctx context.Context, t *testing.T) error {
 	t.Run("test ignored fields", func(t *testing.T) { a.testIgnoredFields(ctx, t) })
 	t.Run("test nested fields", func(t *testing.T) { a.testNestedFields(ctx, t) })
 	t.Run("test field encodings (mappings bug)", func(t *testing.T) { a.testFieldEncodingsMappingsBug(ctx, t) })
+	t.Run("test incomplete types", func(t *testing.T) { a.testIncompleteTypes(ctx, t) })
 	return nil
 }
 
@@ -644,4 +645,166 @@ func (a *IngestTestcase) testFieldEncodingsMappingsBug(ctx context.Context, t *t
 
 	assert.Equal(t, "quesmaMetadataV1:fieldName=Field1", comments["field1"])
 	assert.Equal(t, "quesmaMetadataV1:fieldName=Field2", comments["field2"])
+}
+
+// Test "incomplete" types (e.g. null, empty array, empty object) for which Quesma can't infer a ClickHouse type.
+func (a *IngestTestcase) testIncompleteTypes(ctx context.Context, t *testing.T) {
+	doc := []byte(`
+{
+    "field1": "abc",
+    "field2": null,
+
+    "field3": ["def", "ghi"],
+    "field4": [],
+    "field5": [[]],
+
+    "field6": {"ijk": "klm"},
+    "field7": {},
+    "field8": {"cde": {}},
+
+    "field9": [[{"nop": "qrs"}]],
+    "field10": [[{}]]
+}
+`)
+	resp, body := a.RequestToQuesma(ctx, t, "POST", "/incomplete_types_test/_doc", doc)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(body), "error")
+
+	cols, err := a.FetchClickHouseColumns(ctx, "incomplete_types_test")
+	assert.NoError(t, err, "error fetching clickhouse columns")
+
+	expectedCols := map[string]string{
+		"@timestamp":          "DateTime64(3)",
+		"attributes_metadata": "Map(String, String)",
+		"attributes_values":   "Map(String, String)",
+
+		"field1": "Nullable(String)",
+		// field2 is null; null can be a Nullable(String), Nullable(Int64), ...
+
+		"field3": "Array(String)",
+		// field4 is an empty array; an empty array can be a Array(String), Array(Int64), ...
+		// field5 is an array of empty array; it could be an Array(Array(String)), Array(Array(Int64)), ...
+
+		"field6_ijk": "Nullable(String)",
+		// field7 is an empty object; it could be a Tuple(field1 String), Tuple(field1 Int64, field2 String), ...
+		// field8 is an object with an empty object; it could be a Tuple(cde Tuple(subfield Int64)), Tuple(cde Tuple(subfield String)), ...
+
+		"field9": "Array(Array(Tuple(nop Nullable(String))))",
+		// field10 is an array of arrays of empty objects; it could be an Array(Array(Tuple(subfield Int64))), Array(Array(Tuple(subfield String))), ...
+	}
+	assert.Equal(t, expectedCols, cols)
+
+	// Insert a similar document again (now that the table is already created)
+	doc2 := []byte(`
+{
+    "field1": "QUESMA_DOC2_1",
+    "field2": null,
+
+    "field3": ["QUESMA_DOC2_2", "QUESMA_DOC2_3"],
+    "field4": [],
+    "field5": [[]],
+
+    "field6": {"ijk": "QUESMA_DOC2_4"},
+    "field7": {},
+    "field8": {"cde": {}},
+
+    "field9": [[{"nop": "QUESMA_DOC2_5"}]],
+    "field10": [[{}]]
+}
+`)
+	resp, body = a.RequestToQuesma(ctx, t, "POST", "/incomplete_types_test/_doc", doc2)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(body), "error")
+
+	cols, err = a.FetchClickHouseColumns(ctx, "incomplete_types_test")
+	assert.NoError(t, err, "error fetching clickhouse columns")
+	assert.Equal(t, expectedCols, cols)
+
+	// Insert a document with all fields with complete types, testing ALTER TABLE ADD COLUMN behavior.
+	doc3 := []byte(`
+{
+    "field1": "QUESMA_DOC3_1",
+    "field2": "QUESMA_DOC3_2",
+
+    "field3": ["QUESMA_DOC3_3", "QUESMA_DOC3_4"],
+    "field4": ["QUESMA_DOC3_5"],
+    "field5": [["QUESMA_DOC3_6"]],
+
+    "field6": {"ijk": "QUESMA_DOC3_7"},
+    "field7": {"klm": "QUESMA_DOC3_8"},
+    "field8": {"cde": {"efg":"QUESMA_DOC3_9"}},
+
+    "field9": [[{"nop": "QUESMA_DOC3_10"}]],
+    "field10": [[{"asd": "QUESMA_DOC3_11"}]]
+}
+`)
+	resp, body = a.RequestToQuesma(ctx, t, "POST", "/incomplete_types_test/_doc", doc3)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotContains(t, string(body), "error")
+
+	expectedCols = map[string]string{
+		"@timestamp":          "DateTime64(3)",
+		"attributes_metadata": "Map(String, String)",
+		"attributes_values":   "Map(String, String)",
+
+		"field1": "Nullable(String)",
+		"field2": "Nullable(String)",
+
+		"field3": "Array(String)",
+		"field4": "Array(String)",
+		"field5": "Array(Array(String))",
+
+		"field6_ijk":     "Nullable(String)",
+		"field7_klm":     "Nullable(String)",
+		"field8_cde_efg": "Nullable(String)",
+
+		"field9":  "Array(Array(Tuple(nop Nullable(String))))",
+		"field10": "Array(Array(Tuple(asd Nullable(String))))",
+	}
+	cols, err = a.FetchClickHouseColumns(ctx, "incomplete_types_test")
+	assert.NoError(t, err, "error fetching clickhouse columns")
+	assert.Equal(t, expectedCols, cols)
+
+	// Verify that DOC2 and DOC3 were correctly inserted.
+	rows, err := a.ExecuteClickHouseQuery(ctx, "SELECT toString(field1), toString(field2), toString(field3), toString(field4), toString(field5), toString(field6_ijk), toString(field7_klm), toString(field8_cde_efg), toString(field9), toString(field10) FROM incomplete_types_test WHERE field1 IN ('QUESMA_DOC2_1', 'QUESMA_DOC3_1') ORDER BY field1")
+	assert.NoError(t, err)
+	defer rows.Close()
+
+	var results []struct {
+		cols []interface{}
+	}
+	for rows.Next() {
+		r := make([]interface{}, 10)
+		valPtrs := make([]interface{}, 10)
+		for i := range r {
+			valPtrs[i] = &r[i]
+		}
+		err = rows.Scan(valPtrs...)
+		assert.NoError(t, err)
+		results = append(results, struct{ cols []interface{} }{cols: r})
+	}
+	assert.Equal(t, 2, len(results))
+
+	assert.Contains(t, *results[0].cols[0].(*string), "QUESMA_DOC2_1")
+	assert.Contains(t, results[0].cols[2].(string), "QUESMA_DOC2_2")
+	assert.Contains(t, results[0].cols[2].(string), "QUESMA_DOC2_3")
+	assert.Contains(t, *results[0].cols[5].(*string), "QUESMA_DOC2_4")
+
+	// FIXME: this is not inserted correctly yet!
+	// assert.Contains(t, results[0].cols[8].(string), "QUESMA_DOC2_5")
+
+	assert.Contains(t, *results[1].cols[0].(*string), "QUESMA_DOC3_1")
+	assert.Contains(t, *results[1].cols[1].(*string), "QUESMA_DOC3_2")
+	assert.Contains(t, results[1].cols[2].(string), "QUESMA_DOC3_3")
+	assert.Contains(t, results[1].cols[2].(string), "QUESMA_DOC3_4")
+	assert.Contains(t, results[1].cols[3].(string), "QUESMA_DOC3_5")
+	assert.Contains(t, results[1].cols[4].(string), "QUESMA_DOC3_6")
+	assert.Contains(t, *results[1].cols[5].(*string), "QUESMA_DOC3_7")
+	assert.Contains(t, *results[1].cols[6].(*string), "QUESMA_DOC3_8")
+	assert.Contains(t, *results[1].cols[7].(*string), "QUESMA_DOC3_9")
+
+	// FIXME: this is not inserted correctly yet!
+	// assert.Contains(t, results[1].cols[8].(string), "QUESMA_DOC3_10")
+
+	assert.Contains(t, results[1].cols[9].(string), "QUESMA_DOC3_11")
 }

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -156,7 +156,13 @@ func BuildAttrsMap(m SchemaMap, config *ChTableConfig) (map[string][]interface{}
 			if a.Type.CanConvert(value) {
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
-				result[a.TypesArrayName] = append(result[a.TypesArrayName], NewType(value, name).String())
+
+				valueType, err := NewType(value, name)
+				if err != nil {
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], err.Error())
+				} else {
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], valueType.String())
+				}
 
 				matched = true
 				break

--- a/quesma/clickhouse/parser.go
+++ b/quesma/clickhouse/parser.go
@@ -159,7 +159,7 @@ func BuildAttrsMap(m SchemaMap, config *ChTableConfig) (map[string][]interface{}
 
 				valueType, err := NewType(value, name)
 				if err != nil {
-					result[a.TypesArrayName] = append(result[a.TypesArrayName], err.Error())
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], UndefinedType)
 				} else {
 					result[a.TypesArrayName] = append(result[a.TypesArrayName], valueType.String())
 				}

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -21,6 +21,8 @@ const (
 	attributesColumnType     = "Map(String, String)" // ClickHouse type of AttributesValuesColumn, AttributesMetadataColumn
 	AttributesValuesColumn   = "attributes_values"
 	AttributesMetadataColumn = "attributes_metadata"
+
+	UndefinedType = "Undefined" // used for unknown types or incomplete types for which NewType can't infer a proper type
 )
 
 type (

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -231,7 +231,8 @@ func ResolveType(clickHouseTypeName string) reflect.Type {
 }
 
 // 'value': value of a field, from unmarshalled JSON
-func NewType(value any, valueOrigin string) Type {
+// 'valueOrigin': name of the field (for error messages)
+func NewType(value any, valueOrigin string) (Type, error) {
 	isFloatInt := func(f float64) bool {
 		return math.Mod(f, 1.0) == 0.0
 	}
@@ -239,42 +240,54 @@ func NewType(value any, valueOrigin string) Type {
 	case string:
 		t, err := time.Parse(time.RFC3339Nano, valueCasted)
 		if err == nil {
-			return BaseType{Name: "DateTime64", GoType: reflect.TypeOf(t)}
+			return BaseType{Name: "DateTime64", GoType: reflect.TypeOf(t)}, nil
 		}
 		t, err = time.Parse("2006-01-02T15:04:05", valueCasted)
 		if err == nil {
-			return BaseType{Name: "DateTime64", GoType: reflect.TypeOf(t)}
+			return BaseType{Name: "DateTime64", GoType: reflect.TypeOf(t)}, nil
 		}
-		return BaseType{Name: "String", GoType: reflect.TypeOf("")}
+		return BaseType{Name: "String", GoType: reflect.TypeOf("")}, nil
 	case float64:
 		if isFloatInt(valueCasted) {
-			return BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0))}
+			return BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0))}, nil
 		} else {
-			return BaseType{Name: "Float64", GoType: reflect.TypeOf(float64(0))}
+			return BaseType{Name: "Float64", GoType: reflect.TypeOf(float64(0))}, nil
 		}
 	case bool:
-		return BaseType{Name: "Bool", GoType: reflect.TypeOf(true)}
+		return BaseType{Name: "Bool", GoType: reflect.TypeOf(true)}, nil
 	case map[string]interface{}:
 		cols := make([]*Column, len(valueCasted))
 		for k, v := range valueCasted {
-			if v != nil {
-				cols = append(cols, &Column{Name: k, Type: NewType(v, fmt.Sprintf("%s.%s", valueOrigin, k)), Codec: Codec{Name: ""}})
+			innerName := fmt.Sprintf("%s.%s", valueOrigin, k)
+			innerType, err := NewType(v, innerName)
+			if err != nil {
+				return nil, err
 			}
+			cols = append(cols, &Column{Name: k, Type: innerType, Codec: Codec{Name: ""}})
 		}
-		return MultiValueType{Name: "Tuple", Cols: cols}
+		if len(cols) == 0 {
+			logger.Warn().Msgf("Empty map type (origin: %s).", valueOrigin)
+			return nil, fmt.Errorf("empty map type (origin: %s)", valueOrigin)
+		}
+		return MultiValueType{Name: "Tuple", Cols: cols}, nil
 	case []interface{}:
 		if len(valueCasted) == 0 {
-			// empty array defaults to string for now, maybe change needed or error returned
-			return CompoundType{Name: "Array", BaseType: NewBaseType("String")}
+			logger.Warn().Msgf("Empty array type (origin: %s).", valueOrigin)
+			return nil, fmt.Errorf("empty array type (origin: %s)", valueOrigin)
 		}
-		return CompoundType{Name: "Array", BaseType: NewType(valueCasted[0], fmt.Sprintf("%s[0]", valueOrigin))}
+		innerName := fmt.Sprintf("%s[0]", valueOrigin)
+		innerType, err := NewType(valueCasted[0], innerName)
+		if err != nil {
+			return nil, err
+		}
+		return CompoundType{Name: "Array", BaseType: innerType}, nil
+	case nil:
+		logger.Warn().Msgf("Nil type (origin: %s).", valueOrigin)
+		return nil, fmt.Errorf("nil type (origin: %s)", valueOrigin)
 	}
 
 	logger.Warn().Msgf("Unsupported type '%T' of value: %v (origin: %s).", value, value, valueOrigin)
-
-	// value can be nil, so should return something reasonable here
-	return BaseType{Name: "String", GoType: reflect.TypeOf("")}
-
+	return nil, fmt.Errorf("unsupported type '%T' of value: %v (origin: %s)", value, value, valueOrigin)
 }
 
 func NewTable(createTableQuery string, config *ChTableConfig) (*Table, error) {

--- a/quesma/ingest/parser.go
+++ b/quesma/ingest/parser.go
@@ -93,6 +93,7 @@ func JsonToColumns(m SchemaMap, chConfig *clickhouse.ChTableConfig) []CreateTabl
 		fType, err := clickhouse.NewType(value, name)
 		if err != nil {
 			// Skip column with invalid/incomplete type
+			logger.Warn().Msgf("Skipping field '%s' with invalid/incomplete type: %v", name, err)
 			continue
 		}
 

--- a/quesma/ingest/parser.go
+++ b/quesma/ingest/parser.go
@@ -90,23 +90,17 @@ func JsonToColumns(m SchemaMap, chConfig *clickhouse.ChTableConfig) []CreateTabl
 	var resultColumns []CreateTableEntry
 
 	for name, value := range m {
-		var fTypeString string
-		if value == nil { // HACK ALERT -> We're treating null values as strings for now, so that we don't completely discard documents with empty values
-			fTypeString = "Nullable(String)"
-		} else {
-			fType := clickhouse.NewType(value, name)
-
-			// handle "field":{} case (Elastic Agent sends such JSON fields) by ignoring them
-			if multiValueType, ok := fType.(clickhouse.MultiValueType); ok && len(multiValueType.Cols) == 0 {
-				logger.Warn().Msgf("Ignoring empty JSON object: \"%s\":%v", name, value)
-				continue
-			}
-
-			fTypeString = fType.String()
-			if !strings.Contains(fTypeString, "Array") && !strings.Contains(fTypeString, "DateTime") {
-				fTypeString = "Nullable(" + fTypeString + ")"
-			}
+		fType, err := clickhouse.NewType(value, name)
+		if err != nil {
+			// Skip column with invalid/incomplete type
+			continue
 		}
+
+		fTypeString := fType.String()
+		if !strings.Contains(fTypeString, "Array") && !strings.Contains(fTypeString, "DateTime") {
+			fTypeString = "Nullable(" + fTypeString + ")"
+		}
+
 		// hack for now
 		if name == timestampFieldName && chConfig.TimestampDefaultsNow {
 			fTypeString += " DEFAULT now64()"
@@ -315,7 +309,13 @@ func BuildAttrsMap(m SchemaMap, config *clickhouse.ChTableConfig) (map[string][]
 			if a.Type.CanConvert(value) {
 				result[a.KeysArrayName] = append(result[a.KeysArrayName], name)
 				result[a.ValuesArrayName] = append(result[a.ValuesArrayName], fmt.Sprintf("%v", value))
-				result[a.TypesArrayName] = append(result[a.TypesArrayName], clickhouse.NewType(value, name).String())
+
+				valueType, err := clickhouse.NewType(value, name)
+				if err != nil {
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], err.Error())
+				} else {
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], valueType.String())
+				}
 
 				matched = true
 				break

--- a/quesma/ingest/parser.go
+++ b/quesma/ingest/parser.go
@@ -312,7 +312,7 @@ func BuildAttrsMap(m SchemaMap, config *clickhouse.ChTableConfig) (map[string][]
 
 				valueType, err := clickhouse.NewType(value, name)
 				if err != nil {
-					result[a.TypesArrayName] = append(result[a.TypesArrayName], err.Error())
+					result[a.TypesArrayName] = append(result[a.TypesArrayName], clickhouse.UndefinedType)
 				} else {
 					result[a.TypesArrayName] = append(result[a.TypesArrayName], valueType.String())
 				}

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -261,7 +261,7 @@ func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalid
 
 		valueType, err := chLib.NewType(v, k)
 		if err != nil {
-			newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], err.Error())
+			newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], chLib.UndefinedType)
 		} else {
 			newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], valueType.String())
 		}
@@ -314,6 +314,11 @@ func (ip *IngestProcessor) generateNewColumns(
 
 		columnType := ""
 		modifiers := ""
+
+		if attrTypes[i] == chLib.UndefinedType {
+			continue
+		}
+
 		// Array and Map are not Nullable
 		if strings.Contains(attrTypes[i], "Array") || strings.Contains(attrTypes[i], "Map") {
 			columnType = attrTypes[i]

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -258,7 +258,13 @@ func addInvalidJsonFieldsToAttributes(attrsMap map[string][]interface{}, invalid
 	for k, v := range invalidJson {
 		newAttrsMap[chLib.DeprecatedAttributesKeyColumn] = append(newAttrsMap[chLib.DeprecatedAttributesKeyColumn], k)
 		newAttrsMap[chLib.DeprecatedAttributesValueColumn] = append(newAttrsMap[chLib.DeprecatedAttributesValueColumn], v)
-		newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], chLib.NewType(v, k).String())
+
+		valueType, err := chLib.NewType(v, k)
+		if err != nil {
+			newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], err.Error())
+		} else {
+			newAttrsMap[chLib.DeprecatedAttributesValueType] = append(newAttrsMap[chLib.DeprecatedAttributesValueType], valueType.String())
+		}
 	}
 	return newAttrsMap
 }


### PR DESCRIPTION
When a user sends a JSON with a `nil` field, we can't determine a ClickHouse type for such field (column). This is the case for `nil` (we used to fall back to String), an empty array or empty dictionary.

This PR changes the logic in `NewType()` - when the type is determined to be invalid/incomplete, the function now returns an error. The `CREATE TABLE` code now can skip such problematic column. If a user sends such field with complete type, it will be handled in some future `ALTER TABLE ADD COLUMN` statement (as now Quesma sees an example with complete type).