### PR TITLE
Removing field caps map capabilities to be on par with elasticsearch

### DIFF
--- a/platform/functionality/field_capabilities/field_caps.go
+++ b/platform/functionality/field_capabilities/field_caps.go
@@ -73,10 +73,6 @@ func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegist
 				case "keyword", "text":
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.QuesmaTypeKeyword, resolvedIndex)
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
-				case "map":
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapKeysSuffix), schema.QuesmaTypeText, resolvedIndex)
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldMapValuesSuffix), schema.QuesmaTypeText, resolvedIndex)
 				}
 			}
 


### PR DESCRIPTION
Elasticsearch does not emit `.keys()` and `.values()` for maps. Definitely we should not emit `text` type as well. Below `bar` index is handled by elasticsearch.

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/b2480303-0a79-49f9-ae9f-2c6aa81f0afb" />



and `foo` index handled by `quesma` and `clickhouse` after fix.


<img width="1689" alt="image" src="https://github.com/user-attachments/assets/3e36a022-75a8-464e-a733-2be5be1b3336" />


<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' -->
