### PR TITLE
Fix E2E tests failing - fetch submodules

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:     ## @TODO REMOVE
           ref: ${{ github.event.inputs.GIT_REF }}
+          submodules: 'true'
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
After #1313 was merged, we now have a Git submodule for testdata (for lexer). I forgot to update `e2e-test.yml` GitHub Actions workflow to also fetch submodules (other workflows were updated and work correctly).