### PR TITLE
[done, needs some testing] Revert `Text/keyword` change?

### DIFF
--- a/platform/functionality/field_capabilities/field_caps.go
+++ b/platform/functionality/field_capabilities/field_caps.go
@@ -70,8 +70,9 @@ func handleFieldCapsIndex(cfg map[string]config.IndexConfiguration, schemaRegist
 			for fieldName, field := range fieldsWithAliases {
 				addFieldCapabilityFromSchemaRegistry(fields, fieldName.AsString(), field.Type, resolvedIndex)
 				switch field.Type.Name {
-				case "keyword", "text":
+				case "text":
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldKeywordSuffix), schema.QuesmaTypeKeyword, resolvedIndex)
+				case "keyword":
 					addFieldCapabilityFromSchemaRegistry(fields, fmt.Sprintf("%s%s", fieldName.AsString(), types.MultifieldTextSuffix), schema.QuesmaTypeText, resolvedIndex)
 				}
 			}

--- a/platform/functionality/field_capabilities/field_caps_test.go
+++ b/platform/functionality/field_capabilities/field_caps_test.go
@@ -15,83 +15,77 @@ import (
 
 func TestFieldCaps(t *testing.T) {
 	expected := []byte(`{
-  "fields": {
-    "arrayOfArraysOfStrings": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
-        "type": "keyword",
-		"metadata_field": false,
-		"indices": ["logs-generic-default"]
+   "fields":{
+      "arrayOfArraysOfStrings":{
+         "keyword":{
+            "aggregatable":true,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"keyword"
+         }
+      },
+      "arrayOfArraysOfStrings.text":{
+         "text":{
+            "aggregatable":false,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"text"
+         }
+      },
+      "arrayOfTuples":{
+         "object":{
+            "aggregatable":false,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":false,
+            "type":"object"
+         }
+      },
+      "host.name":{
+         "object":{
+            "aggregatable":false,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":false,
+            "type":"object"
+         }
+      },
+      "service.name":{
+         "keyword":{
+            "aggregatable":true,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"keyword"
+         }
+      },
+      "service.name.text":{
+         "text":{
+            "aggregatable":false,
+            "indices":[
+               "logs-generic-default"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"text"
+         }
       }
-    },
-	"arrayOfArraysOfStrings.keyword": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
-        "type": "keyword",
-		"metadata_field": false,
-		"indices": ["logs-generic-default"]
-      }
-    },
-    "arrayOfArraysOfStrings.text": {
-      "text": {
-        "type": "text",
-        "metadata_field": false,
-        "searchable": true,
-        "aggregatable": false,
-        "indices": ["logs-generic-default"] 
-      }
-    },
-    "arrayOfTuples": {
-      "object": {
-        "aggregatable": false,
-        "metadata_field": false,
-        "searchable": true,
-        "type": "object",
-		"indices": ["logs-generic-default"]
-      }
-    },
-    "host.name": {
-      "object": {
-        "aggregatable": false,
-        "metadata_field": false,
-        "searchable": true,
-        "type": "object",
-		"indices": ["logs-generic-default"]
-      }
-    },
-    "service.name": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
-        "metadata_field": false,
-		"type": "keyword",
-		"indices": ["logs-generic-default"]
-      }
-    },
-	"service.name.keyword": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
-        "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-generic-default"]
-      }
-    },
-    "service.name.text": {
-      "text": {
-        "aggregatable": false,
-        "searchable": true,
-        "metadata_field": false,
-        "type": "text",
-		"indices": ["logs-generic-default"]
-      }
-    }
-  },
-  "indices": [
-    "logs-generic-default"
-  ]
+   },
+   "indices":[
+      "logs-generic-default"
+   ]
 }
 `)
 	resp, err := handleFieldCapsIndex(
@@ -122,7 +116,6 @@ func TestFieldCaps(t *testing.T) {
 		string(resp),
 		string(expectedResp),
 	)
-
 	assert.NoError(t, err)
 	assert.Empty(t, difference1)
 	assert.Empty(t, difference2)
@@ -223,63 +216,56 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 		}, []string{"logs-1", "logs-2"})
 	assert.NoError(t, err)
 	expectedResp, err := json.MarshalIndent([]byte(`{
-  "fields": {
-    "foo.bar1": {
-      "text": {
-        "aggregatable": false,
-        "indices": ["logs-1"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "text"
+   "fields":{
+      "foo.bar1":{
+         "text":{
+            "aggregatable":false,
+            "indices":[
+               "logs-1"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"text"
+         }
+      },
+      "foo.bar1.keyword":{
+         "keyword":{
+            "aggregatable":true,
+            "indices":[
+               "logs-1"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"keyword"
+         }
+      },
+      "foo.bar2":{
+         "text":{
+            "aggregatable":false,
+            "indices":[
+               "logs-2"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"text"
+         }
+      },
+      "foo.bar2.keyword":{
+         "keyword":{
+            "aggregatable":true,
+            "indices":[
+               "logs-2"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"keyword"
+         }
       }
-    },
-    "foo.bar1.keyword": {
-      "keyword": {
-        "aggregatable": true,
-        "indices": ["logs-1"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "keyword"
-      }
-    },
-    "foo.bar1.text": {
-      "text": {
-        "aggregatable": false,
-        "indices": ["logs-1"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "text"
-      }
-    },
-    "foo.bar2": {
-      "text": {
-        "aggregatable": false,
-        "indices": ["logs-2"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "text"
-      }
-    },
-    "foo.bar2.keyword": {
-      "keyword": {
-        "aggregatable": true,
-        "indices": ["logs-2"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "keyword"
-      }
-    },
-    "foo.bar2.text": {
-      "text": {
-        "aggregatable": false,
-        "indices": ["logs-2"],
-        "metadata_field": false,
-        "searchable": true,
-        "type": "text"
-      }
-    }
-  },
-  "indices": ["logs-1", "logs-2"]
+   },
+   "indices":[
+      "logs-1",
+      "logs-2"
+   ]
 }
 `), "", "  ")
 	assert.NoError(t, err)
@@ -290,7 +276,6 @@ func TestFieldCapsMultipleIndexes(t *testing.T) {
 		string(resp),
 		string(expectedResp),
 	)
-
 	assert.NoError(t, err)
 	assert.Empty(t, difference1)
 	assert.Empty(t, difference2)
@@ -351,53 +336,50 @@ func TestFieldCapsMultipleIndexesConflictingEntries(t *testing.T) {
 		}, []string{"logs-1", "logs-2", "logs-3"})
 	assert.NoError(t, err)
 	expectedResp, err := json.MarshalIndent([]byte(`{
-  "fields": {
-    "foo.bar": {
-      "keyword": {
-        "aggregatable": true,
-        "searchable": true,
-        "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-1"]
+   "fields":{
+      "foo.bar":{
+         "boolean":{
+            "aggregatable":true,
+            "indices":[
+               "logs-2",
+               "logs-3"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"boolean"
+         },
+         "keyword":{
+            "aggregatable":true,
+            "indices":[
+               "logs-1"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"keyword"
+         }
       },
-		"boolean": {
-		  "aggregatable": false,
-		  "searchable": true,
-          "metadata_field": false,
-          "type": "boolean",
-		  "indices": ["logs-2", "logs-3"]
+      "foo.bar.text":{
+         "text":{
+            "aggregatable":false,
+            "indices":[
+               "logs-1"
+            ],
+            "metadata_field":false,
+            "searchable":true,
+            "type":"text"
+         }
       }
-    },
-	"foo.bar.keyword": {
-      "keyword": {
-        "aggregatable": false,
-        "searchable": true,
-        "metadata_field": false,
-        "type": "keyword",
-		"indices": ["logs-1"]
-      }
-    },
-    "foo.bar.text": {
-      "text": {
-        "aggregatable": false,
-        "searchable": true,
-        "metadata_field": false,
-        "type": "text",
-		"indices": ["logs-1"]
-      }
-    }
-  },
-  "indices": [
-    "logs-1",
-	"logs-2",
-	"logs-3"
-  ]
+   },
+   "indices":[
+      "logs-1",
+      "logs-2",
+      "logs-3"
+   ]
 }
 `), "", "  ")
 	assert.NoError(t, err)
 	err = json.Unmarshal(expectedResp, &expectedResp)
 	assert.NoError(t, err)
-
 	difference1, difference2, err := util.JsonDifference(
 		string(resp),
 		string(expectedResp),


### PR DESCRIPTION
Before this PR all sample dashboards load in Kibana 8.11, but one single panel doesn't in newest Kibana 8.17.
After this PR they all load in both of them.

https://github.com/QuesmaOrg/quesma/pull/1321

Draft for a bit, let me inspect a) PR above b) the customer case which was why I also introduced the reverse change a few months ago (we used to have exactly the same version in code as after this PR months ago)