### PR TITLE
Unify golang type to ClickHouse type conversion in `CREATE TABLE` and validation codepaths, improve `Tuple(...)` validation

### DIFF
--- a/ci/it/testcases/test_ingest.go
+++ b/ci/it/testcases/test_ingest.go
@@ -789,9 +789,7 @@ func (a *IngestTestcase) testIncompleteTypes(ctx context.Context, t *testing.T) 
 	assert.Contains(t, results[0].cols[2].(string), "QUESMA_DOC2_2")
 	assert.Contains(t, results[0].cols[2].(string), "QUESMA_DOC2_3")
 	assert.Contains(t, *results[0].cols[5].(*string), "QUESMA_DOC2_4")
-
-	// FIXME: this is not inserted correctly yet!
-	// assert.Contains(t, results[0].cols[8].(string), "QUESMA_DOC2_5")
+	assert.Contains(t, results[0].cols[8].(string), "QUESMA_DOC2_5")
 
 	assert.Contains(t, *results[1].cols[0].(*string), "QUESMA_DOC3_1")
 	assert.Contains(t, *results[1].cols[1].(*string), "QUESMA_DOC3_2")
@@ -802,9 +800,6 @@ func (a *IngestTestcase) testIncompleteTypes(ctx context.Context, t *testing.T) 
 	assert.Contains(t, *results[1].cols[5].(*string), "QUESMA_DOC3_7")
 	assert.Contains(t, *results[1].cols[6].(*string), "QUESMA_DOC3_8")
 	assert.Contains(t, *results[1].cols[7].(*string), "QUESMA_DOC3_9")
-
-	// FIXME: this is not inserted correctly yet!
-	// assert.Contains(t, results[1].cols[8].(string), "QUESMA_DOC3_10")
-
+	assert.Contains(t, results[1].cols[8].(string), "QUESMA_DOC3_10")
 	assert.Contains(t, results[1].cols[9].(string), "QUESMA_DOC3_11")
 }

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -192,7 +192,7 @@ func (t MultiValueType) CanConvert(v interface{}) bool {
 }
 
 func (t MultiValueType) GetColumn(name string) *Column {
-	// TODO: maybe use map for faster lookup, but Tuples probably aren't typically large so linear scan suffices for now
+	// TODO: linear scan, but this will suffice for now (Tuples aren't typically large)
 	for _, col := range t.Cols {
 		if col.Name == name {
 			return col

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -255,6 +255,8 @@ func NewType(value any, valueOrigin string) (Type, error) {
 		} else {
 			return BaseType{Name: "Float64", GoType: reflect.TypeOf(float64(0))}, nil
 		}
+	case int:
+		return BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0))}, nil
 	case bool:
 		return BaseType{Name: "Bool", GoType: reflect.TypeOf(true)}, nil
 	case map[string]interface{}:

--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -191,6 +191,16 @@ func (t MultiValueType) CanConvert(v interface{}) bool {
 	return false // TODO for now. For sure can implement tuples easily, maybe some other too
 }
 
+func (t MultiValueType) GetColumn(name string) *Column {
+	// TODO: maybe use map for faster lookup, but Tuples probably aren't typically large so linear scan suffices for now
+	for _, col := range t.Cols {
+		if col.Name == name {
+			return col
+		}
+	}
+	return nil
+}
+
 func NewBaseType(clickHouseTypeName string) BaseType {
 	var GoType = ResolveType(clickHouseTypeName)
 	if GoType == nil {

--- a/quesma/ingest/ingest_validator.go
+++ b/quesma/ingest/ingest_validator.go
@@ -134,8 +134,9 @@ func validateValueAgainstType(fieldName string, value interface{}, columnType cl
 				}
 				return true
 			}
+		} else {
+			logger.Error().Msgf("MultiValueType validation is not yet supported for type: %v", columnType)
 		}
-		logger.Error().Msgf("MultiValueType validation is not yet supported for type: %v", columnType)
 
 		return false
 	case clickhouse.CompoundType:
@@ -148,9 +149,9 @@ func validateValueAgainstType(fieldName string, value interface{}, columnType cl
 				}
 				return true
 			}
+		} else {
+			logger.Error().Msgf("CompoundType validation is not yet supported for type: %v", columnType)
 		}
-
-		logger.Error().Msgf("CompoundType validation is not yet supported for type: %v", columnType)
 
 		return false
 	}

--- a/quesma/ingest/ingest_validator.go
+++ b/quesma/ingest/ingest_validator.go
@@ -9,79 +9,7 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
 	"math"
-	"reflect"
 )
