### PR TITLE
Fix Slack notification not working for PRs from forks

### DIFF
--- a/.github/workflows/issues-and-prs.yml
+++ b/.github/workflows/issues-and-prs.yml
@@ -9,7 +9,7 @@ permissions:
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
I (and potential outside contributors) don't commit branches to the `QuesmaOrg/quesma` repo, but to personal forks. For such a workflow, the `issues-and-prs.yml` job (Slack notifications for new PRs/issues) didn't work, failing with error:

> Missing input! A token must be provided to use the method decided.

The problem is that the Slack token GitHub secret isn't available for forks - due to security reasons.

However, by changing the type of job from `pull_request` to `pull_request_target`, it changes how GitHub will run the job - it will run it in context of "parent" repo (`QuesmaOrg/quesma`), meaning it has access to the Slack token. 

Some [GitHub documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) for context:

> [With pull_request_target] This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. **This event allows your workflow to do things like label or comment on pull requests from forks**. Avoid using this event if you need to build or run code from the pull request.