### PR TITLE
Support Kibana CSV export

### DIFF
--- a/platform/frontend_connectors/matchers.go
+++ b/platform/frontend_connectors/matchers.go
@@ -84,7 +84,7 @@ func matchPitId(getPitFn func(*quesma_api.Request) string) quesma_api.RequestMat
 	})
 }
 
-func hasQuesmaPitInPayload() quesma_api.RequestMatcher {
+func isSearchRequestWithQuesmaPit() quesma_api.RequestMatcher {
 	return matchPitId(func(req *quesma_api.Request) string {
 		return getPitIdFromRequest(req, false)
 	})

--- a/platform/frontend_connectors/matchers.go
+++ b/platform/frontend_connectors/matchers.go
@@ -28,11 +28,6 @@ func matchedAgainstPattern(indexRegistry table_resolver.TableResolver) quesma_ap
 func matchAgainstTableResolver(indexRegistry table_resolver.TableResolver, pipelineName string) quesma_api.RequestMatcher {
 	return quesma_api.RequestMatcherFunc(func(req *quesma_api.Request) quesma_api.MatchResult {
 		indexName := req.Params["index"]
-
-		if strings.HasPrefix(indexName, ".") { // Skip internal indices
-			return quesma_api.MatchResult{Matched: false}
-		}
-
 		decision := indexRegistry.Resolve(pipelineName, indexName)
 		if decision.Err != nil {
 			return quesma_api.MatchResult{Matched: false, Decision: decision}

--- a/platform/frontend_connectors/matchers.go
+++ b/platform/frontend_connectors/matchers.go
@@ -21,16 +21,17 @@ func matchedAgainstAsyncId() quesma_api.RequestMatcher {
 	})
 }
 
-// Query path only (looks at QueryTarget)
 func matchedAgainstPattern(indexRegistry table_resolver.TableResolver) quesma_api.RequestMatcher {
 	return matchAgainstTableResolver(indexRegistry, quesma_api.QueryPipeline)
 }
 
-// check whether exact index name is enabled
 func matchAgainstTableResolver(indexRegistry table_resolver.TableResolver, pipelineName string) quesma_api.RequestMatcher {
 	return quesma_api.RequestMatcherFunc(func(req *quesma_api.Request) quesma_api.MatchResult {
-
 		indexName := req.Params["index"]
+
+		if strings.HasPrefix(indexName, ".") { // Skip internal indices
+			return quesma_api.MatchResult{Matched: false}
+		}
 
 		decision := indexRegistry.Resolve(pipelineName, indexName)
 		if decision.Err != nil {
@@ -42,17 +43,6 @@ func matchAgainstTableResolver(indexRegistry table_resolver.TableResolver, pipel
 			}
 		}
 		return quesma_api.MatchResult{Matched: false, Decision: decision}
-	})
-}
-
-func isNotTargetingInternalIndex() quesma_api.RequestMatcher {
-	return quesma_api.RequestMatcherFunc(func(req *quesma_api.Request) quesma_api.MatchResult {
-		indexPattern := req.Params["indexPattern"]
-		if strings.HasPrefix(indexPattern, ".") {
-			return quesma_api.MatchResult{Matched: false}
-		} else {
-			return quesma_api.MatchResult{Matched: true}
-		}
 	})
 }
 

--- a/platform/frontend_connectors/router_v2.go
+++ b/platform/frontend_connectors/router_v2.go
@@ -133,8 +133,8 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, dependencies quesm
 		return HandleResolveIndex(ctx, req.Params["index"], sr, cfg.Elasticsearch)
 	})
 
-	router.Register(routes.IndexPatternPitPath, and(method("POST"), isNotTargetingInternalIndex(), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
-		indexPattern := req.Params["indexPattern"]
+	router.Register(routes.IndexPatternPitPath, and(method("POST"), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+		indexPattern := req.Params["index"]
 		logger.Debug().Msgf("Quesma-managed PIT request, targeting indexPattern=%s", indexPattern)
 		return HandlePitStore(indexPattern)
 	})

--- a/platform/frontend_connectors/router_v2.go
+++ b/platform/frontend_connectors/router_v2.go
@@ -133,14 +133,23 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, dependencies quesm
 		return HandleResolveIndex(ctx, req.Params["index"], sr, cfg.Elasticsearch)
 	})
 
+	router.Register(routes.IndexPatternPitPath, and(method("POST"), isNotTargetingInternalIndex(), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+		indexPattern := req.Params["indexPattern"]
+		logger.Debug().Msgf("Quesma-managed PIT request, targeting indexPattern=%s", indexPattern)
+		return HandlePitStore(indexPattern)
+	})
+
+	router.Register(routes.PitPath, and(method("DELETE"), hasQuesmaPitId()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+		return PitDeletedResponse()
+	})
+
 	router.Register(routes.IndexCountPath, and(method("GET"), matchedAgainstPattern(tableResolver)), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
 		return HandleIndexCount(ctx, req.Params["index"], queryRunner)
 	})
 
-	// TODO: This endpoint is currently disabled (mux.Never()) as it's pretty much used only by internal Kibana requests,
-	// it's error-prone to detect them in matchAgainstKibanaInternal() and Quesma can't handle well the cases of wildcard
-	// matching many indices either way.
-	router.Register(routes.GlobalSearchPath, and(quesma_api.Never(), method("GET", "POST"), matchAgainstKibanaInternal()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+	router.Register(routes.GlobalSearchPath, and(method("GET", "POST"), hasQuesmaPitInPayload()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+		pitId := getPitIdFromRequest(req, false)
+		indexPattern := strings.TrimPrefix(pitId, quesmaPitPrefix)
 
 		body, err := types.ExpectJSON(req.ParsedBody)
 		if err != nil {
@@ -148,7 +157,7 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, dependencies quesm
 		}
 
 		// TODO we should pass JSON here instead of []byte
-		responseBody, err := queryRunner.HandleSearch(ctx, "*", body)
+		responseBody, err := queryRunner.HandleSearch(ctx, indexPattern, body)
 		if err != nil {
 			if errors.Is(quesma_errors.ErrIndexNotExists(), err) {
 				return &quesma_api.Result{StatusCode: http.StatusNotFound, GenericResult: make([]byte, 0)}, nil

--- a/platform/frontend_connectors/router_v2.go
+++ b/platform/frontend_connectors/router_v2.go
@@ -147,7 +147,7 @@ func ConfigureSearchRouterV2(cfg *config.QuesmaConfiguration, dependencies quesm
 		return HandleIndexCount(ctx, req.Params["index"], queryRunner)
 	})
 
-	router.Register(routes.GlobalSearchPath, and(method("GET", "POST"), hasQuesmaPitInPayload()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
+	router.Register(routes.GlobalSearchPath, and(method("GET", "POST"), isSearchRequestWithQuesmaPit()), func(ctx context.Context, req *quesma_api.Request, _ http.ResponseWriter) (*quesma_api.Result, error) {
 		pitId := getPitIdFromRequest(req, false)
 		indexPattern := strings.TrimPrefix(pitId, quesmaPitPrefix)
 

--- a/platform/v2/core/routes/paths.go
+++ b/platform/v2/core/routes/paths.go
@@ -17,6 +17,8 @@ const (
 	IndexMappingPath          = "/:index/_mapping"
 	FieldCapsPath             = "/:index/_field_caps"
 	TermsEnumPath             = "/:index/_terms_enum"
+	IndexPatternPitPath       = "/:indexPattern/_pit"
+	PitPath                   = "/_pit"
 	EQLSearch                 = "/:index/_eql/search"
 	ResolveIndexPath          = "/_resolve/index/:index"
 	ClusterHealthPath         = "/_cluster/health"

--- a/platform/v2/core/routes/paths.go
+++ b/platform/v2/core/routes/paths.go
@@ -17,7 +17,7 @@ const (
 	IndexMappingPath          = "/:index/_mapping"
 	FieldCapsPath             = "/:index/_field_caps"
 	TermsEnumPath             = "/:index/_terms_enum"
-	IndexPatternPitPath       = "/:indexPattern/_pit"
+	IndexPatternPitPath       = "/:index/_pit"
 	PitPath                   = "/_pit"
 	EQLSearch                 = "/:index/_eql/search"
 	ResolveIndexPath          = "/_resolve/index/:index"


### PR DESCRIPTION
Adding a support for CSV export in Kibana.

<img width="1561" alt="image" src="https://github.com/user-attachments/assets/5e36becc-0161-4535-9c52-8f0536d32226" />


### Some technical details
Kibana CSV report generation uses two steps:
1. Create Point-In-Time  (`:indexPattern/_pit` API) for an index pattern
2. Fetch data via `/_search` API, referencing PIT ID created before

In our case, we're **not** creating any persistent PIT for ClickHouse table - we're simply using that PIT ID as a reference to specific index pattern. So the logic looks like the following:
1. Quesma controls `:indexPattern/_pit` endpoint.
  Whenever pit creation is issued and `:indexPattern` is under our control, instead of relaying request to Elasticsearch we respond that PIT has been created and it's ID is `quesma_:indexPattern`.
2. When a request to `/_search` comes to Quesma and it has PIT == `quesma_:indexPattern`, we simply execute query to a table which is matching `:indexPattern`

Having that, we have this feature implemented without the need of any persistent storage 🎉 

<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' -->
