### PR TITLE
splitTimeRangeExt is considered harmful

### DIFF
--- a/platform/optimize/pipeline.go
+++ b/platform/optimize/pipeline.go
@@ -27,19 +27,13 @@ func NewOptimizePipeline(config *config.QuesmaConfiguration) model.QueryTransfor
 	// TODO remove this line when splitTimeRange is removed
 	// this is just to satisfy the linter
 	_ = &splitTimeRange{}
+	_ = &splitTimeRangeExt{}
 	return &OptimizePipeline{
 		config: config,
 		optimizations: []OptimizeTransformer{
 			&truncateDate{truncateTo: 5 * time.Minute},
 			&cacheQueries{},
 			&materializedViewReplace{},
-			// TODO finally remove this transformer
-			// commenting out splitTimeRange for now
-			// as we have splitTimeRangeExt that uses novel approach
-			// of splitting queries based on time range
-			// executing them in parallel and finally merging results
-			// &splitTimeRange{},
-			&splitTimeRangeExt{},
 		},
 	}
 }


### PR DESCRIPTION

<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' or '/run-it' -->
