### PR TITLE
Transform `ILIKE '%%'` to `IS NOT NULL`

### DIFF
--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -1134,6 +1134,10 @@ func (s *SchemaCheckPass) applyMatchOperator(indexSchema schema.Schema, query *m
 				rhs.EscapeType = model.NormalNotEscaped
 				return equal()
 			default:
+				// ILIKE '%%' has terrible performance, but semantically means "is not null", hence this transformation
+				if rhsValue == "%%" {
+					return model.NewInfixExpr(lhs, "IS", model.NewLiteral("NOT NULL"))
+				}
 				return ilike()
 			}
 		}

--- a/platform/frontend_connectors/schema_transformer_test.go
+++ b/platform/frontend_connectors/schema_transformer_test.go
@@ -1431,7 +1431,7 @@ func Test_applyMatchOperator(t *testing.T) {
 			},
 		},
 		{
-			name: "match operator transformation for Attributes map (2/2)",
+			name: "match operator should change `ILIKE '%%'` TO `IS NOT NULL`",
 			query: &model.Query{
 				TableName: "test",
 				SelectCommand: model.SelectCommand{

--- a/platform/frontend_connectors/schema_transformer_test.go
+++ b/platform/frontend_connectors/schema_transformer_test.go
@@ -1430,6 +1430,33 @@ func Test_applyMatchOperator(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "match operator transformation for Attributes map (2/2)",
+			query: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewColumnRef("message")},
+					WhereClause: model.NewInfixExpr(
+						model.NewColumnRef("message"),
+						model.MatchOperator,
+						model.NewLiteralWithEscapeType("'%%'", model.NotEscapedLikeFull),
+					),
+				},
+			},
+			expected: &model.Query{
+				TableName: "test",
+				SelectCommand: model.SelectCommand{
+					FromClause: model.NewTableRef("test"),
+					Columns:    []model.Expr{model.NewColumnRef("message")},
+					WhereClause: model.NewInfixExpr(
+						model.NewColumnRef("message"),
+						"IS",
+						model.NewLiteral("NOT NULL"),
+					),
+				},
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/platform/testdata/pipeline_aggregation_requests.go
+++ b/platform/testdata/pipeline_aggregation_requests.go
@@ -176,14 +176,14 @@ var PipelineAggregationTests = []AggregationTestCase{}
 		ExpectedSQLs: []string{
 			`SELECT count() FROM ` + QuotedTableName + ` `,
 			"SELECT toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000), count() " +
-				"FROM " + QuotedTableName + ` WHERE "message" ILIKE '%'  ` +
+				"FROM " + QuotedTableName + ` WHERE "message" ILIKE '%'  ` +   // TODO: when uncommenting, investigate whether this shouldn't be    "message" IS NOT NULL
 				"GROUP BY (toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000)) " +
 				"ORDER BY (toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000))",
 			"SELECT toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000), count() " +
-				"FROM " + QuotedTableName + ` WHERE "message" ILIKE '%'  ` +
+				"FROM " + QuotedTableName + ` WHERE "message" ILIKE '%'  ` + // TODO: when uncommenting, investigate whether this shouldn't be    "message" IS NOT NULL
 				"GROUP BY (toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000)) " +
 				"ORDER BY (toInt64(toUnixTimestamp64Milli(`@timestamp`)/3600000))",
-			`SELECT count() FROM ` + QuotedTableName + ` WHERE "message" ILIKE '%' `,
+			`SELECT count() FROM ` + QuotedTableName + ` WHERE "message" ILIKE '%' `, // TODO: when uncommenting, investigate whether this shouldn't be    "message" IS NOT NULL
 		},
 	},
 	/*


### PR DESCRIPTION
`ILIKE '%%'` has terrible performance, as it semantically means `is not null` we could transform that part of `WHERE` statement for decent speed up.