### PR TITLE
Fix keyword field comparison

### DIFF
--- a/platform/frontend_connectors/schema_transformer.go
+++ b/platform/frontend_connectors/schema_transformer.go
@@ -1207,7 +1207,9 @@ func (s *SchemaCheckPass) applyMatchOperator(indexSchema schema.Schema, query *m
 				rhs.Value = strings.Trim(rhsValue, "%")
 				rhs.Attrs[model.EscapeKey] = model.NormalNotEscaped
 				return equal()
-			case schema.QuesmaTypeKeyword.Name:
+			case schema.QuesmaTypeKeyword.Name: // similar as above, but for keyword type, un-ilike it
+				rhs.Value = strings.Trim(rhsValue, "%")
+				rhs.Attrs[model.EscapeKey] = model.FullyEscaped
 				return equal()
 			default:
 				if rhsValue == "%%" { // ILIKE '%%' has terrible performance, but semantically means "is not null", hence this transformation

--- a/platform/testdata/requests.go
+++ b/platform/testdata/requests.go
@@ -1133,7 +1133,7 @@ var TestsSearch = []SearchTestCase{
 		}`,
 		[]string{`"host_name" __quesma_match '%prometheus%'`},
 		model.ListAllFields,
-		[]string{`SELECT "message" FROM ` + TableName + ` WHERE "host_name"='%prometheus%' LIMIT 10`},
+		[]string{`SELECT "message" FROM ` + TableName + ` WHERE "host_name"='prometheus' LIMIT 10`},
 		[]string{},
 	},
 	{ // [6]
@@ -1712,7 +1712,7 @@ var TestsSearch = []SearchTestCase{
 			  "stream_namespace" AS "aggr__suggestions__key_0",
 			  count(*) AS "aggr__suggestions__count"
 			FROM __quesma_table_name
-			WHERE (("message" ILIKE '%User logged out%' AND "host_name"='%poseidon%')
+			WHERE (("message" ILIKE '%User logged out%' AND "host_name"='poseidon')
 			  AND ("@timestamp">=fromUnixTimestamp64Milli(1706542596491) AND "@timestamp"<=fromUnixTimestamp64Milli(1706551896491)))
 			GROUP BY "stream_namespace" AS "aggr__suggestions__key_0"
 			ORDER BY "aggr__suggestions__count" DESC, "aggr__suggestions__key_0" ASC
@@ -1870,7 +1870,7 @@ var TestsSearch = []SearchTestCase{
 			  "namespace" AS "aggr__suggestions__key_0",
 			  count(*) AS "aggr__suggestions__count"
 			FROM __quesma_table_name
-			WHERE (("message" ILIKE '%User logged out%' AND "host_name"='%poseidon%')
+			WHERE (("message" ILIKE '%User logged out%' AND "host_name"='poseidon')
 			  AND ("@timestamp">=fromUnixTimestamp64Milli(1706542596491) AND "@timestamp"<=fromUnixTimestamp64Milli(1706551896491)))
 			GROUP BY "namespace" AS "aggr__suggestions__key_0"
 			ORDER BY "aggr__suggestions__count" DESC, "aggr__suggestions__key_0" ASC


### PR DESCRIPTION
This PR fixes keyword field comparison. Quesma was comparing against the `ilike` pattern instead of literal. 