### PR TITLE
Ingest - column name mangling fix

### DIFF
--- a/quesma/ingest/dots_test.go
+++ b/quesma/ingest/dots_test.go
@@ -4,6 +4,7 @@ package ingest
 
 import (
 	"github.com/QuesmaOrg/quesma/quesma/types"
+	"github.com/QuesmaOrg/quesma/quesma/util"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
@@ -17,19 +18,44 @@ func Test_removeDotsFromJsons(t *testing.T) {
 		return strings.ReplaceAll(field, ".", "::")
 	}
 
-	assert.True(t, transformFieldName(hostNameJson, fieldTransform))
+	assert.True(t, transformFieldName(hostNameJson, fieldTransform, fieldTransform))
 	newBytes, _ := hostNameJson.Bytes()
 	assert.Equal(t, `{"host::name":"alpha"}`, string(newBytes))
 
 	nestedStr := `{"cloud": {"host.name":"alpha"}}`
 	nestedJson, _ := types.ParseJSON(nestedStr)
-	assert.True(t, transformFieldName(nestedJson, fieldTransform))
+	assert.True(t, transformFieldName(nestedJson, fieldTransform, fieldTransform))
 	newNested, _ := nestedJson.Bytes()
 	assert.Equal(t, `{"cloud":{"host::name":"alpha"}}`, string(newNested))
 
 	noChange := `{"host_name": "alpha"}`
 	noChangeJson, _ := types.ParseJSON(noChange)
-	assert.False(t, transformFieldName(noChangeJson, fieldTransform))
+	assert.False(t, transformFieldName(noChangeJson, fieldTransform, fieldTransform))
 	newNoChange, _ := noChangeJson.Bytes()
 	assert.Equal(t, `{"host_name":"alpha"}`, string(newNoChange))
+}
+
+func Test_removeDotsFromJsonsDigits(t *testing.T) {
+
+	// test if we prefix the root level key with an underscore
+
+	hostNameStr := `{"9": "2", "host.name": "alpha", "foo": {"10": "1"}}`
+
+	jsonValue, err := types.ParseJSON(hostNameStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := transformFieldName(jsonValue, util.FieldToColumnEncoder, util.FieldPartToColumnEncoder)
+
+	assert.True(t, res)
+
+	foo, ok := jsonValue["foo"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.NotNil(t, foo)
+
+	assert.Equal(t, "2", jsonValue["_9"])
+	assert.Equal(t, "1", foo["10"])
+	assert.Equal(t, "alpha", jsonValue["host_name"])
+
 }

--- a/quesma/ingest/processor.go
+++ b/quesma/ingest/processor.go
@@ -621,12 +621,11 @@ func (ip *IngestProcessor) processInsertQuery(ctx context.Context,
 	if ip.schemaRegistry != nil {
 		ip.schemaRegistry.UpdateFieldEncodings(encodings)
 	}
+
 	// Do field encoding here, once for all jsons
 	// This is in-place operation
 	for _, jsonValue := range jsonData {
-		transformFieldName(jsonValue, func(field string) string {
-			return util.FieldToColumnEncoder(field)
-		})
+		transformFieldName(jsonValue, util.FieldToColumnEncoder, util.FieldPartToColumnEncoder)
 	}
 
 	var transformedJsons []types.JSON

--- a/quesma/util/utils.go
+++ b/quesma/util/utils.go
@@ -899,14 +899,8 @@ func replaceNonAlphabetic(str string) string {
 	return string(chars)
 }
 
-// FieldToColumnEncoder takes input field name
-// and converts it using algorithm defined in
-// https://github.com/QuesmaOrg/quesma/blob/main/adr/5_nested_fields_representation.md
-// all lower case
-// all non-alphanumeric are translated to ‘_’ (e.g. “host-name”, “host.name”, “host name” will be “host_name”)
-// if starts with digit, then add ‘_’ at beginning
-// Save mapping to persitent logic, on-collision do override.
-func FieldToColumnEncoder(field string) string {
+func FieldPartToColumnEncoder(field string) string {
+
 	if len(field) == 0 {
 		return field
 	}
@@ -916,6 +910,19 @@ func FieldToColumnEncoder(field string) string {
 	}
 	newField := strings.ToLower(field)
 	newField = replaceNonAlphabetic(newField)
+	return newField
+}
+
+// FieldToColumnEncoder takes input field name
+// and converts it using algorithm defined in
+// https://github.com/QuesmaOrg/quesma/blob/main/adr/5_nested_fields_representation.md
+// all lower case
+// all non-alphanumeric are translated to ‘_’ (e.g. “host-name”, “host.name”, “host name” will be “host_name”)
+// if starts with digit, then add ‘_’ at beginning
+// Save mapping to persitent logic, on-collision do override.
+func FieldToColumnEncoder(field string) string {
+	newField := FieldPartToColumnEncoder(field)
+
 	if isDigit(newField[0]) {
 		newField = "_" + newField
 	}


### PR DESCRIPTION
This PR solves a bug. When we have documents like 
```
{"foo": {"10": "1"}}
```
Our column mangling mechanism gives two results, `foo__10` and `foo_10`,  depending on the situation (flatten JSON/unprocessed JSON). This is caused by how we process JSONs which is documented in the `processInsertQuery` function. 
