### PR TITLE
Support Client certificate authentication for opensearch/elastic search 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM golang:alpine AS builder
 COPY platform /platform
 COPY cmd /cmd
 
+ENV GOOS=linux
+ENV GOARCH=amd64
 ENV GOCACHE=/root/.cache/go-build
 ARG QUESMA_BUILD_SHA
 ARG QUESMA_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM golang:alpine AS builder
 COPY platform /platform
 COPY cmd /cmd
 
-ENV GOOS=linux
-ENV GOARCH=amd64
 ENV GOCACHE=/root/.cache/go-build
 ARG QUESMA_BUILD_SHA
 ARG QUESMA_VERSION

--- a/platform/backend_connectors/elasticsearch_backend_connector.go
+++ b/platform/backend_connectors/elasticsearch_backend_connector.go
@@ -6,7 +6,6 @@ package backend_connectors
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"fmt"
 	"github.com/QuesmaOrg/quesma/platform/config"
 	"github.com/QuesmaOrg/quesma/platform/elasticsearch"
@@ -32,32 +31,29 @@ type ElasticsearchBackendConnector struct {
 
 // NewElasticsearchBackendConnector is a constructor which uses old (v1) configuration object
 func NewElasticsearchBackendConnector(cfg config.ElasticsearchConfiguration) *ElasticsearchBackendConnector {
+	client := elasticsearch.NewHttpsClient(&cfg, esRequestTimeout)
 	conn := &ElasticsearchBackendConnector{
 		config: cfg,
-		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-			Timeout: esRequestTimeout,
-		},
+		client: client,
 	}
 	return conn
 }
 
 // NewElasticsearchBackendConnectorFromDbConfig is an alternative constructor which uses the generic database configuration object
 func NewElasticsearchBackendConnectorFromDbConfig(cfg config.RelationalDbConfiguration) *ElasticsearchBackendConnector {
+	esConfig := config.ElasticsearchConfiguration{
+		Url:            cfg.Url,
+		User:           cfg.User,
+		Password:       cfg.Password,
+		ClientCertPath: cfg.ClientCertPath,
+		ClientKeyPath:  cfg.ClientKeyPath,
+		CACertPath:     cfg.CACertPath,
+	}
+
+	client := elasticsearch.NewHttpsClient(&esConfig, esRequestTimeout)
 	conn := &ElasticsearchBackendConnector{
-		config: config.ElasticsearchConfiguration{
-			Url:      cfg.Url,
-			User:     cfg.User,
-			Password: cfg.Password,
-		},
-		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-			Timeout: esRequestTimeout,
-		},
+		config: esConfig,
+		client: client,
 	}
 	return conn
 }

