### PR TITLE
Fix old E2E test run

### DIFF
--- a/ci/e2e.yml
+++ b/ci/e2e.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   quesma:
-    build: ../cmd
+    build: ../
     image: quesma:nightly
     environment:
       - QUESMA_CONFIG_FILE=/mnt/ci-config.yaml


### PR DESCRIPTION
It is not able to find `Dockerfile` after recent changes: https://github.com/QuesmaOrg/quesma/actions/runs/13675543327/job/38235238910