### PR TITLE
Dynamic objects fieldcaps fixes #1

### DIFF
--- a/platform/elasticsearch/mappings.go
+++ b/platform/elasticsearch/mappings.go
@@ -81,6 +81,8 @@ func ParseElasticType(t string) (schema.QuesmaType, bool) {
 		return schema.QuesmaTypeIp, true
 	case elasticsearch_field_types.FieldTypeGeoPoint:
 		return schema.QuesmaTypePoint, true
+	case elasticsearch_field_types.FieldTypeObject:
+		return schema.QuesmaTypeObject, true
 	default:
 		return schema.QuesmaTypeUnknown, false
 	}

--- a/platform/elasticsearch/mappings.go
+++ b/platform/elasticsearch/mappings.go
@@ -114,6 +114,8 @@ func schemaTypeToElasticType(t schema.QuesmaType) string {
 		return elasticsearch_field_types.FieldTypeIp
 	case schema.QuesmaTypePoint.Name:
 		return elasticsearch_field_types.FieldTypeGeoPoint
+	case schema.QuesmaTypeMap.Name:
+		return elasticsearch_field_types.FieldTypeObject
 	default:
 		logger.Error().Msgf("Unknown Quesma type '%s', defaulting to 'text' type", t.Name)
 		return elasticsearch_field_types.FieldTypeText

--- a/platform/frontend_connectors/route_handlers.go
+++ b/platform/frontend_connectors/route_handlers.go
@@ -126,9 +126,7 @@ func HandleFieldCaps(ctx context.Context, indexPattern string, allowNoIndices, i
 			return nil, err
 		}
 	}
-
 	return elasticsearchQueryResult(string(responseBody), http.StatusOK), nil
-
 }
 
 func HandlePutIndex(index string, reqBody types.JSON, sr schema.Registry) (*quesma_api.Result, error) {

--- a/platform/frontend_connectors/route_handlers.go
+++ b/platform/frontend_connectors/route_handlers.go
@@ -126,7 +126,9 @@ func HandleFieldCaps(ctx context.Context, indexPattern string, allowNoIndices, i
 			return nil, err
 		}
 	}
+
 	return elasticsearchQueryResult(string(responseBody), http.StatusOK), nil
