### PR TITLE
`Match_phrase` accept ints as strings

### DIFF
--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -1067,7 +1067,7 @@ func (s *SchemaCheckPass) applyMatchOperator(indexSchema schema.Schema, query *m
 			rhsValue = strings.TrimSuffix(rhsValue, "'")
 
 			switch field.Type.String() {
-			case schema.QuesmaTypeInteger.Name, schema.QuesmaTypeLong.Name, schema.QuesmaTypeUnsignedLong.Name, schema.QuesmaTypeBoolean.Name:
+			case schema.QuesmaTypeInteger.Name, schema.QuesmaTypeLong.Name, schema.QuesmaTypeUnsignedLong.Name, schema.QuesmaTypeFloat.Name, schema.QuesmaTypeBoolean.Name:
 				return model.NewInfixExpr(lhs, "=", model.NewLiteral(rhsValue))
 			default:
 				return model.NewInfixExpr(lhs, "iLIKE", model.NewLiteralWithEscapeType(rhsValue, model.NotEscapedLikeFull))

--- a/platform/parsers/elastic_query_dsl/query_parser.go
+++ b/platform/parsers/elastic_query_dsl/query_parser.go
@@ -586,8 +586,7 @@ func (cw *ClickhouseQueryTranslator) parseMatch(queryMap QueryMap, matchPhrase b
 			return model.NewSimpleQuery(model.Or(statements), true)
 		}
 
-		// so far we assume that only strings can be ORed here
-		statement := model.NewInfixExpr(model.NewColumnRef(fieldName), "==", model.NewLiteral(sprint(vUnNested)))
+		statement := model.NewInfixExpr(model.NewColumnRef(fieldName), model.MatchOperator, model.NewLiteral(sprint(vUnNested)))
 		return model.NewSimpleQuery(statement, true)
 	}
 

--- a/platform/testdata/aggregation_requests.go
+++ b/platform/testdata/aggregation_requests.go
@@ -309,8 +309,8 @@ var AggregationTests = []AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "OriginCityName" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
-			  countIf("FlightDelay"==true) AS "metric__0__1-bucket_col_0",
-			  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0"
+			  countIf(("FlightDelay" __quesma_match true)) AS "metric__0__1-bucket_col_0",
+			  countIf(("Cancelled" __quesma_match true)) AS "metric__0__3-bucket_col_0"
 			FROM ` + TableName + `
 			WHERE ("timestamp">=fromUnixTimestamp64Milli(1706881636029) AND "timestamp"<=fromUnixTimestamp64Milli(1707486436029))
 			GROUP BY "OriginCityName" AS "aggr__0__key_0"
@@ -861,7 +861,7 @@ var AggregationTests = []AggregationTestCase{
 			}},
 		},
 		ExpectedPancakeSQL: `
-			SELECT countIf("FlightDelay"==true) AS "metric__0-bucket_col_0"
+			SELECT countIf(("FlightDelay" __quesma_match true)) AS "metric__0-bucket_col_0"
 			FROM ` + TableName + `
 			 WHERE ("timestamp">=fromUnixTimestamp64Milli(1706881636029) AND "timestamp"<=fromUnixTimestamp64Milli(1707486436029))`,
 	},
@@ -1024,7 +1024,7 @@ var AggregationTests = []AggregationTestCase{
 			  <=fromUnixTimestamp64Milli(1706881636029))) AS
 			  "filter_1__aggr__time_offset_split__count"
 			FROM __quesma_table_name
-			WHERE ("FlightDelay"==true AND (("timestamp">=fromUnixTimestamp64Milli(
+			WHERE (("FlightDelay" __quesma_match true) AND (("timestamp">=fromUnixTimestamp64Milli(
 			  1706881636029) AND "timestamp"<=fromUnixTimestamp64Milli(1707486436029)) OR (
 			  "timestamp">=fromUnixTimestamp64Milli(1706276836029) AND "timestamp"<=
 			  fromUnixTimestamp64Milli(1706881636029))))`,
@@ -1618,7 +1618,7 @@ var AggregationTests = []AggregationTestCase{
 			SELECT "FlightDelayMin" AS "aggr__0__key_0", count(*) AS "aggr__0__count"
 			FROM ` + TableName + `
 			WHERE (("timestamp">=fromUnixTimestamp64Milli(1706881636029) AND "timestamp"<=
-              fromUnixTimestamp64Milli(1707486436029)) AND NOT ("FlightDelayMin"==0))
+              fromUnixTimestamp64Milli(1707486436029)) AND NOT (("FlightDelayMin" __quesma_match 0)))
 			GROUP BY "FlightDelayMin" AS "aggr__0__key_0"
 			ORDER BY "aggr__0__key_0" ASC`,
 	},
@@ -5336,8 +5336,8 @@ var AggregationTests = []AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "OriginCityName" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
-			    countIf("FlightDelay"==true) AS "metric__0__1-bucket_col_0",
-  				countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0"
+			    countIf(("FlightDelay" __quesma_match true)) AS "metric__0__1-bucket_col_0",
+  				countIf(("Cancelled" __quesma_match true)) AS "metric__0__3-bucket_col_0"
 			FROM ` + TableName + `
 			GROUP BY "OriginCityName" AS "aggr__0__key_0"
 			ORDER BY "aggr__0__key_0" ASC

--- a/platform/testdata/kibana_sample_data_flights.go
+++ b/platform/testdata/kibana_sample_data_flights.go
@@ -222,7 +222,7 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 			  minOrNull("FlightDelayMin") AS "metric__minAgg_col_0"
 			FROM __quesma_table_name
 			WHERE (("timestamp">=fromUnixTimestamp64Milli(1740230608853) AND "timestamp"<=
-			  fromUnixTimestamp64Milli(1740835408853)) AND NOT ("FlightDelayMin"==0))`,
+			  fromUnixTimestamp64Milli(1740835408853)) AND NOT (("FlightDelayMin" __quesma_match 0)))`,
 	},
 	{ // [2]
 		TestName: "Delays & Cancellations (request 1/2)",
@@ -1051,8 +1051,9 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 				model.NewQueryResultCol("metric__0-bucket_col_0", int64(532)),
 			}},
 		},
