### PR TITLE
🚧 [WIP] Fixing "surrounding documents" view with new _id implementation

### DIFF
--- a/platform/model/expr.go
+++ b/platform/model/expr.go
@@ -123,9 +123,10 @@ func (e TupleExpr) Accept(v ExprVisitor) interface{} {
 }
 
 type InfixExpr struct {
-	Left  Expr
-	Op    string
-	Right Expr
+	Left     Expr
+	Op       string
+	Right    Expr
+	Metadata string // Metadata can store additional information about the expression for futher transofrmation
 }
 
 func (e InfixExpr) Accept(v ExprVisitor) interface{} {
@@ -237,6 +238,12 @@ func (o OrderByExpr) IsCountDesc() bool {
 
 func NewInfixExpr(lhs Expr, operator string, rhs Expr) InfixExpr {
 	return InfixExpr{Left: lhs, Op: operator, Right: rhs}
+}
+
+const IDQuery = "ID_QUERY"
+
+func NewInfixExprWithMetadata(lhs Expr, operator string, rhs Expr, metadata string) InfixExpr {
+	return InfixExpr{Left: lhs, Op: operator, Right: rhs, Metadata: metadata}
 }
 
 // AliasedExpr is an expression with an alias, e.g. `columnName AS alias` or `COUNT(x) AS sum_of_xs`

--- a/platform/model/query.go
+++ b/platform/model/query.go
@@ -69,6 +69,7 @@ type (
 
 		RuntimeMappings map[string]RuntimeMapping
 
+		IgnoreSize bool
 		// dictionary to add as 'meta' field in the response.
 		// WARNING: it's probably not passed everywhere where it's needed, just in one place.
 		// But it works for the test + our dashboards, so let's fix it later if necessary.

--- a/platform/model/typical_queries/hits.go
+++ b/platform/model/typical_queries/hits.go
@@ -36,6 +36,7 @@ type Hits struct {
 	addVersion         bool // true <=> we add hit.Version field to the response (whose value is always 1)
 	indexes            []string
 	timestampFieldName string
+	IgnoreSize         bool
 }
 
 func NewHits(ctx context.Context, table *clickhouse.Table, highlighter *model.Highlighter,

--- a/platform/parsers/elastic_query_dsl/query_parser.go
+++ b/platform/parsers/elastic_query_dsl/query_parser.go
@@ -389,7 +389,7 @@ func (cw *ClickhouseQueryTranslator) parseIds(queryMap QueryMap) model.SimpleQue
 			logger.ErrorWithCtx(cw.Ctx).Msgf("error converting id to sql: %v", err)
 			return model.NewSimpleQueryInvalid()
 		}
-		whereStmt = model.NewInfixExpr(model.NewColumnRef(timestampColumnName), " = ", sql)
+		whereStmt = model.NewInfixExprWithMetadata(model.NewColumnRef(timestampColumnName), " = ", sql, model.IDQuery)
 	default:
 		idsAsExprs := make([]model.Expr, len(ids))
 		for i, id := range ids {
@@ -400,7 +400,7 @@ func (cw *ClickhouseQueryTranslator) parseIds(queryMap QueryMap) model.SimpleQue
 			}
 		}
 		idsTuple := model.NewTupleExpr(idsAsExprs...)
-		whereStmt = model.NewInfixExpr(model.NewColumnRef(timestampColumnName), " IN ", idsTuple)
+		whereStmt = model.NewInfixExprWithMetadata(model.NewColumnRef(timestampColumnName), " IN ", idsTuple, model.IDQuery)
 	}
 	cw.UniqueIDs = uniqueIds // TODO a crucial side effect here
 	return model.NewSimpleQuery(whereStmt, true)
@@ -1205,11 +1205,13 @@ func ResolveField(ctx context.Context, fieldName string, schemaInstance schema.S
 }
 
 func (cw *ClickhouseQueryTranslator) parseSize(queryMap QueryMap, defaultSize int) int {
-	if len(cw.UniqueIDs) > 0 {
-		// If this is a unique ID query, we can't limit size at the SQL level,
-		// because we need all matching timestamps that later will be filtered out but looking at hashes computed on hits
-		return defaultSize
-	}
+	//isIDQuery := len(cw.UniqueIDs) > 0
+	// If this is a unique ID query, we can't limit size at the SQL level,
+	// because we need all matching timestamps that later will be filtered out but looking at hashes computed on hits
+
+	//if len(cw.UniqueIDs) > 0 { TODO: maybe remove
+	//	return defaultSize
+	//}
 	sizeRaw, exists := queryMap["size"]
 	if !exists {
 		return defaultSize

--- a/platform/parsers/elastic_query_dsl/query_translator.go
+++ b/platform/parsers/elastic_query_dsl/query_translator.go
@@ -26,8 +26,9 @@ type ClickhouseQueryTranslator struct {
 	Indexes []string
 
 	// TODO this will be removed
-	Table     *clickhouse.Table
-	UniqueIDs []string // used for hits queries, to filter out hits that are not in the list of IDs
+	Table      *clickhouse.Table
+	UniqueIDs  []string // used for hits queries, to filter out hits that are not in the list of IDs
+	IgnoreSize bool
 }
 
 var completionStatusOK = func() *int { value := 200; return &value }()


### PR DESCRIPTION
The challenge here is to fix the "surrounding documents" view in Kibana given the new unique ID (`_id` field) implementation (ref: https://github.com/QuesmaOrg/quesma/pull/1435). See **Related screenshots** section.

At this moment Kibana just says "No documents newer/older than the anchor could be found"

### Present situation

Our current implementation of the `_id` field is based on rendering this value dynamically, **after** fetching all the data from ClickHouse. It looks like this:
```
{hex-encoded timestamp field}qqq{hex-encoded hash of the document}
```
While at the query parsing/execution phase we can of course access the timestamp field, the "hash of the document" part is computed during JSON response rendering.

The current implementation stores a list of IDs in `ClickhouseQueryTranslator` (`UniqueIDs`) - therefore we know that this query was using `_id` field and we have to apply extra logic on JSON response rendering. The situation is quite clear during simple filtering query:
```json
    "query": {
        "bool": {
            "filter": [
                {
                    "ids": {
                        "values": [
                       "323032352d30362d30352031323a33303a33322e323036202b3030303020555443qqq4qqq3634363633353337363233323631333533333632363333353337363533303339363333333336363133393633333836323332333033393337363533323634333336333333363236343331333036343331333636313332333033303334363233303338333236343330363433333334333433333336333236353633333836343336"
                        ]
                    }
                },
                {
                    "term": {
                        "_index": "kibana_sample_data_flights"
                    }
                }
            ]
        }
    },
``` 
When parsing the SQL we simply take the first (timestamp) part of the query, make relevant WHERE clause which will filter out all the non-matching timestamps and then compare the doc hashes during JSON response rendering (see `platform/parsers/elastic_query_dsl/query_translator.go`). Of course we have to make sure that we don't fallback to default `LIMIT 10` for our SQL clause because we might not have enough documents to filter from (see `(cw *ClickhouseQueryTranslator) parseSize`). 

### Problem

When fetching "surrounding documents", Kibana sends following query:
```json
    "query": {
        "bool": {
            "filter": [],
            "must": [
                {
                    "bool": {
                        "must": {
                            "constant_score": {
                                "filter": {
                                    "range": {
                                        "@timestamp": {
                                            "format": "strict_date_optional_time",
                                            "gte": "2025-06-04T12:30:32.206Z",
                                            "lte": "2025-06-05T12:30:32.206Z"
                                        }
                                    }
                                }
                            }
                        },
                        "must_not": {
                            "ids": {
                                "values": [
                                    "323032352d30362d30352031323a33303a33322e323036202b3030303020555443qqq4qqq3634363633353337363233323631333533333632363333353337363533303339363333333336363133393633333836323332333033393337363533323634333336333333363236343331333036343331333636313332333033303334363233303338333236343330363433333334333433333336333236353633333836343336"
                                ]
                            }
                        }
                    }
                }
            ],
            "must_not": [],
            "should": []
        }
    },
```

And the `must_not` query becomes quite problematic. It's pretty obvious that when fetching next/previos N documents, we don't want to include that anchor document. 
So at the SQL query level we **cannot** filter out all the documents with matching timestamp, because our next document might have exactly the same timestamp. One approach to do so is add a schema transformer to do so.
On response rendering, we cannot rely on the current logic which just leaves only matching ids, because we want the opposite affect. However, this is post-query phase and at that level we're unaware of the query - we just have hits as the result, but didn't know whether `ids` has been within `must_not` (or any other logical clause).

There are few gotchas here: 
* `size` passed in query lands in the SQLs `LIMIT` clause - we have to ignore it 
* relying on `_id` in any aggregation might produce completely absurd results
* .... ?

### Possible solution

TODO: check this PR

### Related screenshots
<details>

<img width="700" alt="image" src="https://github.com/user-attachments/assets/bdbcb452-aaca-41fb-b05c-5ea8803912e0" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/855db2c6-39d3-42a6-9722-95eeae03fdb6" />

</details>