### PR TITLE
Extending map keys types discovering

### DIFF
--- a/platform/clickhouse/schema.go
+++ b/platform/clickhouse/schema.go
@@ -240,7 +240,7 @@ func ResolveType(clickHouseTypeName string) reflect.Type {
 		return reflect.TypeOf(true)
 	case "JSON":
 		return reflect.TypeOf(map[string]interface{}{})
-	case "Map(String, Nullable(String))", "Map(String, String)", "Map(LowCardinality(String), String)":
+	case "Map(String, Nullable(String))", "Map(String, String)", "Map(LowCardinality(String), String)", "Map(LowCardinality(String), Nullable(String))":
 		return reflect.TypeOf(map[string]string{})
 	case "Unknown":
 		return reflect.TypeOf(UnknownType{})

--- a/platform/clickhouse/table_discovery.go
+++ b/platform/clickhouse/table_discovery.go
@@ -614,20 +614,17 @@ func removePrecision(str string) string {
 }
 
 // extractMapValueType extracts the value type from a ClickHouse Map definition
+// extractMapValueType extracts the value type from a ClickHouse Map definition.
 func extractMapValueType(mapType string) (string, error) {
-	// Regular expression to match Map(String, valueType)
-	re := regexp.MustCompile(`Map\(String,\s*([^)]+)\)`)
-	matches := re.FindStringSubmatch(mapType)
+	// Regular expression to match "Map(String, <valueType>)"
+	re := regexp.MustCompile(`Map\((?:LowCardinality\()?String\)?,\s*(.+)\)$`)
 
+	matches := re.FindStringSubmatch(mapType)
 	if len(matches) < 2 {
-		re = regexp.MustCompile(`Map\(LowCardinality\(String\),\s*([^)]+)\)`)
-		matches = re.FindStringSubmatch(mapType)
-		if len(matches) < 2 {
-			return "", fmt.Errorf("invalid map type format: %s", mapType)
-		}
-		return strings.TrimSpace(matches[1]), nil
+		return "", errors.New("invalid map type format: " + mapType)
 	}
 
+	// Trim spaces and return the full value type
 	return strings.TrimSpace(matches[1]), nil
 }
 

--- a/platform/clickhouse/table_discovery.go
+++ b/platform/clickhouse/table_discovery.go
@@ -635,8 +635,9 @@ func (td *tableDiscovery) enrichTableWithMapFields(inputTable map[string]map[str
 	outputTable := make(map[string]map[string]columnMetadata)
 	for table, columns := range inputTable {
 		for colName, columnMeta := range columns {
-			if strings.HasPrefix(columnMeta.colType, "Map(String") ||
-				strings.HasPrefix(columnMeta.colType, "Map(LowCardinality(String") {
+			columnType := strings.TrimSpace(columnMeta.colType)
+			if strings.HasPrefix(columnType, "Map(String") ||
+				strings.HasPrefix(columnType, "Map(LowCardinality(String") {
 				logger.Debug().Msgf("Discovered map column: %s.%s", table, colName)
 				// Ensure the table exists in outputTable
 				if _, ok := outputTable[table]; !ok {
@@ -667,7 +668,7 @@ func (td *tableDiscovery) enrichTableWithMapFields(inputTable map[string]map[str
 					// with origin set to mapping
 					mapKeyCol := colName + "." + key
 					var valueType string
-					valueType, err = extractMapValueType(columnMeta.colType)
+					valueType, err = extractMapValueType(columnType)
 					if err != nil {
 						logger.Error().Msgf("Error extracting value type for table, column: %s, %s, %v", table, colName, err)
 						continue


### PR DESCRIPTION
This PR:
- handles `Map(LowCardinality(String),...)`
- fixes `extractMapValueType`

<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' or '/run-it' -->
