### PR TITLE
Comments/docs on "bring your own table" and `ALTER` situation

### DIFF
--- a/platform/ingest/processor.go
+++ b/platform/ingest/processor.go
@@ -633,6 +633,7 @@ func (ip *SqlLowerer) GenerateIngestContent(table *chLib.Table,
 	encodings map[schema.FieldEncodingKey]schema.EncodedFieldName) ([]AlterStatement, types.JSON, []NonSchemaField, error) {
 
 	if len(table.Config.Attributes) == 0 {
+		// This implies that the table has no `attributes_*` columns, most likely it's a Bring Your Own Table (BYOT) situation, ref: https://github.com/QuesmaOrg/quesma/pull/1484
 		logger.Error().Msg("received non-schema fields but no attributes config found. Extra fields will not be stored")
 		return nil, data, nil, nil
 	}

--- a/platform/ingest/processor.go
+++ b/platform/ingest/processor.go
@@ -633,6 +633,7 @@ func (ip *SqlLowerer) GenerateIngestContent(table *chLib.Table,
 	encodings map[schema.FieldEncodingKey]schema.EncodedFieldName) ([]AlterStatement, types.JSON, []NonSchemaField, error) {
 
 	if len(table.Config.Attributes) == 0 {
+		logger.Error().Msg("received non-schema fields but no attributes config found (bring-your-own-table situation?)")
 		return nil, data, nil, nil
 	}
 

--- a/platform/ingest/processor.go
+++ b/platform/ingest/processor.go
@@ -633,7 +633,7 @@ func (ip *SqlLowerer) GenerateIngestContent(table *chLib.Table,
 	encodings map[schema.FieldEncodingKey]schema.EncodedFieldName) ([]AlterStatement, types.JSON, []NonSchemaField, error) {
 
 	if len(table.Config.Attributes) == 0 {
-		logger.Error().Msg("received non-schema fields but no attributes config found. Extra fields will be DROPPED")
+		logger.Error().Msg("received non-schema fields but no attributes config found. Extra fields will not be stored")
 		return nil, data, nil, nil
 	}
 

--- a/platform/ingest/processor.go
+++ b/platform/ingest/processor.go
@@ -633,7 +633,7 @@ func (ip *SqlLowerer) GenerateIngestContent(table *chLib.Table,
 	encodings map[schema.FieldEncodingKey]schema.EncodedFieldName) ([]AlterStatement, types.JSON, []NonSchemaField, error) {
 
 	if len(table.Config.Attributes) == 0 {
-		logger.Error().Msg("received non-schema fields but no attributes config found (bring-your-own-table situation?)")
+		logger.Error().Msg("received non-schema fields but no attributes config found. Extra fields will be DROPPED")
 		return nil, data, nil, nil
 	}
 


### PR DESCRIPTION
When users connect Quesma to ClickHouse and would like to work with tables which **are not created by Quesma**, `ALTER` statements doesn't work, unless `attributes_*` columns are present. Therefore we end up with:
1. No `ALTER` executed
2. Extra fields being ignored because we **neither** added the dedicated column **nor** had `attributes_*` column to store it.


In general, we discourage such setup in read/write scenarios - it's always better to have Quesma manage your CH tables so that it controls any required metadata.

In most cases BYOT is used in read-only, ingest-disabled situations. However, there's a simple way to mitigate this limitation:
```
ALTER TABLE test_db.test_table [ON cluster quesma_cluster] ADD COLUMN "attributes_values" Map(String, String)
ALTER TABLE test_db.test_table [ON cluster quesma_cluster] ADD COLUMN "attributes_metadata" Map(String, String)
```
