### PR TITLE
Moving stuff related to frontend connectors

### DIFF
--- a/quesma/frontend_connectors/es_responses.go
+++ b/quesma/frontend_connectors/es_responses.go
@@ -1,13 +1,12 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"
 	"errors"
 	"github.com/QuesmaOrg/quesma/quesma/elasticsearch"
 	"github.com/QuesmaOrg/quesma/quesma/end_user_errors"
-	"github.com/QuesmaOrg/quesma/quesma/frontend_connectors"
 	"github.com/QuesmaOrg/quesma/quesma/logger"
 	"github.com/QuesmaOrg/quesma/quesma/parsers/elastic_query_dsl"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/functionality/bulk"
@@ -139,8 +138,8 @@ func ElasticsearchInsertResult(body string, statusCode int) *quesma_api.Result {
 func elasticsearchInsertResult(body string, statusCode int) *quesma_api.Result {
 	return &quesma_api.Result{Body: body, Meta: map[string]any{
 		// TODO copy paste from the original request
-		frontend_connectors.ContentTypeHeaderKey: "application/json",
-		"X-Quesma-Headers-Source":                "Quesma",
+		ContentTypeHeaderKey:      "application/json",
+		"X-Quesma-Headers-Source": "Quesma",
 	}, StatusCode: statusCode,
 		GenericResult: []byte(body)}
 }

--- a/quesma/frontend_connectors/matchers.go
+++ b/quesma/frontend_connectors/matchers.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/painful"

--- a/quesma/frontend_connectors/matchers_test.go
+++ b/quesma/frontend_connectors/matchers_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"

--- a/quesma/frontend_connectors/query_translator.go
+++ b/quesma/frontend_connectors/query_translator.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/route_handlers.go
+++ b/quesma/frontend_connectors/route_handlers.go
@@ -1,7 +1,7 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
 
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/router_test.go
+++ b/quesma/frontend_connectors/router_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/router_v2.go
+++ b/quesma/frontend_connectors/router_v2.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/schema_array_transformer.go
+++ b/quesma/frontend_connectors/schema_array_transformer.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/logger"

--- a/quesma/frontend_connectors/schema_map_transformation.go
+++ b/quesma/frontend_connectors/schema_map_transformation.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/logger"

--- a/quesma/frontend_connectors/schema_search_after_transformer.go
+++ b/quesma/frontend_connectors/schema_search_after_transformer.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"fmt"

--- a/quesma/frontend_connectors/schema_search_after_transformer_test.go
+++ b/quesma/frontend_connectors/schema_search_after_transformer_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"fmt"

--- a/quesma/frontend_connectors/schema_transformer.go
+++ b/quesma/frontend_connectors/schema_transformer.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"fmt"

--- a/quesma/frontend_connectors/schema_transformer_test.go
+++ b/quesma/frontend_connectors/schema_transformer_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/clickhouse"

--- a/quesma/frontend_connectors/search.go
+++ b/quesma/frontend_connectors/search.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/search_ab_testing.go
+++ b/quesma/frontend_connectors/search_ab_testing.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/search_common_table_test.go
+++ b/quesma/frontend_connectors/search_common_table_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"fmt"

--- a/quesma/frontend_connectors/search_norace_test.go
+++ b/quesma/frontend_connectors/search_norace_test.go
@@ -6,7 +6,7 @@
   This file contains  tests which can raise a race condition.
 */
 
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/search_opensearch_test.go
+++ b/quesma/frontend_connectors/search_opensearch_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/search_test.go
+++ b/quesma/frontend_connectors/search_test.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"context"

--- a/quesma/frontend_connectors/transformations.go
+++ b/quesma/frontend_connectors/transformations.go
@@ -1,6 +1,6 @@
 // Copyright Quesma, licensed under the Elastic License 2.0.
 // SPDX-License-Identifier: Elastic-2.0
-package quesma
+package frontend_connectors
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/model"

--- a/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
+++ b/quesma/processors/es_to_ch_ingest/elasticsearch_to_clickhouse_ingest_processor.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/QuesmaOrg/quesma/quesma/processors"
 	"github.com/QuesmaOrg/quesma/quesma/processors/es_to_ch_common"
-	quesm "github.com/QuesmaOrg/quesma/quesma/quesma"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/config"
 	"github.com/QuesmaOrg/quesma/quesma/quesma/types"
 	"github.com/QuesmaOrg/quesma/quesma/schema"
@@ -109,7 +108,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) Handle(metadata map[string]in
 			if err != nil {
 				return metadata, nil, err
 			}
-			res, err := quesm.HandleIndexDoc(ctx, indexPatterFromRequestUri, payloadJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
+			res, err := frontend_connectors.HandleIndexDoc(ctx, indexPatterFromRequestUri, payloadJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
 			if err != nil {
 				return metadata, nil, err
 			}
@@ -126,7 +125,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) Handle(metadata map[string]in
 			if err != nil {
 				return metadata, nil, err
 			}
-			res, err := quesm.HandleBulkIndex(ctx, indexPatterFromRequestUri, payloadNDJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
+			res, err := frontend_connectors.HandleBulkIndex(ctx, indexPatterFromRequestUri, payloadNDJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
 			if err != nil {
 				return metadata, nil, err
 			}
@@ -137,7 +136,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) Handle(metadata map[string]in
 			if err != nil {
 				return metadata, nil, err
 			}
-			res, err := quesm.HandleBulk(ctx, payloadNDJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
+			res, err := frontend_connectors.HandleBulk(ctx, payloadNDJson, p.legacyIngestProcessor, ingestStats, esConn, p.legacyDependencies, p.legacyIngestProcessor.GetTableResolver())
 			if err != nil {
 				return metadata, nil, err
 			}
@@ -147,7 +146,7 @@ func (p *ElasticsearchToClickHouseIngestProcessor) Handle(metadata map[string]in
 			if err != nil {
 				return metadata, nil, err
 			}
-			res, err := quesm.HandlePutIndex(indexPatterFromRequestUri, payloadJson, p.GetSchemaRegistry())
+			res, err := frontend_connectors.HandlePutIndex(indexPatterFromRequestUri, payloadJson, p.GetSchemaRegistry())
 			if err != nil {
 				return metadata, nil, err
 			}


### PR DESCRIPTION
This PR is about splitting and finally removing the `quesma\quesma\quesma` package and moving the relevant parts to `frontend_connectors`. It is an intermediate step forward. The plan is to further split `frontend_connectors` into smaller, self-contained packages.