### PR TITLE
Fix creating `Nullable(Tuple)` type

### DIFF
--- a/quesma/clickhouse/schema.go
+++ b/quesma/clickhouse/schema.go
@@ -130,7 +130,7 @@ func (t MultiValueType) String() string {
 			// 		WORKAROUND: if col.Name == "discount_amount" || col.Name == "unit_discount_amount" -> tupleParams = append(tupleParams, fmt.Sprintf("%s %s", col.Name, "Float64"))
 			//	But it's not a good solution, need to find a better one
 			colType := col.Type.String()
-			if !strings.Contains(colType, "Array") && !strings.Contains(colType, "DateTime") {
+			if (!strings.Contains(colType, "Array") && !strings.Contains(colType, "Tuple")) && !strings.Contains(colType, "DateTime") {
 				colType = "Nullable(" + colType + ")"
 			}
 			tupleParams = append(tupleParams, fmt.Sprintf("%s %s", col.Name, colType))

--- a/quesma/ingest/parser.go
+++ b/quesma/ingest/parser.go
@@ -98,7 +98,7 @@ func JsonToColumns(m SchemaMap, chConfig *clickhouse.ChTableConfig) []CreateTabl
 		}
 
 		fTypeString := fType.String()
-		if !strings.Contains(fTypeString, "Array") && !strings.Contains(fTypeString, "DateTime") {
+		if (!strings.Contains(fTypeString, "Array") && !strings.Contains(fTypeString, "Tuple")) && !strings.Contains(fTypeString, "DateTime") {
 			fTypeString = "Nullable(" + fTypeString + ")"
 		}
 

--- a/quesma/ingest/parser_test.go
+++ b/quesma/ingest/parser_test.go
@@ -1,0 +1,53 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package ingest
+
+import (
+	"github.com/QuesmaOrg/quesma/quesma/clickhouse"
+	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJsonToColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  string
+		expected []CreateTableEntry
+	}{
+		{
+			name:    "NestedTuples",
+			payload: `{"nested_tuples":[[{"test":{"id":"asdf","ns":"rrrr"}}]]}`,
+			expected: []CreateTableEntry{
+				{ClickHouseColumnName: "nested_tuples", ClickHouseType: "Array(Array(Tuple(test Tuple(id Nullable(String), ns Nullable(String)))))"},
+			},
+		},
+		{
+			name:    "NotSoDeeplyNested",
+			payload: `{"not_so_deeply_nested":[{"test":{"id":0.1337,"ns":1233}}]}`,
+			expected: []CreateTableEntry{
+				{ClickHouseColumnName: "not_so_deeply_nested", ClickHouseType: "Array(Tuple(test Tuple(id Nullable(Float64), ns Nullable(Int64))))"},
+			},
+		},
+		{
+			name:    "Timestamp",
+			payload: `{"@timestamp":"2024-01-27T16:11:19.94Z"}`,
+			expected: []CreateTableEntry{
+				{ClickHouseColumnName: "@timestamp", ClickHouseType: "DateTime64 DEFAULT now64()"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			json, _ := types.ParseJSON(tt.payload)
+
+			result := JsonToColumns(json, &clickhouse.ChTableConfig{
+				TimestampDefaultsNow: true,
+			})
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This is an invalid ClickHouse type which can end up with:
```
error executing query: code: 43, message: Nested type Tuple(id Nullable(Int64), ns Nullable(Int64)) cannot be inside Nullable type
```
Tuples, similarly to Arrays, cannot be wrapped in a `Nullable` type. This PR fixes this behavior and adds relevant test.