### PR TITLE
Adapt to string type time data

### DIFF
--- a/platform/model/bucket_aggregations/date_histogram.go
+++ b/platform/model/bucket_aggregations/date_histogram.go
@@ -222,21 +222,7 @@ func (query *DateHistogram) generateSQLForCalendarInterval() model.Expr {
 }
 
 func (query *DateHistogram) getKey(row model.QueryResultRow) int64 {
-	value := row.Cols[len(row.Cols)-2].Value
-	switch v := value.(type) {
-	case int64:
-		return v
-	case string:
-		val, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			logger.Error().Msgf("string conver to int64 failed %T", v)
-			return 0
-		}
-		return val
-	default:
-		logger.Error().Msgf("unsupported key type: %T", v)
-		return 0
-	}
+	return extractRowValue(row)
 }
 
 func (query *DateHistogram) Interval() (interval time.Duration, ok bool) {
@@ -430,6 +416,10 @@ func (qt *DateHistogramRowsTransformer) Transform(ctx context.Context, rowsFromD
 }
 
 func (qt *DateHistogramRowsTransformer) getKey(row model.QueryResultRow) int64 {
+	return extractRowValue(row)
+}
+
+func extractRowValue(row model.QueryResultRow) int64 {
 	value := row.Cols[len(row.Cols)-2].Value
 	switch v := value.(type) {
 	case int64:

--- a/platform/model/bucket_aggregations/date_histogram.go
+++ b/platform/model/bucket_aggregations/date_histogram.go
@@ -222,7 +222,21 @@ func (query *DateHistogram) generateSQLForCalendarInterval() model.Expr {
 }
 
 func (query *DateHistogram) getKey(row model.QueryResultRow) int64 {
-	return row.Cols[len(row.Cols)-2].Value.(int64)
+	value := row.Cols[len(row.Cols)-2].Value
+	switch v := value.(type) {
+	case int64:
+		return v
+	case string:
+		val, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			logger.Error().Msgf("string conver to int64 failed %T", v, err)
+			return 0
+		}
+		return val
+	default:
+		logger.Error().Msgf("unsupported key type: %T", v)
+		return 0
+	}
 }
 
 func (query *DateHistogram) Interval() (interval time.Duration, ok bool) {
@@ -416,7 +430,21 @@ func (qt *DateHistogramRowsTransformer) Transform(ctx context.Context, rowsFromD
 }
 
 func (qt *DateHistogramRowsTransformer) getKey(row model.QueryResultRow) int64 {
-	return row.Cols[len(row.Cols)-2].Value.(int64)
+	value := row.Cols[len(row.Cols)-2].Value
+	switch v := value.(type) {
+	case int64:
+		return v
+	case string:
+		val, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			logger.Error().Msgf("string conver to int64 failed %T", v, err)
+			return 0
+		}
+		return val
+	default:
+		logger.Error().Msgf("unsupported key type: %T", v)
+		return 0
+	}
 }
 
 func (qt *DateHistogramRowsTransformer) nextKey(key int64) int64 {

--- a/platform/model/bucket_aggregations/date_histogram.go
+++ b/platform/model/bucket_aggregations/date_histogram.go
@@ -229,7 +229,7 @@ func (query *DateHistogram) getKey(row model.QueryResultRow) int64 {
 	case string:
 		val, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			logger.Error().Msgf("string conver to int64 failed %T", v, err)
+			logger.Error().Msgf("string conver to int64 failed %T", v)
 			return 0
 		}
 		return val
@@ -437,7 +437,7 @@ func (qt *DateHistogramRowsTransformer) getKey(row model.QueryResultRow) int64 {
 	case string:
 		val, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
-			logger.Error().Msgf("string conver to int64 failed %T", v, err)
+			logger.Error().Msgf("string conver to int64 failed %T", v)
 			return 0
 		}
 		return val


### PR DESCRIPTION
Since the data is converted into string type in the data reading of doris, we need to process the string type specifically here.

Related PR: https://github.com/QuesmaOrg/quesma/blob/main/platform/database_common/quesma_communicator.go#L228