+		// TODO Sprawdz boola
 		ExpectedPancakeSQL: `
-			SELECT countIf("FlightDelay"==true) AS "metric__0-bucket_col_0"
+			SELECT countIf(("FlightDelay" __quesma_match true)) AS "metric__0-bucket_col_0"
 			FROM __quesma_table_name
 			WHERE ("timestamp">=fromUnixTimestamp64Milli(1740230608853) AND "timestamp"<=
 			  fromUnixTimestamp64Milli(1740835408853))`,
@@ -1166,7 +1167,7 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 			}},
 		},
 		ExpectedPancakeSQL: `
-			SELECT countIf("Cancelled"==true) AS "metric__0-bucket_col_0"
+			SELECT countIf(("Cancelled" __quesma_match true)) AS "metric__0-bucket_col_0"
 			FROM __quesma_table_name
 			WHERE ("timestamp">=fromUnixTimestamp64Milli(1740230608853) AND "timestamp"<=
 			  fromUnixTimestamp64Milli(1740835408853))`,
@@ -1330,7 +1331,7 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 			  <=fromUnixTimestamp64Milli(1740230608853))) AS
 			  "filter_1__aggr__time_offset_split__count"
 			FROM __quesma_table_name
-			WHERE ("Cancelled"==true AND (("timestamp">=fromUnixTimestamp64Milli(
+			WHERE (("Cancelled" __quesma_match true) AND (("timestamp">=fromUnixTimestamp64Milli(
 			  1740230608853) AND "timestamp"<=fromUnixTimestamp64Milli(1740835408853)) OR (
 			  "timestamp">=fromUnixTimestamp64Milli(1739625808853) AND "timestamp"<=
 			  fromUnixTimestamp64Milli(1740230608853))))`,
@@ -1842,8 +1843,8 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 		ExpectedPancakeSQL: `
 			SELECT sum(count(*)) OVER () AS "aggr__0__parent_count",
 			  "OriginCityName" AS "aggr__0__key_0", count(*) AS "aggr__0__count",
-			  countIf("FlightDelay"==true) AS "metric__0__1-bucket_col_0",
-			  countIf("Cancelled"==true) AS "metric__0__3-bucket_col_0"
+			  countIf(("FlightDelay" __quesma_match true)) AS "metric__0__1-bucket_col_0",
+			  countIf(("Cancelled" __quesma_match true)) AS "metric__0__3-bucket_col_0"
 			FROM __quesma_table_name
 			WHERE ("timestamp">=fromUnixTimestamp64Milli(1740230608853) AND "timestamp"<=
 			  fromUnixTimestamp64Milli(1740835408853))
@@ -2638,7 +2639,7 @@ var KibanaSampleDataFlights = []AggregationTestCase{
 			SELECT "FlightDelayMin" AS "aggr__0__key_0", count(*) AS "aggr__0__count"
 			FROM __quesma_table_name
 			WHERE (("timestamp">=fromUnixTimestamp64Milli(1740230608853) AND "timestamp"<=
-			  fromUnixTimestamp64Milli(1740835408853)) AND NOT ("FlightDelayMin"==0))
+			  fromUnixTimestamp64Milli(1740835408853)) AND NOT (("FlightDelayMin" __quesma_match 0)))
 			GROUP BY "FlightDelayMin" AS "aggr__0__key_0"
 			ORDER BY "aggr__0__key_0" ASC`,
 	},


### PR DESCRIPTION
I need to fix `(( ))` instead of `( )`, but let me do that in another PR. Without it, this PR is very simple and almost certain to be correct.