-
-func isInt(f float64) bool {
-	return f == float64(int64(f))
-}
-
-func isUnsignedInt(f float64) bool {
-	if f < 0 {
-		return false
-	}
-	return f == float64(uint64(f))
-}
-
-func getTypeName(v interface{}) string {
-	const unknownLiteral = "unknown"
-	const arrayLiteral = "Array"
-	primitiveTypes := map[string]string{
-		"string":  "String",
-		"bool":    "Bool",
-		"int":     "Int64",
-		"float64": "Float64",
-		"uint":    "UInt64",
-	}
-	if v == nil {
-		return unknownLiteral
-	}
-	GoType := reflect.TypeOf(v).String()
-	switch GoType {
-	case "string", "bool":
-		return primitiveTypes[GoType]
-	case "int":
-		if v.(int) < 0 {
-			return primitiveTypes["int"]
-		} else {
-			return primitiveTypes["uint"]
-		}
-	case "float64":
-		if isInt(v.(float64)) {
-			return primitiveTypes["int"]
-		} else if isUnsignedInt(v.(float64)) {
-			return primitiveTypes["uint"]
-		}
-		return primitiveTypes[GoType]
-	}
-	switch elem := v.(type) {
-	case []interface{}:
-		if len(elem) == 0 {
-			return arrayLiteral + "(unknown)"
-		} else {
-			innerTypeName := getTypeName(elem[0])
-			// Make sure that all elements of the array have the same type
-			for _, e := range elem {
-				if getTypeName(e) != innerTypeName {
-					return arrayLiteral + "(unknown)"
-				}
-			}
-			return arrayLiteral + "(" + innerTypeName + ")"
-		}
-	case interface{}:
-		if e := reflect.ValueOf(elem); e.Kind() == reflect.Slice {
-			innerTypeName := getTypeName(e.Index(0).Interface())
-			// Make sure that all elements of the slice have the same type
-			for i := 1; i < e.Len(); i++ {
-				if getTypeName(e.Index(i).Interface()) != innerTypeName {
-					return arrayLiteral + "(unknown)"
-				}
-			}
-			return arrayLiteral + "(" + innerTypeName + ")"
-		}
-	}
-	return GoType
-}
 
 func removeLowCardinality(columnType string) string {
 	if columnType == "LowCardinality(String)" {

--- a/quesma/ingest/ingest_validator.go
+++ b/quesma/ingest/ingest_validator.go
@@ -98,13 +98,13 @@ func validateNumericType(columnType string, incomingValueType string, value inte
 }
 
 func validateValueAgainstType(fieldName string, value interface{}, columnType clickhouse.Type) (isValid bool) {
-	incomingValueType, err := clickhouse.NewType(value, fieldName)
-	if err != nil {
-		return false
-	}
-
 	switch columnType := columnType.(type) {
 	case clickhouse.BaseType:
+		incomingValueType, err := clickhouse.NewType(value, fieldName)
+		if err != nil {
+			return false
+		}
+
 		columnTypeName := removeLowCardinality(columnType.Name)
 
 		if isNumericType(columnTypeName) {

--- a/quesma/ingest/ingest_validator_test.go
+++ b/quesma/ingest/ingest_validator_test.go
@@ -19,27 +19,6 @@ import (
 	"testing"
 )
 
-func TestGetTypeName(t *testing.T) {
-	values := make(map[string][]interface{})
-	values["UInt64"] = []interface{}{1}
-	values["Float64"] = []interface{}{1.1}
-	values["Int64"] = []interface{}{-1}
-	values["String"] = []interface{}{"string"}
-	values["Bool"] = []interface{}{true}
-	values["Array(UInt64)"] = []interface{}{[]interface{}{1}}
-	values["Array(Int64)"] = []interface{}{[]interface{}{-1}}
-	values["Array(Array(Int64))"] = []interface{}{[][]interface{}{{-1}}}
-	values["Array(Array(Array(Int64)))"] = []interface{}{[][][]interface{}{{{-1}}}}
-	for typeName, values := range values {
-		for _, value := range values {
-			t.Run(typeName, func(t *testing.T) {
-				assert.NotNil(t, value)
-				assert.Equal(t, typeName, getTypeName(value))
-			})
-		}
-	}
-}
-
 func TestValidateIngest(t *testing.T) {
 	floatCol := &clickhouse.Column{Name: "float_field", Type: clickhouse.BaseType{
 		Name:   "Float64",

--- a/quesma/ingest/ingest_validator_test.go
+++ b/quesma/ingest/ingest_validator_test.go
@@ -47,14 +47,14 @@ func TestValidateIngest(t *testing.T) {
 	}}
 
 	invalidJson := validateValueAgainstType("float", 1, floatCol.Type)
-	assert.Equal(t, 0, len(invalidJson))
+	assert.True(t, invalidJson)
 	StringCol := &clickhouse.Column{Name: "float_field", Type: clickhouse.BaseType{
 		Name:   "String",
 		GoType: clickhouse.NewBaseType("string").GoType,
 	}}
 
 	invalidJson = validateValueAgainstType("string", 1, StringCol.Type)
-	assert.Equal(t, 1, len(invalidJson))
+	assert.False(t, invalidJson)
 
 }
 


### PR DESCRIPTION
In the ingest processor we had two separate codepaths for converting a Golang type into ClickHouse column type: one used in `CREATE TABLE` codepath (`clickhouse.NewType`) and another in ingest validation (`getTypeName`). The first one had better support for (nested) arrays and maps, which were not fully supported in ingest validation.

Therefore this PR unifies the ingest validation codepath to use the `clickhouse.NewType` from `CREATE TABLE` codepath. As a result, ingest validation now has a better support for nested arrays, maps (see `test_ingest.go`) and the code is now simpler.