### PR TITLE
Update `examples/` a bit

### DIFF
--- a/examples/kibana-sample-data/docker-compose.yml
+++ b/examples/kibana-sample-data/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     command: [ "/bin/bash", "-c", "/local_mount/run.sh" ]
   clickhouse:
     # user: 'default', no password
-    image: clickhouse/clickhouse-server:23.12.2.59-alpine
+    image: clickhouse/clickhouse-server:24.5.3.5-alpine
     ports:
       - "8123:8123"
       - "9000:9000"

--- a/examples/kibana-sample-data/kibana/run.sh
+++ b/examples/kibana-sample-data/kibana/run.sh
@@ -61,7 +61,7 @@ add_sample_dataset() {
 wait_until_available
 
 add_sample_dataset "flights"
-#add_sample_dataset "logs"
+add_sample_dataset "logs"
 add_sample_dataset "ecommerce"
 
 echo -n "Adding data view logs-generic... "

--- a/examples/kibana-sample-data/quesma/config/local-dev.yaml
+++ b/examples/kibana-sample-data/quesma/config/local-dev.yaml
@@ -54,6 +54,21 @@ processors:
                 type: geo_point
               "OriginLocation":
                 type: geo_point
+        kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
+          schemaOverrides:
+            fields:
+              timestamp:
+                type: alias
+                targetColumnName: "@timestamp"
+              ip:
+                type: ip
+              clientip:
+                type: ip
+              "geo.coordinates":
+                type: geo_point
+              "geo.src":
+                type: keyword
         logs-generic-default:
           target:
             - my-clickhouse-data-source
@@ -103,6 +118,21 @@ processors:
                 type: geo_point
               "OriginLocation":
                 type: geo_point
+        kibana_sample_data_logs:
+          target: [ my-clickhouse-data-source ]
+          schemaOverrides:
+            fields:
+              timestamp:
+                type: alias
+                targetColumnName: "@timestamp"
+              ip:
+                type: ip
+              clientip:
+                type: ip
+              "geo.coordinates":
+                type: geo_point
+              "geo.src":
+                type: keyword
         logs-generic-default:
           target:
             - my-clickhouse-data-source


### PR DESCRIPTION
* added `sample_logs`. I checked by running the docker compose myself and the dashboard fully works, so why not do so.
* bumped Clickhouse version to match our local configs