### PR TITLE
Nicer license checker error message

### DIFF
--- a/platform/clickhouse/clickhouse.go
+++ b/platform/clickhouse/clickhouse.go
@@ -270,10 +270,12 @@ func (lm *LogManager) CheckIfConnectedPaidService(service PaidServiceName) (retu
 	if _, ok := paidServiceChecks[service]; !ok {
 		return fmt.Errorf("service %s is not supported", service)
 	}
+	backOffTime := 3 * time.Second
 	for {
 		isConnectedToPaidService, err := lm.isConnectedToPaidService(service)
 		if err != nil {
-			logger.Error().Msgf("Licensing checker failed to connect with the database")
+			logger.ErrorWithCtx(lm.ctx).Msgf(
+				"Failed to connect with the database, can't determine if license is required: %v", err)
 		}
 		if isConnectedToPaidService {
 			return fmt.Errorf("detected %s-specific table engine, which is not allowed", service)
@@ -281,7 +283,11 @@ func (lm *LogManager) CheckIfConnectedPaidService(service PaidServiceName) (retu
 			returnedErr = nil
 			break
 		}
-		time.Sleep(3 * time.Second)
+		time.Sleep(backOffTime)
+		backOffTime *= 2 // exponential backoff
+		if backOffTime > time.Minute {
+			backOffTime = time.Minute
+		}
 	}
 	return returnedErr
 }


### PR DESCRIPTION
The error message `License checker failed to connect with the database` is very confusing. It was interpreted during a talk with our user as a licensing problem.

This PR:
1. Creates backoff up to a minute, so we don't flood the logs.
2. Reword it too `Failed to connect with the database, can't determine if license is required`.
3. Show underling error.