--- a/platform/config/config_v2.go
+++ b/platform/config/config_v2.go
@@ -94,6 +94,11 @@ type RelationalDbConfiguration struct {
 	ClusterName   string `koanf:"clusterName"` // When creating tables by Quesma - they'll use `ON CLUSTER ClusterName` clause
 	AdminUrl      *Url   `koanf:"adminUrl"`
 	DisableTLS    bool   `koanf:"disableTLS"`
+
+	// This supports es backend only.
+	ClientCertPath string `koanf:"clientCertPath"`
+	ClientKeyPath  string `koanf:"clientKeyPath"`
+	CACertPath     string `koanf:"caCertPath"`
 }
 
 func (c *RelationalDbConfiguration) IsEmpty() bool {
@@ -1069,9 +1074,12 @@ func (c *QuesmaNewConfiguration) getRelationalDBBackendConnector() (*BackendConn
 func (c *QuesmaNewConfiguration) getElasticsearchConfig() (ElasticsearchConfiguration, error) {
 	if esBackendConn := c.getElasticsearchBackendConnector(); esBackendConn != nil {
 		return ElasticsearchConfiguration{
-			Url:      esBackendConn.Config.Url,
-			User:     esBackendConn.Config.User,
-			Password: esBackendConn.Config.Password,
+			Url:            esBackendConn.Config.Url,
+			User:           esBackendConn.Config.User,
+			Password:       esBackendConn.Config.Password,
+			ClientCertPath: esBackendConn.Config.ClientCertPath,
+			ClientKeyPath:  esBackendConn.Config.ClientKeyPath,
+			CACertPath:     esBackendConn.Config.CACertPath,
 		}, nil
 	}
 	return ElasticsearchConfiguration{}, fmt.Errorf("elasticsearch backend connector must be configured")

--- a/platform/config/elasticsearch_config.go
+++ b/platform/config/elasticsearch_config.go
@@ -7,4 +7,8 @@ type ElasticsearchConfiguration struct {
 	User     string `koanf:"user"`
 	Password string `koanf:"password"`
 	AdminUrl *Url   `koanf:"adminUrl"`
+
+	ClientCertPath string `koanf:"clientCertPath"`
+	ClientKeyPath  string `koanf:"clientKeyPath"`
+	CACertPath     string `koanf:"caCertPath"`
 }

--- a/platform/elasticsearch/client.go
+++ b/platform/elasticsearch/client.go
@@ -26,6 +26,7 @@ type SimpleClient struct {
 	config *config.ElasticsearchConfiguration
 }
 
+// NewHttpsClient should be merged with NewSimpleClient at some point -> TODO!
 func NewHttpsClient(configuration *config.ElasticsearchConfiguration, timeout time.Duration) *http.Client {
 	tlsConfig := &tls.Config{
 		MinVersion:         tls.VersionTLS12,

--- a/platform/elasticsearch/client.go
+++ b/platform/elasticsearch/client.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"github.com/QuesmaOrg/quesma/platform/config"
 	"github.com/QuesmaOrg/quesma/platform/logger"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -24,18 +26,52 @@ type SimpleClient struct {
 	config *config.ElasticsearchConfiguration
 }
 
-func NewSimpleClient(configuration *config.ElasticsearchConfiguration) *SimpleClient {
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		Timeout: esRequestTimeout,
+func NewHttpsClient(configuration *config.ElasticsearchConfiguration, timeout time.Duration) *http.Client {
+	var cert = tls.Certificate{}
+	if configuration.ClientCertPath != "" && configuration.ClientKeyPath != "" {
+		var err error
+		cert, err = tls.LoadX509KeyPair(configuration.ClientCertPath, configuration.ClientKeyPath)
+		if err != nil {
+			panic(fmt.Sprintf("failed to load client certificate/key: %v", err))
+		}
 	}
+
+	var caCertPool *x509.CertPool
+	var insecureSkipVerify = true
+	if configuration.CACertPath != "" {
+		caCert, err := os.ReadFile(configuration.CACertPath)
+		if err != nil {
+			panic(fmt.Sprintf("failed to read CA certificate: %v", err))
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		insecureSkipVerify = false
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            caCertPool,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: insecureSkipVerify,
+	}
+
+	// Create HTTP client with custom transport
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: timeout,
+	}
+}
+
+func NewSimpleClient(configuration *config.ElasticsearchConfiguration) *SimpleClient {
+	client := NewHttpsClient(configuration, esRequestTimeout)
 	return &SimpleClient{
 		client: client,
 		config: configuration,
 	}
 }
+
 func (es *SimpleClient) Request(ctx context.Context, method, endpoint string, body []byte) (*http.Response, error) {
 	return es.doRequest(ctx, method, endpoint, body, nil)
 }

--- a/platform/elasticsearch/client_test.go
+++ b/platform/elasticsearch/client_test.go
@@ -176,12 +176,9 @@ func TestNewHttpsClient_NoCerts(t *testing.T) {
 	client := NewHttpsClient(conf, 5*time.Second)
 
 	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
-	if tlsConfig == nil {
-		t.Fatal("expected TLSClientConfig to be set")
-	}
-	if !tlsConfig.InsecureSkipVerify {
-		t.Error("expected InsecureSkipVerify to be true")
-	}
+	assert.Nil(t, tlsConfig.RootCAs)
+	assert.Nil(t, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.InsecureSkipVerify)
 }
 
 func TestNewHttpsClient_WithCACert(t *testing.T) {
@@ -193,12 +190,9 @@ func TestNewHttpsClient_WithCACert(t *testing.T) {
 	client := NewHttpsClient(conf, 5*time.Second)
 
 	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
-	if tlsConfig.RootCAs == nil {
-		t.Error("expected RootCAs to be set")
-	}
-	if tlsConfig.InsecureSkipVerify {
-		t.Error("expected InsecureSkipVerify to be false")
-	}
+	assert.NotNil(t, tlsConfig.RootCAs)
+	assert.Nil(t, tlsConfig.Certificates)
+	assert.False(t, tlsConfig.InsecureSkipVerify)
 }
 
 func TestNewHttpsClient_WithClientCert(t *testing.T) {
@@ -211,21 +205,21 @@ func TestNewHttpsClient_WithClientCert(t *testing.T) {
 	client := NewHttpsClient(conf, 5*time.Second)
 
 	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
-	if len(tlsConfig.Certificates) == 0 {
-		t.Error("expected client certificate to be set")
-	}
+	assert.Nil(t, tlsConfig.RootCAs)
+	assert.NotNil(t, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.InsecureSkipVerify)
 }
 
 func TestNewHttpsClient_InvalidCAPath(t *testing.T) {
 	conf := &config.ElasticsearchConfiguration{
 		CACertPath: "/nonexistent/file.pem",
 	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for invalid CA path")
-		}
-	}()
-	NewHttpsClient(conf, 5*time.Second)
+	client := NewHttpsClient(conf, 5*time.Second)
+
+	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
+	assert.Nil(t, tlsConfig.RootCAs)
+	assert.Nil(t, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.InsecureSkipVerify)
 }
 
 func TestNewHttpsClient_InvalidClientCertPath(t *testing.T) {
@@ -233,10 +227,10 @@ func TestNewHttpsClient_InvalidClientCertPath(t *testing.T) {
 		ClientCertPath: "/invalid/cert.pem",
 		ClientKeyPath:  "/invalid/key.pem",
 	}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for invalid client cert path")
-		}
-	}()
-	NewHttpsClient(conf, 5*time.Second)
+	client := NewHttpsClient(conf, 5*time.Second)
+
+	tlsConfig := client.Transport.(*http.Transport).TLSClientConfig
+	assert.Nil(t, tlsConfig.RootCAs)
+	assert.Nil(t, tlsConfig.Certificates)
+	assert.True(t, tlsConfig.InsecureSkipVerify)
 }

--- a/platform/frontend_connectors/dispatcher.go
+++ b/platform/frontend_connectors/dispatcher.go
@@ -31,6 +31,8 @@ import (
 	"time"
 )
 
+const httpClientTimeout = time.Minute
+
 func responseFromElastic(ctx context.Context, elkResponse *http.Response, w http.ResponseWriter) {
 	if id, ok := ctx.Value(tracing.RequestIdCtxKey).(string); ok {
 		logger.Debug().Str(logger.RID, id).Msgf("responding from Elasticsearch, status_code=%d", elkResponse.StatusCode)
@@ -91,7 +93,7 @@ func (r *Dispatcher) SetDependencies(deps quesma_api.Dependencies) {
 }
 
 func NewDispatcher(config *config.QuesmaConfiguration) *Dispatcher {
-	client := elasticsearch.NewHttpsClient(&config.Elasticsearch, time.Minute)
+	client := elasticsearch.NewHttpsClient(&config.Elasticsearch, httpClientTimeout)
 	requestProcessors := quesma_api.ProcessorChain{}
 	requestProcessors = append(requestProcessors, quesma_api.NewTraceIdPreprocessor())
 

--- a/platform/frontend_connectors/dispatcher.go
+++ b/platform/frontend_connectors/dispatcher.go
@@ -5,7 +5,6 @@ package frontend_connectors
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"github.com/QuesmaOrg/quesma/platform/clickhouse"
@@ -90,14 +89,9 @@ func (r *Dispatcher) SetDependencies(deps quesma_api.Dependencies) {
 	r.debugInfoCollector = deps.DebugInfoCollector()
 	r.phoneHomeAgent = deps.PhoneHomeAgent()
 }
+
 func NewDispatcher(config *config.QuesmaConfiguration) *Dispatcher {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   time.Minute, // should be more configurable, 30s is Kibana default timeout
-	}
+	client := elasticsearch.NewHttpsClient(&config.Elasticsearch, time.Minute)
 	requestProcessors := quesma_api.ProcessorChain{}
 	requestProcessors = append(requestProcessors, quesma_api.NewTraceIdPreprocessor())
 

--- a/platform/telemetry/phone_home.go
+++ b/platform/telemetry/phone_home.go
@@ -140,7 +140,7 @@ func NewPhoneHomeAgent(configuration *config.QuesmaConfiguration, clickHouseDb q
 			},
 			Timeout: time.Minute,
 		},
-		elasticsearchHttpClient: elasticsearch.NewHttpsClient(&config.ElasticsearchConfiguration{}, time.Minute),
+		elasticsearchHttpClient: elasticsearch.NewHttpsClient(&configuration.Elasticsearch, time.Minute),
 	}
 }
 


### PR DESCRIPTION
In addition to username and password, es/os support client-auth based auth. See [here](https://docs.opensearch.org/docs/latest/security/authentication-backends/client-auth/). This pr wants to support that. 

This change introduces client certificate authentication for Quesm when connecting to Elasticsearch. It does not alter how users authenticate to Quesm.

(this pr is to implement request of this https://github.com/QuesmaOrg/quesma/issues/1394)
<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' or '/run-it' -->
