### PR TITLE
Add tests of lexer dialects (sqlparse, sqlfluff)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
 
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "platform/parsers/sql/testdata"]
+	path = platform/parsers/sql/testdata
+	url = https://github.com/avelanarius/quesma-testdata-wip.git

--- a/platform/parsers/sql/lexer/testutils/testdata_loader.go
+++ b/platform/parsers/sql/lexer/testutils/testdata_loader.go
@@ -1,0 +1,65 @@
+// Copyright Quesma, licensed under the Elastic License 2.0.
+// SPDX-License-Identifier: Elastic-2.0
+
+package testutils
+
+import (
+	"bytes"
+	"os"
+)
+
+type ParsedTestcase struct {
+	Query          string
+	ExpectedTokens []ExpectedToken
+}
+
+type ExpectedToken struct {
+	TokenType  string
+	TokenValue string
+}
+
+// Loads a list of test queries and their expected tokens (extracted from existing parsers).
+// The structure of the file is as follows:
+//
+//	[QUERY1]
+//	<end_of_query/>
+//	[TOKEN_TYPE_1]
+//	[TOKEN_VALUE_1]
+//	<end_of_token/>
+//	[TOKEN_TYPE_2]
+//	[TOKEN_VALUE_2]
+//	<end_of_token/>
+//	...
+//	<end_of_tokens/>
+//	[QUERY2]
+//	...
+func LoadParsedTestcases(filename string) []ParsedTestcase {
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	testcases := bytes.Split(contents, []byte("\n<end_of_tokens/>\n"))
+	testcases = testcases[:len(testcases)-1]
+
+	var parsedTestcases []ParsedTestcase
+	for _, testcase := range testcases {
+		endOfQuerySplit := bytes.Split(testcase, []byte("\n<end_of_query/>\n"))
+
+		query := string(endOfQuerySplit[0])
+
+		tokens := bytes.Split(endOfQuerySplit[1], []byte("\n<end_of_token/>\n"))
+		tokens = tokens[:len(tokens)-1]
+
+		var expectedTokens []ExpectedToken
+		for _, tokenDescription := range tokens {
+			tokenDescriptionSplit := bytes.SplitN(tokenDescription, []byte("\n"), 2)
+			tokenType := string(tokenDescriptionSplit[0])
+			tokenValue := string(tokenDescriptionSplit[1])
+			expectedTokens = append(expectedTokens, ExpectedToken{tokenType, tokenValue})
+		}
+
+		parsedTestcases = append(parsedTestcases, ParsedTestcase{query, expectedTokens})
+	}
+	return parsedTestcases
+}


### PR DESCRIPTION
This PR adds tests of our ports of dialects from sqlparse and sqlfluff.

The test files are extracted SQL queries from the tests of sqlparse and sqlfluff. The expected outputs (tokens) are collected by running the queries through the original lexers of sqlparse and sqlfluff.

By doing this, we get a really good test coverage (>10k SQL queries, many edge case/"strange"/"tricky" SQL queries collected) and we can be almost certain that our implementation behaves identically to the original sqlparse/sqlfluff implementations.

The test files are stored in a separate repo (added to Quesma as a Git submodule), because they are large (~10MB).