### PR TITLE
[Transpiler] Small leftovers of refactor

### DIFF
--- a/platform/parsers/sql/parser/core/helper.go
+++ b/platform/parsers/sql/parser/core/helper.go
@@ -91,6 +91,10 @@ func Space() TokenNode {
 	return NewTokenNode(" ")
 }
 
+func Star() TokenNode {
+	return NewTokenNode("*")
+}
+
 // operators
 
 func And() TokenNode {

--- a/platform/parsers/sql/parser/core/node.go
+++ b/platform/parsers/sql/parser/core/node.go
@@ -50,6 +50,10 @@ func NewTokenNodeSingleQuote(value string) TokenNode {
 	return NewTokenNode(util.SingleQuote(value))
 }
 
+func (n TokenNode) Value() string {
+	return n.Token.RawValue
+}
+
 func (n TokenNode) ValueUpper() string {
 	return strings.ToUpper(n.Token.RawValue)
 }
@@ -72,12 +76,16 @@ func TokensToNode(tokens []core.Token) Node {
 	return &NodeListNode{Nodes: nodes}
 }
 
-type Pipe = []Node
+type Pipe = *[]Node
 
 func NewPipe(nodes ...Node) Pipe {
-	return nodes
+	return &nodes
 }
 
-func Add(pipe *Pipe, nodes ...Node) {
+func Add(pipe Pipe, nodes ...Node) {
 	*pipe = append(*pipe, nodes...)
+}
+
+func AddPipe(pipe, pipeToAdd Pipe) {
+	*pipe = append(*pipe, *pipeToAdd...)
 }

--- a/platform/parsers/sql/parser/pipe_syntax/enrichments.go
+++ b/platform/parsers/sql/parser/pipe_syntax/enrichments.go
@@ -120,8 +120,8 @@ func ExpandEnrichments(node core.Node, conn *sql.DB) {
 				// FIXME: iteration probably breaks after adding new pipes!
 
 				// Replace the old macro pipe with the two new pipes
-				pipeNode.Pipes[i] = core.NodeListNode{Nodes: ipPipe}
-				pipeNode.Pipes = append(pipeNode.Pipes[:i+1], append([]core.Node{core.NodeListNode{Nodes: extendPipe}}, pipeNode.Pipes[i+1:]...)...)
+				pipeNode.Pipes[i] = core.NodeListNode{Nodes: *ipPipe}
+				pipeNode.Pipes = append(pipeNode.Pipes[:i+1], append([]core.Node{core.NodeListNode{Nodes: *extendPipe}}, pipeNode.Pipes[i+1:]...)...)
 			} else if macroType == "ENRICH_LLM" {
 				// Parse out the tokens following "CALL ENRICH_LLM":
 				// Expected form: |> CALL ENRICH_LLM <prompt> , <input_column>
@@ -137,8 +137,8 @@ func ExpandEnrichments(node core.Node, conn *sql.DB) {
 				// FIXME: iteration probably breaks after adding new pipes!
 
 				// Replace the old macro pipe with the two new pipes
-				pipeNode.Pipes[i] = core.NodeListNode{Nodes: enrichPipe}
-				pipeNode.Pipes = append(pipeNode.Pipes[:i+1], append([]core.Node{core.NodeListNode{Nodes: extendPipe}}, pipeNode.Pipes[i+1:]...)...)
+				pipeNode.Pipes[i] = core.NodeListNode{Nodes: *enrichPipe}
+				pipeNode.Pipes = append(pipeNode.Pipes[:i+1], append([]core.Node{core.NodeListNode{Nodes: *extendPipe}}, pipeNode.Pipes[i+1:]...)...)
 			} else {
 				// Enrichment not recognized; continue.
 			}
@@ -173,7 +173,7 @@ func enrichIpMacro(pipeNodeList core.NodeListNode, copiedNode *PipeNode, i int, 
 	// Expected form: |> CALL ENRICH_IP <ip_column>
 
 	var (
-		ipColumn                   core.Pipe
+		ipColumn                   []core.Node
 		columns, firstColumnValues []string
 		db                         *ip2location.DB
 	)
@@ -183,7 +183,7 @@ func enrichIpMacro(pipeNodeList core.NodeListNode, copiedNode *PipeNode, i int, 
 	}
 
 	for j := 5; j < len(pipeNodeList.Nodes); j++ {
-		core.Add(&ipColumn, pipeNodeList.Nodes[j])
+		ipColumn = append(ipColumn, pipeNodeList.Nodes[j])
 	}
 
 	copiedNode.Pipes = copiedNode.Pipes[:i]
@@ -520,8 +520,8 @@ func buildIpPipe(ipColumn []core.Node) core.Pipe {
 		core.Equals(),
 		core.Space(),
 	)
-	core.Add(&pipe, ipColumn...)
-	core.Add(&pipe,
+	core.Add(pipe, ipColumn...)
+	core.Add(pipe,
 		core.Space(),
 		core.And(),
 		core.Space(),
@@ -550,8 +550,8 @@ func buildEnrichLLMPipe(inputColumn []core.Node) core.Pipe {
 		core.Equals(),
 		core.Space(),
 	)
-	core.Add(&pipe, inputColumn...)
-	core.Add(&pipe,
+	core.Add(pipe, inputColumn...)
+	core.Add(pipe,
 		core.Space(),
 		core.And(),
 		core.Space(),

--- a/platform/parsers/sql/parser/pipe_syntax/expand_macros.go
+++ b/platform/parsers/sql/parser/pipe_syntax/expand_macros.go
@@ -107,11 +107,11 @@ func expandCallTimebucket(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		}
 		switch phase {
 		case 0:
-			core.Add(&timestampTokens, pipeNodeList.Nodes[j])
+			core.Add(timestampTokens, pipeNodeList.Nodes[j])
 		case 1:
-			core.Add(&intervalTokens, pipeNodeList.Nodes[j])
+			core.Add(intervalTokens, pipeNodeList.Nodes[j])
 		case 2:
-			core.Add(&nameTokens, pipeNodeList.Nodes[j])
+			core.Add(nameTokens, pipeNodeList.Nodes[j])
 		}
 	}
 
@@ -137,50 +137,50 @@ func expandCallTimebucket(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.ToStartOfInterval(),
 		core.LeftBracket(),
 	)
-	core.Add(&pipe, timestampTokens...)
-	core.Add(&pipe, core.Comma())
-	core.Add(&pipe, core.Interval())
-	core.Add(&pipe, intervalTokens...)
+	core.AddPipe(pipe, intervalTokens)
+	core.Add(pipe, core.Comma())
+	core.Add(pipe, core.Interval())
+	core.AddPipe(pipe, intervalTokens)
 	// Close toStartOfInterval call.
-	core.Add(&pipe, core.RightBracket())
+	core.Add(pipe, core.RightBracket())
 	// End first argument list for formatDateTime: add comma and the format string.
-	core.Add(&pipe, core.Comma())
-	core.Add(&pipe, core.NewTokenNodeSingleQuote("%Y-%m-%d %H:00"))
+	core.Add(pipe, core.Comma())
+	core.Add(pipe, core.NewTokenNodeSingleQuote("%Y-%m-%d %H:00"))
 	// Close formatDateTime call.
-	core.Add(&pipe, core.RightBracket())
+	core.Add(pipe, core.RightBracket())
 	// Separator for concat arguments.
-	core.Add(&pipe, core.Comma())
+	core.Add(pipe, core.Comma())
 	// Second argument: the literal separator ' - '
-	core.Add(&pipe, core.NewTokenNodeSingleQuote(" - "))
-	core.Add(&pipe, core.Comma())
+	core.Add(pipe, core.NewTokenNodeSingleQuote(" - "))
+	core.Add(pipe, core.Comma())
 	// Second argument: formatDateTime(toStartOfInterval(timestamp, INTERVAL <interval>) + INTERVAL <interval>, '%Y-%m-%d %H:00')
-	core.Add(&pipe, core.FormatDateTime())
-	core.Add(&pipe, core.LeftBracket())
-	core.Add(&pipe, core.ToStartOfInterval())
-	core.Add(&pipe, core.LeftBracket())
-	core.Add(&pipe, timestampTokens...)
-	core.Add(&pipe, core.Comma())
-	core.Add(&pipe, core.Interval())
-	core.Add(&pipe, intervalTokens...)
+	core.Add(pipe, core.FormatDateTime())
+	core.Add(pipe, core.LeftBracket())
+	core.Add(pipe, core.ToStartOfInterval())
+	core.Add(pipe, core.LeftBracket())
+	core.AddPipe(pipe, timestampTokens)
+	core.Add(pipe, core.Comma())
+	core.Add(pipe, core.Interval())
+	core.AddPipe(pipe, intervalTokens)
 	// Close the first toStartOfInterval call.
-	core.Add(&pipe, core.RightBracket())
+	core.Add(pipe, core.RightBracket())
 	// Add the plus operator and the second "INTERVAL" for addition.
-	core.Add(&pipe, core.Plus())
-	core.Add(&pipe, core.Interval())
-	core.Add(&pipe, intervalTokens...)
+	core.Add(pipe, core.Plus())
+	core.Add(pipe, core.Interval())
+	core.AddPipe(pipe, intervalTokens)
 	// Add comma and the format string.
-	core.Add(&pipe, core.Comma())
-	core.Add(&pipe, core.NewTokenNodeSingleQuote("%Y-%m-%d %H:00"))
+	core.Add(pipe, core.Comma())
+	core.Add(pipe, core.NewTokenNodeSingleQuote("%Y-%m-%d %H:00"))
 	// Close the second formatDateTime call.
-	core.Add(&pipe, core.RightBracket())
+	core.Add(pipe, core.RightBracket())
 	// Close the concat call.
-	core.Add(&pipe, core.RightBracket())
+	core.Add(pipe, core.RightBracket())
 	// Add "AS" and the alias tokens.
-	core.Add(&pipe, core.Space())
-	core.Add(&pipe, core.As())
-	core.Add(&pipe, nameTokens...)
+	core.Add(pipe, core.Space())
+	core.Add(pipe, core.As())
+	core.AddPipe(pipe, nameTokens)
 
-	return []core.NodeListNode{{Nodes: pipe}}
+	return []core.NodeListNode{{Nodes: *pipe}}
 }
 
 func expandExtendEnrichIP(pipeNodeList core.NodeListNode) []core.NodeListNode {
@@ -371,9 +371,9 @@ func expandExtendParsePattern(pipeNodeList core.NodeListNode) []core.NodeListNod
 	secondPipe := buildSecondExtendPipe(aliasParts, extractedAlias)
 
 	// Combine both pipe commands into a single node list, separating them with a newline.
-	core.Add(&firstPipe, core.NewLine())
+	core.Add(firstPipe, core.NewLine())
 
-	return []core.NodeListNode{{Nodes: firstPipe}, {Nodes: secondPipe}}
+	return []core.NodeListNode{{Nodes: *firstPipe}, {Nodes: *secondPipe}}
 }
 
 func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
@@ -420,13 +420,13 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.Case(),
 	)
 	// Clause 1
-	core.Add(&pipe,
+	core.Add(pipe,
 		core.Space(),
 		core.When(),
 		core.Space(),
 	)
-	core.Add(&pipe, logLineTokens...)
-	core.Add(&pipe,
+	core.Add(pipe, logLineTokens...)
+	core.Add(pipe,
 		core.Space(),
 		core.Regexp(),
 		core.Space(),
@@ -437,9 +437,9 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.NewTokenNodeSingleQuote("JSON API Response"),
 	)
 	// Clause 2
-	core.Add(&pipe, spaceWhenSpace()...)
-	core.Add(&pipe, logLineTokens...)
-	core.Add(&pipe,
+	core.Add(pipe, spaceWhenSpace()...)
+	core.Add(pipe, logLineTokens...)
+	core.Add(pipe,
 		core.Space(),
 		core.Regexp(),
 		core.Space(),
@@ -450,9 +450,9 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.NewTokenNodeSingleQuote("HTTP Output"),
 	)
 	// Clause 3
-	core.Add(&pipe, spaceWhenSpace()...)
-	core.Add(&pipe, logLineTokens...)
-	core.Add(&pipe,
+	core.Add(pipe, spaceWhenSpace()...)
+	core.Add(pipe, logLineTokens...)
+	core.Add(pipe,
 		core.Space(),
 		core.Regexp(),
 		core.Space(),
@@ -463,9 +463,9 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.NewTokenNodeSingleQuote("Rsyslog Message Lost"),
 	)
 	// Clause 4
-	core.Add(&pipe, spaceWhenSpace()...)
-	core.Add(&pipe, logLineTokens...)
-	core.Add(&pipe,
+	core.Add(pipe, spaceWhenSpace()...)
+	core.Add(pipe, logLineTokens...)
+	core.Add(pipe,
 		core.Space(),
 		core.Regexp(),
 		core.Space(),
@@ -476,9 +476,9 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.NewTokenNodeSingleQuote("Disk Space Error"),
 	)
 	// Clause 5
-	core.Add(&pipe, spaceWhenSpace()...)
-	core.Add(&pipe, logLineTokens...)
-	core.Add(&pipe,
+	core.Add(pipe, spaceWhenSpace()...)
+	core.Add(pipe, logLineTokens...)
+	core.Add(pipe,
 		core.Space(),
 		core.Regexp(),
 		core.Space(),
@@ -489,26 +489,26 @@ func expandCallLogCategory(pipeNodeList core.NodeListNode) []core.NodeListNode {
 		core.NewTokenNodeSingleQuote("SSH Authentication Error"),
 	)
 	// ELSE clause
-	core.Add(&pipe,
+	core.Add(pipe,
 		core.Space(),
 		core.Else(),
 		core.Space(),
 		core.NewTokenNodeSingleQuote("Unknown"),
 	)
 	// End clause: END AS <alias tokens>
-	core.Add(&pipe,
+	core.Add(pipe,
 		core.Space(),
 		core.NewTokenNode("END"),
 		core.Space(),
 		core.As(),
 		core.Space(),
 	)
-	core.Add(&pipe, aliasTokens...)
+	core.Add(pipe, aliasTokens...)
 
-	return []core.NodeListNode{{Nodes: pipe}}
+	return []core.NodeListNode{{Nodes: *pipe}}
 }
 
-func buildFirstExtendPipe(msgTokens []core.Node, finalRegexLiteral, extractedAlias string) []core.Node {
+func buildFirstExtendPipe(msgTokens []core.Node, finalRegexLiteral, extractedAlias string) core.Pipe {
 	firstPipe := core.NewPipe(
 		core.PipeToken(),
 		core.Space(),
@@ -517,8 +517,8 @@ func buildFirstExtendPipe(msgTokens []core.Node, finalRegexLiteral, extractedAli
 		core.NewTokenNode("extractGroups"),
 		core.LeftBracket(),
 	)
-	core.Add(&firstPipe, msgTokens...)
-	core.Add(&firstPipe,
+	core.Add(firstPipe, msgTokens...)
+	core.Add(firstPipe,
 		core.Comma(),
 		core.Space(),
 		core.NewTokenNode(finalRegexLiteral),
@@ -532,22 +532,23 @@ func buildFirstExtendPipe(msgTokens []core.Node, finalRegexLiteral, extractedAli
 	return firstPipe
 }
 
-func buildSecondExtendPipe(aliasParts []string, extractedAlias string) []core.Node {
+func buildSecondExtendPipe(aliasParts []string, extractedAlias string) core.Pipe {
 	secondPipe := core.NewPipe(
 		core.PipeToken(),
 		core.Space(),
 		core.Extend(),
 		core.Space(),
 	)
+
 	for i, alias := range aliasParts {
 		if i > 0 {
-			core.Add(&secondPipe,
+			core.Add(secondPipe,
 				core.Comma(),
 				core.Space(),
 			)
 		}
 		// Build tokens for: extracted_<msg>[<i+1>] AS <alias>
-		core.Add(&secondPipe,
+		core.Add(secondPipe,
 			core.NewTokenNode(extractedAlias),
 			core.NewTokenNode("["),
 			core.NewTokenNode(strconv.Itoa(i+1)),

--- a/platform/parsers/sql/parser/pipe_syntax/group_pipe_syntax.go
+++ b/platform/parsers/sql/parser/pipe_syntax/group_pipe_syntax.go
@@ -78,5 +78,5 @@ func GroupPipeSyntax(node core.Node) {
 
 func isPipeOperator(node core.Node) bool {
 	tokenNode, ok := node.(core.TokenNode)
-	return ok && tokenNode.Token.RawValue == "|>"
+	return ok && tokenNode.Value() == "|>"
 }

--- a/platform/parsers/sql/parser/transforms/group_parenthesis.go
+++ b/platform/parsers/sql/parser/transforms/group_parenthesis.go
@@ -62,17 +62,15 @@ func (p *groupParenthesisParser) Parse(parenStarted bool) []core.Node {
 }
 
 func isOpeningParenthesis(node core.Node) bool {
-	tokenNode, ok := node.(core.TokenNode)
-	if !ok {
-		return false
+	if tokenNode, ok := node.(core.TokenNode); ok {
+		return tokenNode.Value() == "("
 	}
-	return tokenNode.Token.RawValue == "("
+	return false
 }
 
 func isClosingParenthesis(node core.Node) bool {
-	tokenNode, ok := node.(core.TokenNode)
-	if !ok {
-		return false
+	if tokenNode, ok := node.(core.TokenNode); ok {
+		return tokenNode.Value() == ")"
 	}
-	return tokenNode.Token.RawValue == ")"
+	return false
 }


### PR DESCRIPTION
change back to `Add(pipe, ...nodes)` from `Add(&pipe, ...nodes)` which I like more, but idk, maybe you don't.

@avelanarius please look and reject/merge whenever you like, we can wait with this of course.