### PR TITLE
[`flights`, recent regression] Quickfix `__quesma_match` for `bools`

### DIFF
--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -1106,7 +1106,6 @@ func (s *SchemaCheckPass) applyMatchOperator(indexSchema schema.Schema, query *m
 				return model.NewInfixExpr(lhs, "ILIKE", rhs.Clone())
 			}
 			equal := func() model.Expr {
-				rhsValue = strings.Trim(rhsValue, "%")
 				return model.NewInfixExpr(lhs, "=", rhs.Clone())
 			}
 
@@ -1123,6 +1122,8 @@ func (s *SchemaCheckPass) applyMatchOperator(indexSchema schema.Schema, query *m
 			// TODO: improve? we seem to be `ilike'ing` too much
 			switch field.Type.String() {
 			case schema.QuesmaTypeInteger.Name, schema.QuesmaTypeLong.Name, schema.QuesmaTypeUnsignedLong.Name, schema.QuesmaTypeFloat.Name, schema.QuesmaTypeBoolean.Name:
+				rhs.Value = strings.Trim(rhsValue, "%")
+				rhs.EscapeType = model.NormalNotEscaped
 				return equal()
 			default:
 				return ilike()

--- a/platform/frontend_connectors/schema_transformer_test.go
+++ b/platform/frontend_connectors/schema_transformer_test.go
@@ -1143,6 +1143,7 @@ func Test_applyMatchOperator(t *testing.T) {
 	schemaTable := schema.Table{
 		Columns: map[string]schema.Column{
 			"message":     {Name: "message", Type: "String"},
+			"easy":        {Name: "easy", Type: "Bool"},
 			"map_str_str": {Name: "map_str_str", Type: "Map(String, String)"},
 			"map_str_int": {Name: "map_str_int", Type: "Map(String, Int)"},
 			"count":       {Name: "count", Type: "Int64"},
@@ -1203,7 +1204,34 @@ func Test_applyMatchOperator(t *testing.T) {
 					WhereClause: model.NewInfixExpr(
 						model.NewColumnRef("count"),
 						"=",
-						model.NewLiteral("'123'"),
+						model.NewLiteral("123"),
+					),
+				},
+			},
+		},
+		{
+			name: "match operator transformation for Bool",
+			query: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewColumnRef("message")},
+					WhereClause: model.NewInfixExpr(
+						model.NewColumnRef("easy"),
+						model.MatchOperator,
+						model.NewLiteralWithEscapeType("true", model.NotEscapedLikeFull),
+					),
+				},
+			},
+			expected: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewColumnRef("message")},
+					WhereClause: model.NewInfixExpr(
+						model.NewColumnRef("easy"),
+						"=",
+						model.TrueExpr,
 					),
 				},
 			},


### PR DESCRIPTION
a) I think we trimmed `%` from strings a bit too often
b) if trimming `%` from bools or numbers helps, then let's do this as well.
After:
![Screenshot 2025-03-28 at 21 26 53](https://github.com/user-attachments/assets/76fe9449-44ca-462b-b643-8ab8ca124e5b)
Before:
![Screenshot 2025-03-28 at 21 34 57](https://github.com/user-attachments/assets/10d6d988-13e5-4cbb-9abd-ff749d059efc)


