### PR TITLE
Rate limit logs globally

### DIFF
--- a/quesma/logger/logger.go
+++ b/quesma/logger/logger.go
@@ -89,6 +89,11 @@ func InitLogger(cfg Configuration, sig chan os.Signal, doneCh chan struct{}) <-c
 	multi := zerolog.MultiLevelWriter(logWriters...)
 	l := zerolog.New(multi).
 		Level(cfg.Level).
+		Sample(&zerolog.BurstSampler{
+			Burst:       quesma_v2.DefaultBurstSamplerMaxLogsPerSecond * quesma_v2.DefaultBurstSamplerPeriodSeconds,
+			Period:      quesma_v2.DefaultBurstSamplerPeriodSeconds * time.Second,
+			NextSampler: zerolog.RandomSampler(quesma_v2.DefaultSheddingFrequency),
+		}).
 		With().
 		Timestamp().
 		Caller().


### PR DESCRIPTION
This is a first PR in a series to reduce amount of logs generated by Quesma. This PR rate limits logs globally for entire Quesma. This is meant as a fail-safe in case some codepath generates too much logs (specific codepaths will be fixed in next PRs).

The rate limits in this PR are generous, as it's only a fail-safe:
- ~100k log lines per hour
- Allow for bursts of 600 lines of logs (per 20 second period)
- When the limit is exhausted (for the 20 second period), logger will cut down on amount of logs, printing 1/100th of logs. This shedding is not an elegant solution, but that way the user sees that Quesma is still running and printing something (until the next 20 second period).