### PR TITLE
Dont expose internal table/index

### DIFF
--- a/platform/functionality/resolve/resolve.go
+++ b/platform/functionality/resolve/resolve.go
@@ -24,7 +24,7 @@ func HandleResolve(pattern string, sr schema.Registry, ir elasticsearch.IndexRes
 		sourcesToShow = &sourcesFromElasticsearch
 	}
 
-	var filteredOut []elasticsearch.Index
+	var filtered []elasticsearch.Index
 	for _, index := range sourcesToShow.Indices {
 		if index.Name == common_table.VirtualTableElasticIndexName {
 			// don't include the common table in the results

--- a/platform/functionality/resolve/resolve.go
+++ b/platform/functionality/resolve/resolve.go
@@ -3,6 +3,7 @@
 package resolve
 
 import (
+	"github.com/QuesmaOrg/quesma/platform/common_table"
 	"github.com/QuesmaOrg/quesma/platform/config"
 	"github.com/QuesmaOrg/quesma/platform/elasticsearch"
 	"github.com/QuesmaOrg/quesma/platform/logger"
@@ -23,16 +24,28 @@ func HandleResolve(pattern string, sr schema.Registry, ir elasticsearch.IndexRes
 		sourcesToShow = &sourcesFromElasticsearch
 	}
 
+	var filteredOut []elasticsearch.Index
+	for _, index := range sourcesToShow.Indices {
+		if index.Name == common_table.VirtualTableElasticIndexName {
+			// don't include the common table in the results
+			// it's internal table used by Quesma, and should be exposed as an index / data stream
+			continue
+		}
+		filteredOut = append(filteredOut, index)
+
+	}
+	sourcesToShow.Indices = filteredOut
+
 	tablesFromClickHouse := getMatchingClickHouseTables(sr.AllSchemas(), normalizedPattern)
 
 	addClickHouseTablesToSourcesFromElastic(sourcesToShow, tablesFromClickHouse)
+
 	return *sourcesToShow, nil
 }
 
 func getMatchingClickHouseTables(schemas map[schema.IndexName]schema.Schema, normalizedPattern string) (tables []string) {
 	for name, currentSchema := range schemas {
 		indexName := name.AsString()
-
 		if config.MatchName(normalizedPattern, indexName) && currentSchema.ExistsInDataSource {
 			tables = append(tables, indexName)
 		}
@@ -41,7 +54,15 @@ func getMatchingClickHouseTables(schemas map[schema.IndexName]schema.Schema, nor
 }
 
 func addClickHouseTablesToSourcesFromElastic(sourcesFromElastic *elasticsearch.Sources, chTableNames []string) {
-	for _, name := range chTableNames { // Quesma presents CH tables as Elasticsearch Data Streams.
+	for _, name := range chTableNames {
+
+		if name == common_table.TableName {
+			// don't include the common table in the results
+			// it's internal table used by Quesma, and should be exposed as an index / data stream
+			continue
+		}
+
+		// Quesma presents CH tables as Elasticsearch Data Streams.
 		sourcesFromElastic.DataStreams = append(sourcesFromElastic.DataStreams, elasticsearch.DataStream{
 			Name:           name,
 			BackingIndices: []string{name},

--- a/platform/functionality/resolve/resolve.go
+++ b/platform/functionality/resolve/resolve.go
@@ -28,7 +28,7 @@ func HandleResolve(pattern string, sr schema.Registry, ir elasticsearch.IndexRes
 	for _, index := range sourcesToShow.Indices {
 		if index.Name != common_table.VirtualTableElasticIndexName {
 			// don't include the common table in the results
-			// it's internal table used by Quesma, and should be exposed as an index / data stream
+			// it's internal table used by Quesma, and should not be exposed as an index / data stream
 			filtered = append(filtered, index)
 		}
 	}
@@ -56,7 +56,7 @@ func addClickHouseTablesToSourcesFromElastic(sourcesFromElastic *elasticsearch.S
 
 		if name == common_table.TableName {
 			// don't include the common table in the results
-			// it's internal table used by Quesma, and should be exposed as an index / data stream
+			// it's internal table used by Quesma, and should not be exposed as an index / data stream
 			continue
 		}
 

--- a/platform/functionality/resolve/resolve.go
+++ b/platform/functionality/resolve/resolve.go
@@ -26,15 +26,13 @@ func HandleResolve(pattern string, sr schema.Registry, ir elasticsearch.IndexRes
 
 	var filtered []elasticsearch.Index
 	for _, index := range sourcesToShow.Indices {
-		if index.Name == common_table.VirtualTableElasticIndexName {
+		if index.Name != common_table.VirtualTableElasticIndexName {
 			// don't include the common table in the results
 			// it's internal table used by Quesma, and should be exposed as an index / data stream
-			continue
+			filtered = append(filtered, index)
 		}
-		filteredOut = append(filteredOut, index)
-
 	}
-	sourcesToShow.Indices = filteredOut
+	sourcesToShow.Indices = filtered
 
 	tablesFromClickHouse := getMatchingClickHouseTables(sr.AllSchemas(), normalizedPattern)
 


### PR DESCRIPTION
Users should not be able to create a data view that matches the common table.  Querying the common table causes an error. 

This PR filters out our internal common table and index that contains a list of virtual tables.