### PR TITLE
Add integration test exercising `_bulk` endpoint

### DIFF
--- a/ci/it/configs/quesma-ingest.yml.template
+++ b/ci/it/configs/quesma-ingest.yml.template
@@ -67,6 +67,15 @@ processors:
                 type: geo_point
               "OriginLocation":
                 type: geo_point
+        kibana_sample_data_flights_bulk:
+          target:
+            - my-clickhouse-instance
+          schemaOverrides:
+            fields:
+              "DestLocation":
+                type: geo_point
+              "OriginLocation":
+                type: geo_point
         kibana_sample_data_flights_with_mappings:
           target:
             - my-clickhouse-instance
@@ -140,6 +149,15 @@ processors:
               manufacturer:
                 type: text
         kibana_sample_data_flights:
+          target:
+            - my-clickhouse-instance
+          schemaOverrides:
+            fields:
+              "DestLocation":
+                type: geo_point
+              "OriginLocation":
+                type: geo_point
+        kibana_sample_data_flights_bulk:
           target:
             - my-clickhouse-instance
           schemaOverrides:


### PR DESCRIPTION
Recently our tests didn't catch a panic (see #1457), because the `_bulk` endpoint wasn't exercised in the tests - only the `_doc` endpoint.

Even though #1457 added a reproducer integration test, `_bulk` endpoint isn't exercised that much in integration tests - this PR adds an additional integration test that uses this endpoint.
