### PR TITLE
Quickfix failing e2e

### DIFF
--- a/quesma/quesma/search_test.go
+++ b/quesma/quesma/search_test.go
@@ -862,7 +862,7 @@ func TestSearchTrackTotalCount(t *testing.T) {
 }
 
 func TestFullQueryTestWIP(t *testing.T) {
-	logger.InitSimpleLoggerForTests()
+	// logger.InitSimpleLoggerForTests()
 	s := &schema.StaticRegistry{Tables: map[schema.IndexName]schema.Schema{}}
 
 	s.Tables[tableName] = schema.Schema{

--- a/quesma/testdata/aggregation_requests.go
+++ b/quesma/testdata/aggregation_requests.go
@@ -1378,7 +1378,7 @@ var AggregationTests = []AggregationTestCase{
 					Cols: []model.QueryResultCol{
 						model.NewQueryResultCol("aggr__origins__parent_count", uint64(13014)),
 						model.NewQueryResultCol("aggr__origins__key_0", "DLH"),
-						model.NewQueryResultCol("aggr__origins__count", int64(15)),
+						model.NewQueryResultCol("aggr__origins__count", int64(25)),
 						model.NewQueryResultCol("top_hits__origins__originLocation_col_0", map[string]interface{}{
 							"lat": "46.84209824",
 							"lon": "-92.19360352",


### PR DESCRIPTION
I run e2e twice now and no errors. It failed because of:
* data race with logger in the test
* sometimes flaky 1 aggregation test, mistype and it had `15` and `25` in 2 places, where the number must be the same (result of the same query)

Sorry for the issue, my PR a few days ago introduced the first error.