### PR TITLE
ElasticSearch schema consistency fixes, query fixes

### DIFF
--- a/platform/clickhouse/type_adapter.go
+++ b/platform/clickhouse/type_adapter.go
@@ -22,7 +22,9 @@ func (c SchemaTypeAdapter) Convert(s string) (schema.QuesmaType, bool) {
 	}
 
 	switch s {
-	case "String", "LowCardinality(String)", "UUID", "FixedString":
+	case "String":
+		return schema.QuesmaTypeText, true
+	case "LowCardinality(String)", "UUID", "FixedString":
 		return schema.QuesmaTypeKeyword, true
 	case "Int", "Int8", "Int16", "Int32", "Int64":
 		return schema.QuesmaTypeLong, true

--- a/platform/clickhouse/type_adapter.go
+++ b/platform/clickhouse/type_adapter.go
@@ -22,9 +22,7 @@ func (c SchemaTypeAdapter) Convert(s string) (schema.QuesmaType, bool) {
 	}
 
 	switch s {
-	case "String":
-		return schema.QuesmaTypeText, true
-	case "LowCardinality(String)", "UUID", "FixedString":
+	case "String", "LowCardinality(String)", "UUID", "FixedString":
 		return schema.QuesmaTypeKeyword, true
 	case "Int", "Int8", "Int16", "Int32", "Int64":
 		return schema.QuesmaTypeLong, true

--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -1003,6 +1003,7 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 		{TransformationName: "PhysicalFromExpressionTransformation", Transformation: s.applyPhysicalFromExpression},
 		{TransformationName: "WildcardExpansion", Transformation: s.applyWildcardExpansion},
 		{TransformationName: "RuntimeMappings", Transformation: s.applyRuntimeMappings},
+		{TransformationName: "FieldMapSyntaxTransformation", Transformation: s.applyFieldMapSyntax},
 		{TransformationName: "AliasColumnsTransformation", Transformation: s.applyAliasColumns},
 
 		// Section 2: generic schema based transformations
@@ -1011,7 +1012,6 @@ func (s *SchemaCheckPass) Transform(queries []*model.Query) ([]*model.Query, err
 		// because WildcardExpansion expands the wildcard to all fields
 		// and columns are expanded as PublicFieldName, so we need to encode them
 		// or in other words use internal field names
-		{TransformationName: "FieldMapSyntaxTransformation", Transformation: s.applyFieldMapSyntax},
 		{TransformationName: "FieldEncodingTransformation", Transformation: s.applyFieldEncoding},
 		{TransformationName: "FullTextFieldTransformation", Transformation: s.applyFullTextField},
 		{TransformationName: "TimestampFieldTransformation", Transformation: s.applyTimestampField},

--- a/platform/frontend_connectors/schema_transformer_test.go
+++ b/platform/frontend_connectors/schema_transformer_test.go
@@ -1076,7 +1076,7 @@ func TestFullTextFields(t *testing.T) {
 			var schemaColumns []schema.Column
 
 			for _, col := range columns {
-				schemaColumns = append(schemaColumns, schema.Column{Name: col, Type: "String"})
+				schemaColumns = append(schemaColumns, schema.Column{Name: col, Type: "LowCardinality(String)"})
 			}
 
 			columnMap := make(map[string]schema.Column)

--- a/platform/functionality/field_capabilities/field_caps.go
+++ b/platform/functionality/field_capabilities/field_caps.go
@@ -70,9 +70,8 @@ func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegist
 			for fieldName, field := range fieldsWithAliases {
 				addFieldCapabilityFromSchemaRegistry(fields, fieldName.AsString(), field.Type, resolvedIndex)
 				switch field.Type.Name {
-				case "keyword", "text":
+				case "text":
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.QuesmaTypeKeyword, resolvedIndex)
-					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
 				}
 			}
 

--- a/platform/functionality/field_capabilities/field_caps.go
+++ b/platform/functionality/field_capabilities/field_caps.go
@@ -70,8 +70,9 @@ func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegist
 			for fieldName, field := range fieldsWithAliases {
 				addFieldCapabilityFromSchemaRegistry(fields, fieldName.AsString(), field.Type, resolvedIndex)
 				switch field.Type.Name {
-				case "text":
+				case "keyword", "text":
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.QuesmaTypeKeyword, resolvedIndex)
+					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
 				}
 			}
 

--- a/platform/functionality/field_capabilities/field_caps_test.go
+++ b/platform/functionality/field_capabilities/field_caps_test.go
@@ -211,12 +211,12 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 			Tables: map[schema.IndexName]schema.Schema{
 				"logs-1": {
 					Fields: map[schema.FieldName]schema.Field{
-						"foo.bar1": {PropertyName: "foo.bar1", InternalPropertyName: "foo.bar1", Type: schema.QuesmaTypeKeyword},
+						"foo.bar1": {PropertyName: "foo.bar1", InternalPropertyName: "foo.bar1", Type: schema.QuesmaTypeText},
 					},
 				},
 				"logs-2": {
 					Fields: map[schema.FieldName]schema.Field{
-						"foo.bar2": {PropertyName: "foo.bar2", InternalPropertyName: "foo.bar2", Type: schema.QuesmaTypeKeyword},
+						"foo.bar2": {PropertyName: "foo.bar2", InternalPropertyName: "foo.bar2", Type: schema.QuesmaTypeText},
 					},
 				},
 			},
@@ -225,68 +225,61 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 	expectedResp, err := json.MarshalIndent([]byte(`{
   "fields": {
     "foo.bar1": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
+      "text": {
+        "aggregatable": false,
+        "indices": ["logs-1"],
         "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-1"]
+        "searchable": true,
+        "type": "text"
       }
     },
-	"foo.bar1.keyword": {
+    "foo.bar1.keyword": {
       "keyword": {
         "aggregatable": true,
-        "searchable": true,
+        "indices": ["logs-1"],
         "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-1"]
+        "searchable": true,
+        "type": "keyword"
       }
     },
     "foo.bar1.text": {
       "text": {
         "aggregatable": false,
-        "indices": [
-          "logs-1"
-        ],
+        "indices": ["logs-1"],
         "metadata_field": false,
         "searchable": true,
         "type": "text"
       }
     },
     "foo.bar2": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
+      "text": {
+        "aggregatable": false,
+        "indices": ["logs-2"],
         "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-2"]
+        "searchable": true,
+        "type": "text"
       }
     },
-	"foo.bar2.keyword": {
+    "foo.bar2.keyword": {
       "keyword": {
         "aggregatable": true,
-        "searchable": true,
+        "indices": ["logs-2"],
         "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-2"]
+        "searchable": true,
+        "type": "keyword"
       }
     },
     "foo.bar2.text": {
       "text": {
         "aggregatable": false,
-        "indices": [
-          "logs-2"
-        ],
+        "indices": ["logs-2"],
         "metadata_field": false,
         "searchable": true,
         "type": "text"
       }
     }
   },
-  "indices": [
-    "logs-1",
-	"logs-2"
-  ]
+  "indices": ["logs-1", "logs-2"]
 }
 `), "", "  ")
 	assert.NoError(t, err)

--- a/platform/schema/registry.go
+++ b/platform/schema/registry.go
@@ -296,13 +296,11 @@ func (s *schemaRegistry) populateAliases(indexConfiguration config.IndexConfigur
 }
 
 func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[string]Table, indexName string, fields map[FieldName]Field, internalToPublicFieldsEncodings map[EncodedFieldName]string) (existsInDataSource bool) {
-
 	tableDefinition, found := definitions[indexName]
 	if found {
 		logger.Debug().Msgf("loading schema for table %s", indexName)
 
 		for _, column := range tableDefinition.Columns {
-
 			var propertyName FieldName
 			if internalField, ok := internalToPublicFieldsEncodings[EncodedFieldName(column.Name)]; ok {
 				propertyName = FieldName(internalField)
@@ -331,7 +329,7 @@ func (s *schemaRegistry) populateSchemaFromTableDefinition(definitions map[strin
 					fields[propertyName] = Field{PropertyName: propertyName, InternalPropertyName: FieldName(column.Name), InternalPropertyType: column.Type, Type: quesmaType, Origin: column.Origin}
 				} else {
 					logger.Debug().Msgf("type %s not supported, falling back to keyword", column.Type)
-					fields[propertyName] = Field{PropertyName: propertyName, InternalPropertyName: FieldName(column.Name), InternalPropertyType: column.Type, Type: QuesmaTypeKeyword}
+					fields[propertyName] = Field{PropertyName: propertyName, InternalPropertyName: FieldName(column.Name), InternalPropertyType: column.Type, Type: QuesmaTypeKeyword, Origin: column.Origin}
 				}
 			} else {
 				fields[propertyName] = Field{PropertyName: propertyName, InternalPropertyName: FieldName(column.Name), InternalPropertyType: column.Type, Type: existing.Type, Origin: existing.Origin}

--- a/platform/schema/registry_test.go
+++ b/platform/schema/registry_test.go
@@ -46,7 +46,7 @@ func Test_schemaRegistry_FindSchema(t *testing.T) {
 			}},
 			tableName: "some_table",
 			want: schema.NewSchema(map[schema.FieldName]schema.Field{
-				"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeKeyword, InternalPropertyType: "String"},
+				"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeText, InternalPropertyType: "String"},
 				"event_date": {PropertyName: "event_date", InternalPropertyName: "event_date", Type: schema.QuesmaTypeTimestamp, InternalPropertyType: "DateTime64"},
 				"count":      {PropertyName: "count", InternalPropertyName: "count", Type: schema.QuesmaTypeLong, InternalPropertyType: "Int64"}},
 				true, ""),
@@ -308,7 +308,7 @@ func Test_schemaRegistry_UpdateDynamicConfiguration(t *testing.T) {
 	defer s.Stop()
 
 	expectedSchema := schema.NewSchema(map[schema.FieldName]schema.Field{
-		"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeKeyword, InternalPropertyType: "String"},
+		"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeText, InternalPropertyType: "String"},
 		"event_date": {PropertyName: "event_date", InternalPropertyName: "event_date", Type: schema.QuesmaTypeTimestamp, InternalPropertyType: "DateTime64"},
 		"count":      {PropertyName: "count", InternalPropertyName: "count", Type: schema.QuesmaTypeLong, InternalPropertyType: "Int64"}},
 		true, "")
@@ -328,7 +328,7 @@ func Test_schemaRegistry_UpdateDynamicConfiguration(t *testing.T) {
 	})
 
 	expectedSchema = schema.NewSchema(map[schema.FieldName]schema.Field{
-		"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeKeyword, InternalPropertyType: "String"},
+		"message":    {PropertyName: "message", InternalPropertyName: "message", Type: schema.QuesmaTypeText, InternalPropertyType: "String"},
 		"event_date": {PropertyName: "event_date", InternalPropertyName: "event_date", Type: schema.QuesmaTypeTimestamp, InternalPropertyType: "DateTime64"},
 		"count":      {PropertyName: "count", InternalPropertyName: "count", Type: schema.QuesmaTypeLong, InternalPropertyType: "Int64"},
 		"new_column": {PropertyName: "new_column", InternalPropertyName: "new_column", Type: schema.QuesmaTypeText, Origin: schema.FieldSourceMapping}},

--- a/platform/schema/types.go
+++ b/platform/schema/types.go
@@ -24,9 +24,9 @@ var (
 	QuesmaTypeDate         = QuesmaType{Name: "date", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
 	QuesmaTypeFloat        = QuesmaType{Name: "float", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
 	QuesmaTypeBoolean      = QuesmaType{Name: "boolean", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
-	QuesmaTypeObject       = QuesmaType{Name: "object", Properties: []QuesmaTypeProperty{Searchable}}
+	QuesmaTypeObject       = QuesmaType{Name: "object", Properties: []QuesmaTypeProperty{}}
 	QuesmaTypeArray        = QuesmaType{Name: "array", Properties: []QuesmaTypeProperty{Searchable}}
-	QuesmaTypeMap          = QuesmaType{Name: "map", Properties: []QuesmaTypeProperty{Searchable}}
+	QuesmaTypeMap          = QuesmaType{Name: "map", Properties: []QuesmaTypeProperty{}}
 	QuesmaTypeIp           = QuesmaType{Name: "ip", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
 	QuesmaTypePoint        = QuesmaType{Name: "point", Properties: []QuesmaTypeProperty{Searchable, Aggregatable}}
 	QuesmaTypeUnknown      = QuesmaType{Name: "unknown", Properties: []QuesmaTypeProperty{Searchable}}

--- a/platform/schema/types.go
+++ b/platform/schema/types.go
@@ -60,6 +60,8 @@ func (t QuesmaType) String() string {
 
 func ParseQuesmaType(t string) (QuesmaType, bool) {
 	switch t {
+	case QuesmaTypeInteger.Name:
+		return QuesmaTypeInteger, true
 	case QuesmaTypeText.Name:
 		return QuesmaTypeText, true
 	case QuesmaTypeKeyword.Name:


### PR DESCRIPTION
This PR fixes two issues:

- Ensuring consistency by aligning behavior with Elasticsearch (field_caps inferred types).
- Preventing query failures.

<img width="1681" alt="image" src="https://github.com/user-attachments/assets/8f6a1f26-0862-40e4-b336-4b5779f8882c" />

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/b355b475-cf59-4b04-93a6-b6c993c24dd0" />


<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' -->