+
 }
 
 func HandlePutIndex(index string, reqBody types.JSON, sr schema.Registry) (*quesma_api.Result, error) {

--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -701,13 +701,7 @@ func (s *SchemaCheckPass) applyTimestampField(indexSchema schema.Schema, query *
 
 }
 
-func (s *SchemaCheckPass) applyFieldEncoding(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
-	table, ok := s.tableDiscovery.TableDefinitions().Load(query.TableName)
-	if !ok {
-		return nil, fmt.Errorf("table %s not found", query.TableName)
-	}
-	_, hasAttributesValuesColumn := table.Cols[clickhouse.AttributesValuesColumn]
-
+func (s *SchemaCheckPass) applyFieldMapSyntax(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
 	visitor := model.NewBaseVisitor()
 
 	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
@@ -730,6 +724,32 @@ func (s *SchemaCheckPass) applyFieldEncoding(indexSchema schema.Schema, query *m
 				}
 			}
 		}
+		return e
+	}
+	expr := query.SelectCommand.Accept(visitor)
+
+	if _, ok := expr.(*model.SelectCommand); ok {
+		query.SelectCommand = *expr.(*model.SelectCommand)
+	}
+
+	return query, nil
+}
+
+func (s *SchemaCheckPass) applyFieldEncoding(indexSchema schema.Schema, query *model.Query) (*model.Query, error) {
+	table, ok := s.tableDiscovery.TableDefinitions().Load(query.TableName)
+	if !ok {
+		return nil, fmt.Errorf("table %s not found", query.TableName)
+	}
+	_, hasAttributesValuesColumn := table.Cols[clickhouse.AttributesValuesColumn]
+
+	visitor := model.NewBaseVisitor()
+
+	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
+
+		// we don't want to resolve our well know technical fields
+		if e.ColumnName == model.FullTextFieldNamePlaceHolder || e.ColumnName == common_table.IndexNameColumn {
+			return e
+		}
 
 		// This is workaround.
 		// Our query parse resolves columns sometimes. Here we detect it and skip the resolution.
@@ -742,9 +762,7 @@ func (s *SchemaCheckPass) applyFieldEncoding(indexSchema schema.Schema, query *m
 			return model.NewColumnRefWithTable(resolvedField.InternalPropertyName.AsString(), e.TableAlias)
 		} else {
 			// here we didn't find a column by field name,
-			// we try some other options
-
-			// 2. maybe we should use attributes
+			// maybe we should use attributes
 
 			if hasAttributesValuesColumn {
 				return model.NewArrayAccess(model.NewColumnRef(clickhouse.AttributesValuesColumn), model.NewLiteral(fmt.Sprintf("'%s'", e.ColumnName)))
@@ -991,6 +1009,7 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 		// because WildcardExpansion expands the wildcard to all fields
 		// and columns are expanded as PublicFieldName, so we need to encode them
 		// or in other words use internal field names
+		{TransformationName: "FieldMapSyntaxTransformation", Transformation: s.applyFieldMapSyntax},
 		{TransformationName: "FieldEncodingTransformation", Transformation: s.applyFieldEncoding},
 		{TransformationName: "FullTextFieldTransformation", Transformation: s.applyFullTextField},
 		{TransformationName: "TimestampFieldTransformation", Transformation: s.applyTimestampField},

--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -525,6 +525,7 @@ func (s *SchemaCheckPass) applyWildcardExpansion(indexSchema schema.Schema, quer
 	var hasWildcard bool
 
 	for _, selectColumn := range query.SelectCommand.Columns {
+
 		if selectColumn == model.NewWildcardExpr {
 			hasWildcard = true
 		} else {
@@ -592,6 +593,7 @@ func (s *SchemaCheckPass) applyFullTextField(indexSchema schema.Schema, query *m
 
 	visitor.OverrideVisitColumnRef = func(b *model.BaseExprVisitor, e model.ColumnRef) interface{} {
 		// full text field should be used only in where clause
+
 		if e.ColumnName == model.FullTextFieldNamePlaceHolder {
 			err = fmt.Errorf("full text field name placeholder found in query")
 		}

--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -538,7 +538,7 @@ func (s *SchemaCheckPass) applyWildcardExpansion(indexSchema schema.Schema, quer
 		cols := make([]string, 0, len(indexSchema.Fields))
 		for _, col := range indexSchema.Fields {
 			// Take only fields that are ingested
-			if col.Origin == schema.FieldSourceIngest {
+			if col.Origin == schema.FieldSourceIngest || col.Origin == schema.FieldSourceMapping {
 				cols = append(cols, col.PropertyName.AsString())
 			}
 		}

--- a/platform/functionality/field_capabilities/field_caps.go
+++ b/platform/functionality/field_capabilities/field_caps.go
@@ -142,6 +142,8 @@ func asElasticType(t schema.QuesmaType) string {
 		return elasticsearch_field_types.FieldTypeGeoPoint
 	case schema.QuesmaTypeInteger.Name:
 		return elasticsearch_field_types.FieldTypeInteger
+	case schema.QuesmaTypeMap.Name:
+		return elasticsearch_field_types.FieldTypeObject
 	default:
 		return elasticsearch_field_types.FieldTypeText
 	}


### PR DESCRIPTION
This PR:
- fixes few problems with type handing in mappings and field_caps
- extracts `applyFieldMapSyntax` as a separate transformation

This improves field caps experience via mapping
```
PUT foo
{
  "mappings": {
    "properties": {
      "@timestamp": {
          "type": "date"
      },
      "bar": {
        "properties": {
          "a": {
            "type": "text"
          },
          "c": {
            "type": "text"
          },
          "d": {
            "type": "text"
          }
        }
      }
    }
  }
}
```
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/05781032-8297-47a2-ba9a-253d7d5c61e7" />


<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' -->
