### PR TITLE
Add `Run Quesma Locally` run configuration.

### DIFF
--- a/.idea/runConfigurations/Run_Quesma_Locally.xml
+++ b/.idea/runConfigurations/Run_Quesma_Locally.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Quesma Locally" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="quesma" />
+    <working_directory value="$PROJECT_DIR$/cmd" />
+    <kind value="PACKAGE" />
+    <package value="github.com/QuesmaOrg/quesma/quesma-cli" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/main.go" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
Recent change addition in local debugger run configuration overwritten the "default" run configuration (a.k.a. "play button) in `main.go`.

Therefore, instead of running with default `config.yaml` Quesma ended up loading config from the most recent IT run 🙃  

<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' or '/run-it' -->
