### PR TITLE
[`sample_ecommerce`] Fix group by SQL for arrays

### DIFF
--- a/platform/frontend_connectors/schema_array_transformer.go
+++ b/platform/frontend_connectors/schema_array_transformer.go
@@ -222,7 +222,7 @@ func NewArrayJoinVisitor(resolver arrayTypeResolver) model.ExprVisitor {
 	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
 		dbType := resolver.dbColumnType(e.ColumnName)
 		if strings.HasPrefix(dbType, "Array") {
-			return model.NewFunction("arrayJoin", e)
+			return model.NewFunction("arrayJoin", model.NewFunction("arrayDistinct", e))
 		}
 		return e
 	}


### PR DESCRIPTION
Before (Quesma):
<img width="866" alt="Screenshot 2025-03-02 at 16 25 24" src="https://github.com/user-attachments/assets/8352794b-e645-496b-9ad2-ca0255bdedd1" />
After, we give the same results as Elastic:
<img width="850" alt="Screenshot 2025-03-02 at 16 25 39" src="https://github.com/user-attachments/assets/4551e55a-ffbc-401a-9892-0e6824131391" />
