### PR TITLE
Small tweaks to NOTICE.MD generator

### DIFF
--- a/.github/notice-generator/collect-go-dependencies.sh
+++ b/.github/notice-generator/collect-go-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-for gomod in **/go.mod ; do
+find . -type f -name go.mod | while read -r gomod; do
   pushd "$(dirname "$gomod")" 1>&2
   echo "Processing $gomod" 1>&2
 

--- a/.github/notice-generator/collect-manual-notices.sh
+++ b/.github/notice-generator/collect-manual-notices.sh
@@ -4,9 +4,9 @@
 # (for example if we use code from a project, but that project isn't
 # a Go dependency of our project)
 
-for notice in **/NOTICE.MD ; do
-  if [ -f "$notice" ]; then
-    echo "" # newline between added notices
-    cat "$notice"
-  fi
+find */ -type f -iname NOTICE.MD | while read -r notice; do
+  echo "$notice" 1>&2
+
+  echo "" # newline between added notices
+  cat "$notice"
 done

--- a/.github/notice-generator/go-licence-detector/overrides.ndjson
+++ b/.github/notice-generator/go-licence-detector/overrides.ndjson
@@ -1,3 +1,6 @@
 {"name": "github.com/pascaldekloe/goe", "licenceType": "Public Domain"}
 {"name": "github.com/pascaldekloe/name", "licenceType": "Public Domain"}
 {"name": "github.com/mrjones/oauth", "licenceFile": "MIT-LICENSE.txt"}
+{"name": "github.com/xeipuuv/gojsonpointer", "licenceFile": "LICENSE-APACHE-2.0.txt"}
+{"name": "github.com/xeipuuv/gojsonreference", "licenceFile": "LICENSE-APACHE-2.0.txt"}
+{"name": "github.com/xeipuuv/gojsonschema", "licenceFile": "LICENSE-APACHE-2.0.txt"}

--- a/.github/workflows/generate-notice.yml
+++ b/.github/workflows/generate-notice.yml
@@ -31,6 +31,7 @@ jobs:
         run: go install go.elastic.co/go-licence-detector@v0.7.0
 
       - name: Generate NOTICE.MD
+        shell: bash # to get 'set -o pipefail'
         run: |
           rm NOTICE.MD
           .github/notice-generator/collect-go-dependencies.sh | sort | uniq | go-licence-detector -includeIndirect -noticeTemplate=.github/notice-generator/go-licence-detector/NOTICE.MD.tmpl -noticeOut=NOTICE.MD -overrides=.github/notice-generator/go-licence-detector/overrides.ndjson -rules=.github/notice-generator/go-licence-detector/rules.json
@@ -41,6 +42,7 @@ jobs:
 
       - name: Check if NOTICE.MD changed
         id: notice-file-changed
+        shell: bash # to get 'set -o pipefail'
         run: |
           git fetch origin
           if git ls-tree --name-only origin/main | grep -q '^NOTICE.MD$'; then


### PR DESCRIPTION
1. When `collect-go-dependencies.sh` failed, the "Generate NOTICE.MD" GitHub Actions step didn't fail, because `pipefail` mode wasn't turned on. `shell: bash` fixes that and the step will now correctly fail in such case.

2. `collect-go-dependencies.sh` and `collect-manual-notices.sh` now look for go.mod and NOTICE.MD files recursively (`**` by default doesn't). This catches more things that should be included in `NOTICE.MD`.