### PR TITLE
Change integration test (should be changed in #1442)

### DIFF
--- a/ci/it/testcases/test_dual_write_and_common_table.go
+++ b/ci/it/testcases/test_dual_write_and_common_table.go
@@ -310,10 +310,6 @@ func (a *DualWriteAndCommonTableTestcase) testResolveEndpointInQuesma(ctx contex
 				"attributes": []interface{}{"open"},
 			},
 			map[string]interface{}{
-				"name":       "quesma_virtual_tables",
-				"attributes": []interface{}{"open"},
-			},
-			map[string]interface{}{
 				"name":       "unmentioned_index",
 				"attributes": []interface{}{"open"},
 			},


### PR DESCRIPTION
PR #1442  changed the way we expose our internal indices. Just forgot to change our integration test. This PR fixed it.
