### PR TITLE
Nested type resolution fixes for `table_discovery.go`

### DIFF
--- a/platform/clickhouse/table_discovery.go
+++ b/platform/clickhouse/table_discovery.go
@@ -472,6 +472,20 @@ func resolveColumn(colName, colType string) *Column {
 			isNullable = true
 			arrayType = strings.TrimSuffix(strings.TrimPrefix(arrayType, "Nullable("), ")")
 		}
+		if isArrayType(arrayType) {
+			innerColumn := resolveColumn("inner", arrayType)
+			if innerColumn == nil {
+				logger.Warn().Msgf("invalid inner array type for column %s, %s", colName, colType)
+				return nil
+			}
+			return &Column{
+				Name: colName,
+				Type: CompoundType{
+					Name:     "Array",
+					BaseType: innerColumn.Type,
+				},
+			}
+		}
 		GoType := ResolveType(arrayType)
 		if GoType != nil {
 			return &Column{

--- a/platform/clickhouse/table_discovery_test.go
+++ b/platform/clickhouse/table_discovery_test.go
@@ -262,6 +262,39 @@ func Test_resolveColumn_Nullable(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Array(Array(Tuple(...)))",
+			args: args{colName: "nested_array_tuple", colType: "Array(Array(Tuple(group_a Tuple(field_a Nullable(Int64), field_b Nullable(Int64), field_c Nullable(Int64), field_d Nullable(Int64)), group_b Tuple(field_x Nullable(String)))))"},
+			want: &Column{
+				Name: "nested_array_tuple",
+				Type: CompoundType{
+					Name: "Array",
+					BaseType: CompoundType{
+						Name: "Array",
+						BaseType: MultiValueType{
+							Name: "Tuple",
+							Cols: []*Column{
+								{Name: "group_a", Type: MultiValueType{
+									Name: "Tuple",
+									Cols: []*Column{
+										{Name: "field_a", Type: BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0)), Nullable: true}},
+										{Name: "field_b", Type: BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0)), Nullable: true}},
+										{Name: "field_c", Type: BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0)), Nullable: true}},
+										{Name: "field_d", Type: BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0)), Nullable: true}},
+									},
+								}},
+								{Name: "group_b", Type: MultiValueType{
+									Name: "Tuple",
+									Cols: []*Column{
+										{Name: "field_x", Type: BaseType{Name: "String", GoType: reflect.TypeOf(""), Nullable: true}},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/platform/clickhouse/table_discovery_test.go
+++ b/platform/clickhouse/table_discovery_test.go
@@ -242,6 +242,26 @@ func Test_resolveColumn_Nullable(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Array(Array(Array(Array(String))))",
+			args: args{colName: "deeply_nested_array", colType: "Array(Array(Array(Array(String))))"},
+			want: &Column{
+				Name: "deeply_nested_array",
+				Type: CompoundType{
+					Name: "Array",
+					BaseType: CompoundType{
+						Name: "Array",
+						BaseType: CompoundType{
+							Name: "Array",
+							BaseType: CompoundType{
+								Name:     "Array",
+								BaseType: BaseType{Name: "String", GoType: reflect.TypeOf("")},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/platform/clickhouse/table_discovery_test.go
+++ b/platform/clickhouse/table_discovery_test.go
@@ -228,6 +228,20 @@ func Test_resolveColumn_Nullable(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Array(Array(Int64))",
+			args: args{colName: "array_of_arrays", colType: "Array(Array(Int64))"},
+			want: &Column{
+				Name: "array_of_arrays",
+				Type: CompoundType{
+					Name: "Array",
+					BaseType: CompoundType{
+						Name:     "Array",
+						BaseType: BaseType{Name: "Int64", GoType: reflect.TypeOf(int64(0))},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It turned out that we can't handle double-nested arrays in ClickHouse, which caused tables not being visible in Quesma during table discovery.