### PR TITLE
Support `_msearch` queries targetting mixed sources

### DIFF
--- a/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
+++ b/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
@@ -4,13 +4,13 @@
 package es_to_ch_ingest
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"github.com/QuesmaOrg/quesma/quesma/backend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/frontend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/ingest"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
+	"github.com/QuesmaOrg/quesma/quesma/util"
 	quesma_api "github.com/QuesmaOrg/quesma/quesma/v2/core"
 
 	"github.com/QuesmaOrg/quesma/quesma/processors"
@@ -20,7 +20,6 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
 	"github.com/QuesmaOrg/quesma/quesma/schema"
 	"github.com/rs/zerolog/log"
-	"io"
 	"net/http"
 )
 
@@ -165,15 +164,6 @@ func (p *ElasticsearchToClickHouseIngestProcessor) GetSupportedBackendConnectors
 	return []quesma_api.BackendConnectorType{quesma_api.ClickHouseSQLBackend, quesma_api.ElasticsearchBackend}
 }
 
-func ReadResponseBody(resp *http.Response) ([]byte, error) {
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
-	return respBody, nil
-}
-
 func (p *ElasticsearchToClickHouseIngestProcessor) routeToElasticsearch(metadata map[string]interface{}, req *http.Request) (map[string]interface{}, *quesma_api.Result, error) {
 	metadata[es_to_ch_common.RealSourceHeader] = es_to_ch_common.RealSourceElasticsearch
 	esConn, err := p.getElasticsearchBackendConnector()
@@ -184,7 +174,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) routeToElasticsearch(metadata
 	if err != nil {
 		return metadata, nil, err
 	}
-	respBody, err := ReadResponseBody(resp)
+	respBody, err := util.ReadResponseBody(resp)
 	if err != nil {
 		return metadata, nil, fmt.Errorf("failed to read response body from Elastic")
 	}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -481,7 +481,9 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 			clickhouseConnector = c
 
 		case *quesma_api.ConnectorDecisionElastic:
-			// NOP
+			// After https://github.com/QuesmaOrg/quesma/pull/1278 we should never land in this situation,
+			// previously this was an escape hatch for `_msearch` payload containing Elasticsearch-targetted query
+			// This code lives only to postpone bigger refactor of `handleSearchCommon` which also supports async and A/B testing
 
 		default:
 			return nil, fmt.Errorf("unknown connector type: %T", c)
@@ -489,7 +491,6 @@ func (q *QueryRunner) handleSearchCommon(ctx context.Context, indexPattern strin
 	}
 
 	if clickhouseConnector == nil {
-		// TODO: at this moment it's possible to land in this situation if `_msearch` payload contains Elasticsearch-targetted query
 		logger.Warn().Msgf("multi-search payload contains Elasticsearch-targetted query")
 		return nil, fmt.Errorf("quesma-processed _msearch payload contains Elasticsearch-targetted query")
 	}

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -29,7 +29,6 @@ import (
 	"github.com/QuesmaOrg/quesma/quesma/v2/core/diag"
 	"github.com/QuesmaOrg/quesma/quesma/v2/core/tracing"
 	"github.com/goccy/go-json"
-	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -300,7 +299,7 @@ func (q *QueryRunner) forwardToElasticsearch(ctx context.Context, indexName stri
 	if resp, err := esClient.Request(ctx, "POST", "/_search", queryBody); err != nil {
 		return []byte{}, err
 	} else {
-		respBody, errRead := io.ReadAll(resp.Body)
+		respBody, errRead := util.ReadResponseBody(resp)
 		return respBody, errRead
 	}
 }

--- a/quesma/quesma/search.go
+++ b/quesma/quesma/search.go
@@ -236,7 +236,8 @@ func (q *QueryRunner) HandleMultiSearch(ctx context.Context, defaultIndexName st
 	logger.DebugWithCtx(ctx).Msgf("handling multisearch: queries=%d, indices=[%s], defaultIndex=[%s]", len(queries), queriedIndices, defaultIndexName)
 	for _, query := range queries {
 		var responseBody []byte
-		if q.shouldRouteQueryToElasticsearch(query) {
+		if q.shouldRouteQueryToElasticsearch(query) { // this branch is here to get response from multi-search query targeted an index not stored in Clickhouse
+			// this is also a shortcut that we took to delay a bigger refactor, eventually HandleMultiSearch should dispatch all individual queries to proper connector, similarly to `_bulk` endpoint
 			responseBody, err = q.forwardToElasticsearch(ctx, query.indexName, query.query)
 		} else {
 			responseBody, err = q.HandleSearch(ctx, query.indexName, query.query)


### PR DESCRIPTION
This is a very basic support for `_msearch` targeting Elasticsearch, not ClickHouse.

The main goal is to provide better Grafana experience which almost exclusively relies on `_msearch` endpoint.

In the future we might expand on this, do a bigger refactor or support parrallel execution of multi search queries.