### PR TITLE
[Grafana] Allow adding more than 1000 empty buckets

### DIFF
--- a/platform/model/bucket_aggregations/date_histogram.go
+++ b/platform/model/bucket_aggregations/date_histogram.go
@@ -26,7 +26,7 @@ const (
 	// with date_histogram's map (it already has a "valid", processed key, after TranslateSqlResponseToJson)
 	OriginalKeyName      = "__quesma_originalKey"
 	NoExtendedBound      = int64(-1) // -1 and not e.g. 0, as 0 is a valid value
-	maxEmptyBucketsAdded = 1000
+	maxEmptyBucketsAdded = 100000
 )
 
 type DateHistogram struct {


### PR DESCRIPTION
I think Elastic has 65536 (2^16), so setting something similar.
After this second PR, all date_histograms start looking exactly the same as from Elastic:
<img width="1441" alt="Screenshot 2025-03-02 at 18 04 43" src="https://github.com/user-attachments/assets/3b174a93-66e6-410e-b0d1-c39ae19daf71" />

