### PR TITLE
Log failed ingest statements

### DIFF
--- a/platform/ingest/processor.go
+++ b/platform/ingest/processor.go
@@ -878,7 +878,8 @@ func (ip *IngestProcessor) executeStatements(ctx context.Context, queries []stri
 
 		err := ip.execute(ctx, q)
 		if err != nil {
-			logger.ErrorWithCtx(ctx).Msgf("error executing query: %v", err)
+			logger.DebugWithCtx(ctx).Msgf("error=[%v] while executing statement=[%s]", err, q)
+			logger.ErrorWithCtx(ctx).Msgf("error executing statement: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
1. Let's log full statement which failed, sometimes it's hard to decipher what went wrong just by looking at the error
2. It's not `query`, this part of code handles ingest statements.