### PR TITLE
Print PR ref for IT comment run 

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           PR_URL="${{ github.event.issue.pull_request.url }}"
           PR_INFO=$(curl -s -H "Authorization: token ${{ github.token }}" $PR_URL)
+          REF=$(echo $PR_INFO | jq -r .head.sha)
           echo "ref=$(echo $PR_INFO | jq -r .head.sha)" >> $GITHUB_OUTPUT
 
       - name: Create pending status


### PR DESCRIPTION
<!-- A note on testing your PR -->
<!-- Basic unit test run is executed against each commit in the PR.
     If you want to run a full integration test suite, you can trigger it by commenting 
     with '/run-integration-tests' or '/run-it' -->
